### PR TITLE
fix(import): enhance sibling JSON patch handling for loose-file variants

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -2542,9 +2542,19 @@ def _import_from_extracted(
                 "author": mi.get("author"), "description": mi.get("description"),
                 "force_inplace": mi.get("force_inplace"),
             }
-            return _process_extracted_files(
+            lfm_result = _process_extracted_files(
                 converted, game_dir, db, snapshot, deltas_dir, lfm_name,
                 existing_mod_id=existing_mod_id, modinfo=lfm_modinfo)
+            lfm_base = lfm.get("_base_dir")
+            if (lfm_base and lfm_base != tmp_path
+                    and lfm_result and not lfm_result.error):
+                try:
+                    _import_sibling_json_patches(
+                        tmp_path, lfm_base, game_dir, db, deltas_dir)
+                except Exception as e:
+                    logger.debug(
+                        "Sibling JSON scan after LFM extract failed: %s", e)
+            return lfm_result
 
     # Check for JSON byte-patch format — use ENTR deltas for proper composition
     jp_data = detect_json_patch(tmp_path)
@@ -2940,9 +2950,27 @@ def import_from_zip(
                     "author": mi.get("author"), "description": mi.get("description"),
                     "force_inplace": mi.get("force_inplace"),
                 }
-                return _process_extracted_files(
+                result = _process_extracted_files(
                     converted, game_dir, db, snapshot, deltas_dir, lfm_name,
                     existing_mod_id=existing_mod_id, modinfo=lfm_modinfo)
+                # Same ASI carryover as the main zip tail — LFM used to return
+                # early without `asi_staged`, so CharacterCreatorHead.asi never
+                # reached the GUI installer (GitHub #49 class bug, LFM path).
+                if _carryover_asi_staged:
+                    result.asi_staged = list(_carryover_asi_staged)
+                # Sibling JSON byte-patches next to mod.json (e.g.
+                # FemaleAnimations.json) are skipped if we return before
+                # detect_json_patch — mirror CB compound-mod handling.
+                lfm_base = lfm.get("_base_dir")
+                if (lfm_base and lfm_base != tmp_path
+                        and result and not result.error):
+                    try:
+                        _import_sibling_json_patches(
+                            tmp_path, lfm_base, game_dir, db, deltas_dir)
+                    except Exception as e:
+                        logger.debug(
+                            "Sibling JSON scan after LFM zip failed: %s", e)
+                return result
 
         # Check for JSON byte-patch format — use ENTR deltas for proper composition
         jp_data = detect_json_patch(tmp_path)

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -3349,11 +3349,68 @@ def _import_sibling_json_patches(
                 cand.name, jp_name, len(entr_result["changed_files"]))
 
 
+def _import_mod_json_package_siblings_if_needed(
+    imported_leaf: Path,
+    game_dir: Path,
+    db: Database,
+    deltas_dir: Path,
+    result: ModImportResult,
+    *,
+    import_sibling_json: bool,
+) -> None:
+    """Import byte-patch JSON siblings next to a loose-file ``mod.json`` package.
+
+    When the worker imports only a variant leaf (e.g. ``HumanFemale/``)
+    under ``CharacterCreator/mod.json``, ``FemaleAnimations.json`` lives
+    beside ``mod.json`` and is not visible to the leaf-only import.
+    Walk up to the package root and reuse :func:`_import_sibling_json_patches`.
+
+    Skipped when ``import_sibling_json`` is False (cog variant swap: siblings
+    already exist as separate mod rows).
+    """
+    if not import_sibling_json:
+        return
+    if result.error or not result.changed_files:
+        return
+    try:
+        pkg: Path | None = None
+        cur = imported_leaf
+        for _ in range(16):
+            if not cur.is_dir():
+                break
+            if (cur / "mod.json").is_file():
+                pkg = cur
+                break
+            if cur.parent == cur:
+                break
+            cur = cur.parent
+        if pkg is None:
+            return
+        try:
+            if pkg.resolve() == imported_leaf.resolve():
+                return
+        except OSError:
+            if pkg == imported_leaf:
+                return
+        _import_sibling_json_patches(
+            pkg, imported_leaf, game_dir, db, deltas_dir)
+    except Exception as e:
+        logger.warning(
+            "Package-root sibling JSON import failed: %s", e,
+            exc_info=True)
+
+
 def import_from_folder(
     folder_path: Path, game_dir: Path, db: Database, snapshot: SnapshotManager, deltas_dir: Path,
     existing_mod_id: int | None = None,
+    *,
+    import_sibling_json: bool = True,
 ) -> ModImportResult:
-    """Import a mod from a folder of modified files."""
+    """Import a mod from a folder of modified files.
+
+    ``import_sibling_json``: when False, skip importing JSON byte-patch
+    siblings (used when re-importing a variant leaf after cog swap).
+    """
     mod_name = folder_path.name
 
     # Check for Crimson Browser format and convert if needed
@@ -3378,7 +3435,7 @@ def import_from_folder(
                 # stat-buff vs shop-addition independently.
                 cb_base_raw = manifest.get("_base_dir")
                 cb_base = Path(cb_base_raw) if cb_base_raw is not None else None
-                if (cb_base and cb_base != folder_path
+                if (import_sibling_json and cb_base and cb_base != folder_path
                         and cb_result and not cb_result.error
                         and cb_result.changed_files):
                     try:
@@ -3604,7 +3661,8 @@ def import_from_folder(
     # C1: compound layout — the PAZ-dir primary has landed; now
     # import any sibling .json patches as their own separate mods so
     # users can toggle them independently (issue #34).
-    if (_is_compound_layout and result.changed_files and not result.error
+    if (import_sibling_json and _is_compound_layout
+            and result.changed_files and not result.error
             and result.mod_id is not None):
         try:
             # exclude_subdir is used by the helper to skip a CB/LFM
@@ -3618,6 +3676,12 @@ def import_from_folder(
         except Exception as e:
             logger.warning(
                 "Compound-layout sibling JSON scan failed: %s", e)
+
+    # Loose-file pack leaf (e.g. CharacterCreator/HumanFemale): JSON next to
+    # package mod.json is handled here
+    _import_mod_json_package_siblings_if_needed(
+        folder_path, game_dir, db, deltas_dir, result,
+        import_sibling_json=import_sibling_json)
 
     return result
 

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -4291,13 +4291,12 @@ class CdummWindow(FluentWindow):
                 import shutil
                 shutil.rmtree(str(tmp), ignore_errors=True)
                 self._pending_tmp_cleanup = None
-            # Clean variant-picker pre-extract dir (when a picker fired
-            # and the worker was fed a path inside this temp tree).
+            # Variant-picker pre-extract dir: do NOT delete yet — ASI install
+            # and sibling JSON import below still read files under this tree
+            # (e.g. CharacterCreatorHead.asi, FemaleAnimations.json next to
+            # mod.json). Deleting early left zero-byte / missing ASI installs.
             vtmp = getattr(self, '_pending_variant_cleanup', None)
-            if vtmp:
-                import shutil
-                shutil.rmtree(str(vtmp), ignore_errors=True)
-                self._pending_variant_cleanup = None
+            self._pending_variant_cleanup = None
 
             # Primary mod id captured from the worker's "done" message.
             # Compound imports (Lightsaber: CB + shop JSON siblings) write
@@ -4594,6 +4593,59 @@ class CdummWindow(FluentWindow):
                             _sh.rmtree(parent, ignore_errors=True)
                 except Exception as e:
                     logger.warning("Failed to install staged ASI files: %s", e)
+
+            # Loose-file variant pick (Character Creator): worker imports only
+            # the body-type leaf (e.g. HumanFemale/). Byte-patch JSON next to
+            # mod.json never enters import_from_folder — mirror compound LFM
+            # handling here using the same helper as zip/CB paths.
+            if path.is_dir():
+                try:
+                    from cdumm.engine.import_handler import (
+                        _import_sibling_json_patches,
+                    )
+                    _cur = path
+                    _pkg: Path | None = None
+                    for _ in range(12):
+                        if not _cur.is_dir():
+                            _pkg = None
+                            break
+                        if (_cur / "mod.json").is_file():
+                            _pkg = _cur
+                            break
+                        if _cur.parent == _cur:
+                            _pkg = None
+                            break
+                        _cur = _cur.parent
+                    if _pkg is not None:
+                        try:
+                            _pkg_r = _pkg.resolve()
+                            _leaf_r = path.resolve()
+                        except OSError:
+                            _pkg_r, _leaf_r = _pkg, path
+                        if _pkg_r != _leaf_r:
+                            _sib_fail: list[str] = []
+                            _import_sibling_json_patches(
+                                _pkg,
+                                path,
+                                self._game_dir,
+                                self._db,
+                                self._deltas_dir,
+                                failures_out=_sib_fail,
+                            )
+                            if _sib_fail:
+                                logger.warning(
+                                    "Sibling JSON after variant pick: %s",
+                                    "; ".join(_sib_fail),
+                                )
+                except Exception as _sib_exc:
+                    logger.warning(
+                        "Sibling JSON import after variant pick failed: %s",
+                        _sib_exc,
+                    )
+
+            if vtmp is not None:
+                import shutil
+                shutil.rmtree(str(vtmp), ignore_errors=True)
 
             self._refresh_all()
             if asi_count > 0:

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -4155,7 +4155,10 @@ class CdummWindow(FluentWindow):
         # ── Launch ImportWorker ────────────────────────────────────────
         self._launch_import_worker(path, existing_mod_id)
 
-    def _launch_import_worker(self, path: Path, existing_mod_id: int | None = None) -> None:
+    def _launch_import_worker(
+        self, path: Path, existing_mod_id: int | None = None,
+        *, import_sibling_json: bool = True,
+    ) -> None:
         """Launch import in a SEPARATE PROCESS via QProcess.
 
         Using QProcess instead of QThread completely eliminates GIL contention —
@@ -4198,6 +4201,8 @@ class CdummWindow(FluentWindow):
         ]
         if existing_mod_id is not None:
             _import_args.append(str(existing_mod_id))
+        if not import_sibling_json:
+            _import_args.append("--no-sibling-json")
         exe, args = worker_command(_import_args)
 
         # Buffer for partial JSON lines
@@ -4593,55 +4598,6 @@ class CdummWindow(FluentWindow):
                             _sh.rmtree(parent, ignore_errors=True)
                 except Exception as e:
                     logger.warning("Failed to install staged ASI files: %s", e)
-
-            # Loose-file variant pick (Character Creator): worker imports only
-            # the body-type leaf (e.g. HumanFemale/). Byte-patch JSON next to
-            # mod.json never enters import_from_folder — mirror compound LFM
-            # handling here using the same helper as zip/CB paths.
-            if path.is_dir():
-                try:
-                    from cdumm.engine.import_handler import (
-                        _import_sibling_json_patches,
-                    )
-                    _cur = path
-                    _pkg: Path | None = None
-                    for _ in range(12):
-                        if not _cur.is_dir():
-                            _pkg = None
-                            break
-                        if (_cur / "mod.json").is_file():
-                            _pkg = _cur
-                            break
-                        if _cur.parent == _cur:
-                            _pkg = None
-                            break
-                        _cur = _cur.parent
-                    if _pkg is not None:
-                        try:
-                            _pkg_r = _pkg.resolve()
-                            _leaf_r = path.resolve()
-                        except OSError:
-                            _pkg_r, _leaf_r = _pkg, path
-                        if _pkg_r != _leaf_r:
-                            _sib_fail: list[str] = []
-                            _import_sibling_json_patches(
-                                _pkg,
-                                path,
-                                self._game_dir,
-                                self._db,
-                                self._deltas_dir,
-                                failures_out=_sib_fail,
-                            )
-                            if _sib_fail:
-                                logger.warning(
-                                    "Sibling JSON after variant pick: %s",
-                                    "; ".join(_sib_fail),
-                                )
-                except Exception as _sib_exc:
-                    logger.warning(
-                        "Sibling JSON import after variant pick failed: %s",
-                        _sib_exc,
-                    )
 
             if vtmp is not None:
                 import shutil

--- a/src/cdumm/gui/pages/mods_page.py
+++ b/src/cdumm/gui/pages/mods_page.py
@@ -1321,7 +1321,35 @@ class ModsPage(QWidget):
                     from cdumm.gui.preset_picker import (
                         find_json_presets, find_folder_variants)
                     presets = find_json_presets(sp)
-                    leaves = _flatten_folder_variants(sp)
+                    # Loose-file packs (Character Creator 837): zip has a
+                    # single top-level folder (CharacterCreator/) with
+                    # mod.json + sibling body-type dirs. find_folder_variants
+                    # on the extract root sees only one subdir and returns
+                    # nothing, so _flatten_folder_variants produced zero
+                    # leaves and the cog showed no swap options. Import
+                    # already uses find_loose_file_variants for this layout —
+                    # mirror that here.
+                    leaves: list[tuple] = []
+                    try:
+                        from cdumm.engine.import_handler import (
+                            find_loose_file_variants,
+                        )
+                        loose_v = find_loose_file_variants(sp)
+                        if len(loose_v) >= 2:
+                            _sp_r = sp.resolve()
+                            for v in loose_v:
+                                _bd = Path(v["_base_dir"])
+                                try:
+                                    _rel = _bd.resolve().relative_to(
+                                        _sp_r).as_posix()
+                                except ValueError:
+                                    _rel = _bd.name
+                                leaves.append((_bd, _rel))
+                    except Exception as _lv_e:
+                        logger.debug(
+                            "cog loose-file variants probe: %s", _lv_e)
+                    if len(leaves) < 2:
+                        leaves = _flatten_folder_variants(sp)
                     # Folder-variant branch — only when there are no JSON
                     # presets (XML-only mods like Vaxis LoD). JSON-preset
                     # mods take priority below.

--- a/src/cdumm/gui/pages/mods_page.py
+++ b/src/cdumm/gui/pages/mods_page.py
@@ -1672,7 +1672,8 @@ class ModsPage(QWidget):
                     raw = old_drop_name.split("||", 1)[0]
                     from pathlib import Path as _P
                     window._original_drop_path = _P(raw)
-                window._launch_import_worker(worker_path)
+                window._launch_import_worker(
+                    worker_path, import_sibling_json=False)
             self._config_panel.close_panel()
             self._folder_variant_paths = []
             return
@@ -1772,7 +1773,8 @@ class ModsPage(QWidget):
                     raw = old_drop_name.split("||", 1)[0]
                     from pathlib import Path as _P
                     window._original_drop_path = _P(raw)
-                window._launch_import_worker(worker_path)
+                window._launch_import_worker(
+                    worker_path, import_sibling_json=False)
             self._config_panel.close_panel()
             self._folder_variant_paths = []
             self._folder_variant_is_grid = False
@@ -1939,8 +1941,10 @@ class ModsPage(QWidget):
                         window._update_enabled = old_enabled
                         window._configurable_source = cfg_src
                         if old_drop_name:
-                            window._original_drop_path = Path(old_drop_name)
-                        window._launch_import_worker(worker_path)
+                            raw_dn = old_drop_name.split("||", 1)[0]
+                            window._original_drop_path = Path(raw_dn)
+                        window._launch_import_worker(
+                            worker_path, import_sibling_json=False)
                     self._config_panel.close_panel()
                     self._folder_variant_paths = []
                     return

--- a/src/cdumm/worker_process.py
+++ b/src/cdumm/worker_process.py
@@ -9,6 +9,16 @@ Protocol (each line is valid JSON):
     {"type": "error", "msg": "..."}
     {"type": "warning", "msg": "..."}   — non-fatal warnings (revert)
     {"type": "activity", "cat": "...", "msg": "...", "detail": "..."}
+
+Import subcommand::
+
+    import <mod_path> <game_dir> <db_path> <deltas_dir>
+        [existing_mod_id] [--no-sibling-json]
+
+Optional suffix tokens may appear in any order. ``--no-sibling-json``
+skips importing loose-file package sibling JSON patches (folder import
+only); used when swapping PAZ variants via the cog so FemaleAnimations
+etc. are not duplicated.
 """
 
 import json
@@ -64,8 +74,35 @@ def _emit(obj: dict) -> None:
 
 # ── Import ────────────────────────────────────────────────────────────
 
-def _run_import(mod_path: str, game_dir: str, db_path: str,
-                deltas_dir: str, existing_mod_id: str | None = None) -> None:
+def _parse_import_cli_suffix(tokens: list[str]) -> tuple[int | None, bool]:
+    """Parse optional ``existing_mod_id`` and ``--no-sibling-json`` flags.
+
+    Tokens may appear in any order after the four required path arguments.
+    """
+    logger = logging.getLogger(__name__)
+    existing_mod_id: int | None = None
+    import_sibling_json = True
+    for tok in tokens:
+        if tok == "--no-sibling-json":
+            import_sibling_json = False
+        elif tok.isdigit():
+            if existing_mod_id is None:
+                existing_mod_id = int(tok)
+            else:
+                logger.warning(
+                    "worker import: ignoring extra numeric token %r", tok)
+        else:
+            logger.warning("worker import: ignoring unknown token %r", tok)
+    return existing_mod_id, import_sibling_json
+
+
+def _run_import(
+    mod_path: str, game_dir: str, db_path: str,
+    deltas_dir: str,
+    existing_mod_id: int | None = None,
+    *,
+    import_sibling_json: bool = True,
+) -> None:
     from cdumm.storage.database import Database
     from cdumm.engine.snapshot_manager import SnapshotManager
     from cdumm.engine.import_handler import (
@@ -78,7 +115,7 @@ def _run_import(mod_path: str, game_dir: str, db_path: str,
     game_dir = Path(game_dir)
     db_path = Path(db_path)
     deltas_dir = Path(deltas_dir)
-    existing_id = int(existing_mod_id) if existing_mod_id else None
+    existing_id = existing_mod_id
 
     db = Database(db_path)
     db.initialize()
@@ -92,7 +129,10 @@ def _run_import(mod_path: str, game_dir: str, db_path: str,
         "zip": lambda: import_from_zip(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
         "7z": lambda: import_from_7z(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
         "rar": lambda: import_from_rar(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
-        "folder": lambda: import_from_folder(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
+        "folder": lambda: import_from_folder(
+            mod_path, game_dir, db, snapshot, deltas_dir,
+            existing_mod_id=existing_id,
+            import_sibling_json=import_sibling_json),
         "script": lambda: import_from_script(mod_path, game_dir, db, snapshot, deltas_dir),
         "json_patch": lambda: import_from_json_patch(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
         "natt_format_3": lambda: import_from_natt_format_3(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
@@ -794,9 +834,18 @@ def worker_main(args: list[str]) -> None:
     cmd = args[0]
     try:
         if cmd == "import":
-            # import <mod_path> <game_dir> <db_path> <deltas_dir> [existing_mod_id]
-            _run_import(args[1], args[2], args[3], args[4],
-                        args[5] if len(args) > 5 else None)
+            # import <mod_path> <game_dir> <db_path> <deltas_dir>
+            #     [existing_mod_id] [--no-sibling-json]
+            if len(args) < 5:
+                _emit({"type": "error",
+                       "msg": "import needs mod_path game_dir db_path deltas_dir"})
+                sys.exit(1)
+            _ex_id, _imp_sib = _parse_import_cli_suffix(list(args[5:]))
+            _run_import(
+                args[1], args[2], args[3], args[4],
+                existing_mod_id=_ex_id,
+                import_sibling_json=_imp_sib,
+            )
         elif cmd == "import_batch":
             # import_batch <paths_file> <game_dir> <db_path> <deltas_dir>
             _run_batch_import(args[1], args[2], args[3], args[4])


### PR DESCRIPTION
This update improves the handling of sibling JSON patches during the import process for loose-file variants. It ensures that sibling JSON files next to mod.json are correctly imported after the main extraction, addressing issues where these files were previously overlooked. The changes include:

- Added logic to import sibling JSON patches after processing extracted files from both zip and folder imports.
- Updated the variant picker to handle cases where mod.json is accompanied by sibling directories containing relevant files, ensuring that all variants are detected and processed correctly.

Imports work correctly:
<img width="1643" height="145" alt="image" src="https://github.com/user-attachments/assets/5d680bef-4100-4658-9cca-c70d9bc6d021" />

<img width="1632" height="228" alt="image" src="https://github.com/user-attachments/assets/16b55191-32a0-4634-9e9a-cafa2e139a68" />

Also variant selection:
<img width="243" height="510" alt="image" src="https://github.com/user-attachments/assets/1a9ee95e-c245-4567-86f0-f2999e8b658e" />
