### PR TITLE
ci(macos): switch runner label from macos-26-arm64 to macos-26

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -9,11 +9,23 @@ name: Build macOS release
 #     the .dmg as a workflow artifact (downloadable for 30 days) but
 #     does NOT touch GitHub Releases.
 #
-# Runner: macos-26-arm64 = macOS 26 (Tahoe) on Apple Silicon. Pinned
-# to the explicit -arm64 label rather than ``macos-latest`` so the
-# build stays reproducible if GitHub later bumps ``latest`` to a
-# future image with different defaults. ARM64-only is the right
-# arch because Crimson Desert macOS doesn't run on Intel anyway.
+# Runner: macos-26 = macOS 26 (Tahoe) on Apple Silicon. The bare
+# ``macos-26`` label is GitHub's canonical name for the macOS 26 ARM64
+# image (per actions/runner-images README — ARM64 is the default arch
+# for the unsuffixed label since macOS 14). x86_64 builds need
+# ``macos-26-intel`` explicitly. Pinned to the major-version label
+# rather than ``macos-latest`` so the build stays reproducible if
+# GitHub later bumps ``latest`` to a future image with different
+# defaults. ARM64-only is the right arch because Crimson Desert macOS
+# doesn't run on Intel anyway.
+#
+# We previously requested ``macos-26-arm64``. That label exists but
+# routes to a much smaller runner pool (~118 repos use it vs ~1816
+# for ``macos-26``); during the v3.2.13 / v3.2.14 release window it
+# was completely starved (jobs queued >8h with no runner pickup,
+# faisalkindi/CrimsonDesert-UltimateModsManager runs 25590236083 +
+# 25597593347, 2026-05-09). The unsuffixed label maps to the same
+# image, just with proper capacity behind it.
 #
 # Switched from macos-14 because actions/runner-images announced
 # macOS 14 Sonoma deprecation starting 2026-07-06; macos-26 also
@@ -30,7 +42,7 @@ permissions:
 
 jobs:
   build-macos:
-    runs-on: macos-26-arm64
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Why

Both recent macOS release builds queued for hours with no runner pickup:

- [`v3.2.13` build](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/actions/runs/25590236083/job/75126454830) — queued 2026-05-09 03:17 UTC, still waiting after 9+ hours
- [`v3.2.14` build](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/actions/runs/25597593347/job/75146058769) — queued 2026-05-09 09:23 UTC, still waiting

Both runs request label `macos-26-arm64`. The runner image itself is healthy (badge: `Deployed 20260427.0026`), but the `-arm64` suffixed label routes to a much smaller pool — ~118 repos use it across GitHub vs ~1816 for the bare `macos-26` label.

Repos using the unsuffixed `macos-26` are running normally in the same window:
- [Homebrew/brew Release](https://github.com/Homebrew/brew/actions/runs/25489960866) — 6m56s on 2026-05-07
- [nikitabobko/AeroSpace build](https://github.com/nikitabobko/AeroSpace/actions/runs/25586528005) — 8m52s on 2026-05-09
- [signalapp/Signal-iOS CI](https://github.com/signalapp/Signal-iOS/actions/runs) — 9m on 2026-05-06

## What

Change `runs-on: macos-26-arm64` → `runs-on: macos-26`.

`macos-26` is the [actions/runner-images README](https://github.com/actions/runner-images/blob/main/README.md)'s canonical label for the macOS 26 ARM64 image — ARM64 has been the default arch for the unsuffixed macOS label since macOS 14. `macos-26-intel` is the explicit x86_64 label; we don't want that since Crimson Desert macOS is ARM64-only.

Same image, same Python 3.14, same Rust toolchain, same pre-installed 7-Zip. Cache keys keep their existing `macos26-arm64` descriptive suffix — the underlying image is identical so the pip / cargo cache entries are still valid, and renaming would force a cold rebuild for no benefit.

## After merging

The two stuck runs above can be cancelled and the v3.2.14 tag re-run from the Actions tab (or the next tag push will just pick up the fix). The `.dmg` should attach to the existing GitHub Releases automatically once the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)