### PR TITLE
Linux native - no Wine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ tests/_test_mods_external/
 .tmp_*
 reviewcode_diff.patch
 
+# Runtime logs. The worker subprocess writes cdumm_worker.log relative
+# to its working directory; on a run-from-source Linux launch that
+# lands inside the source tree (the frozen Windows build writes it to
+# the app-data dir instead). Never commit runtime logs.
+*.log
+
 # macOS
 .DS_Store
 # macOS build artifacts. cdumm.icns is regenerated from

--- a/LINUX.md
+++ b/LINUX.md
@@ -1,12 +1,81 @@
 # Running CDUMM on Linux
 
-CDUMM ships as a Windows executable. On Linux it runs through **Wine 11 or
-newer** once its Wine prefix has a couple of Microsoft redistributables
+CDUMM can run on Linux in two modes:
+
+| Mode | Manager runs as | Pros | Cons |
+|------|-----------------|------|------|
+| **Native** (recommended) | Python on Linux directly | No Wine prefix; no `vcrun2022` / `corefonts`; no Wine version churn; avoids the Python-3.13-on-Wine hangs reported on some setups | No ASI plugin support |
+| **Wine** | `CDUMM3.exe` under Wine 11+ | Full feature parity with the Windows build (incl. ASI) | Wine prefix management; needs Wine 11+ |
+
+Crimson Desert itself runs under Proton/Steam in both modes — only the
+manager itself changes. The game's `bin64/CrimsonDesert.exe` is the
+same Windows binary either way.
+
+## Quick start — native Linux build (recommended)
+
+```bash
+git clone https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager.git
+cd CrimsonDesert-UltimateModsManager
+./scripts/cdumm-linux-native.sh
+```
+
+The launcher provisions a Python virtualenv at `.venv/`, `pip install -e .`s
+CDUMM and its dependencies (PySide6, lxml, cryptography, bsdiff4, etc.),
+optionally builds the Rust native component for the hashing / batch-import
+speedup, then launches the GUI. First run takes a couple of minutes;
+subsequent runs are near-instant — the launcher marker-skips the
+provisioning steps.
+
+Requirements:
+
+- **Python 3.10 or newer** (3.10–3.14 all work; PySide6 6.11 ships
+  stable-ABI wheels via `cp310-abi3`).
+- **Rust toolchain** (optional, for the `cdumm_native` extension module
+  — ~260× faster hashing, ~60% faster batch imports). Install via
+  [rustup](https://rustup.rs/), or pass `--no-native` to the launcher
+  to skip and use the pure-Python fallback.
+
+What you give up vs. Wine mode: **ASI plugin support**. ASI mods inject
+a Windows DLL (`winmm.dll`) into `CrimsonDesert.exe`, which requires
+Wine DLL-override plumbing on Steam's launch options that the native
+build deliberately doesn't manage. Texture, XML, JSON, PAZ overlay,
+and ReShade mods all work normally. The ASI page renders a "not
+supported on Linux" placeholder instead of the scan + card list.
+
+Launcher flags:
+
+```
+./scripts/cdumm-linux-native.sh              # provision (first run) + launch
+./scripts/cdumm-linux-native.sh --reinstall  # wipe venv, rebuild from scratch
+./scripts/cdumm-linux-native.sh --no-native  # skip the Rust build
+./scripts/cdumm-linux-native.sh -- --nxm URL # pass args through to CDUMM
+```
+
+The NexusMods `nxm://` URL handler is registered from the Settings page
+(Settings → Handle nxm:// links → Register). It writes a `.desktop` file
+to `~/.local/share/applications/cdumm-nxm.desktop` and runs
+`xdg-mime default cdumm-nxm.desktop x-scheme-handler/nxm`. The same page
+handles Unregister, and refuses to displace an existing Vortex / MO2
+registration without explicit user confirmation.
+
+Steam install paths probed by the auto-detect: `~/.local/share/Steam`,
+the `~/.steam/steam` and `~/.steam/root` symlinks (deduped by
+`Path.resolve()`), the Flatpak install under
+`~/.var/app/com.valvesoftware.Steam/...`, and the Snap install under
+`~/snap/steam/...`. The detector parses each install's
+`steamapps/libraryfolders.vdf` and locates Crimson Desert in any
+listed library — same behaviour as the Windows VDF scan.
+
+## Quick start — Wine mode (legacy)
+
+CDUMM also ships as a Windows executable that can run through **Wine 11
+or newer** once its Wine prefix has a couple of Microsoft redistributables
 installed. The smoke test (`CDUMM3.exe --worker` boots and emits the
 expected JSON) was verified on Ubuntu 24.04.3 LTS with WineHQ 11.0 stable,
-`vcrun2022`, and `corefonts`.
+`vcrun2022`, and `corefonts`. Choose this path if you need ASI plugin
+support.
 
-## Quick start
+### Wine quick start
 
 Use the bundled launcher in `scripts/cdumm-linux.sh`:
 

--- a/LINUX.md
+++ b/LINUX.md
@@ -58,6 +58,30 @@ to `~/.local/share/applications/cdumm-nxm.desktop` and runs
 handles Unregister, and refuses to displace an existing Vortex / MO2
 registration without explicit user confirmation.
 
+### Desktop integration
+
+The launcher installs a freedesktop entry on first run so the app
+shows the correct icon on Wayland (where compositors ignore
+client-set `setWindowIcon` and look up icons via the `.desktop`
+file matched to the window's `app_id`):
+
+- `~/.local/share/applications/cdumm.desktop` — `Exec=` points at
+  the launcher, `Icon=` is an absolute path, `StartupWMClass=cdumm`.
+- `~/.local/share/icons/cdumm.png` — copied from
+  `assets/cdumm-icon-square.png` (735×735 RGBA).
+
+`main.py` sets the Qt app_id via `QGuiApplication.setDesktopFileName(
+"cdumm")` on Linux, matching the `.desktop` basename so Wayland
+compositors bind the window to the entry. The same path fixes the
+"icon disappears from the taskbar after hide-on-launch" case on
+compositors that show iconified windows.
+
+**Packagers (Nix, Flatpak, distro packages):** if you're not using
+the launcher, install the equivalent yourself — the `.desktop` file
+with `StartupWMClass=cdumm` and an icon that matches the
+`setDesktopFileName` call in `main.py`. The launcher's
+`install_desktop_entry()` function is the reference implementation.
+
 Steam install paths probed by the auto-detect: `~/.local/share/Steam`,
 the `~/.steam/steam` and `~/.steam/root` symlinks (deduped by
 `Path.resolve()`), the Flatpak install under

--- a/scripts/cdumm-linux-native.sh
+++ b/scripts/cdumm-linux-native.sh
@@ -140,5 +140,26 @@ provision_venv
 install_deps
 build_native
 
+# Route Qt file dialogs through the XDG desktop portal.
+#
+# CDUMM forces the Fusion QStyle and themes its own UI via
+# qfluentwidgets, but the QFileDialog convenience methods
+# (getExistingDirectory etc.) are plain Qt widgets that don't
+# inherit the qfluentwidgets dark palette — so on a setup where
+# QT_QPA_PLATFORMTHEME=qt6ct (which doesn't delegate file dialogs
+# to the portal), the picker pops up in light mode regardless of
+# the app theme.
+#
+# Setting the platform theme to 'xdgdesktopportal' makes Qt use
+# the portal's file chooser (the gtk backend), which renders with
+# the system GTK theme — so the picker follows your desktop's
+# light/dark preference instead of CDUMM's internal theme. Only
+# affects this process; your global qt6ct setting is untouched.
+#
+# Override with CDUMM_QT_PLATFORMTHEME=... (or set it empty to
+# fall back to whatever your environment already has) if the
+# portal isn't available on a given machine.
+export QT_QPA_PLATFORMTHEME="${CDUMM_QT_PLATFORMTHEME-xdgdesktopportal}"
+
 log "Launching CDUMM"
 exec "$VENV_DIR/bin/python" -m cdumm.main "${CDUMM_ARGS[@]+"${CDUMM_ARGS[@]}"}"

--- a/scripts/cdumm-linux-native.sh
+++ b/scripts/cdumm-linux-native.sh
@@ -28,6 +28,11 @@ readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly VENV_DIR="$REPO_ROOT/.venv"
 readonly DEPS_MARKER="$VENV_DIR/.cdumm-deps-installed"
 readonly NATIVE_MARKER="$VENV_DIR/.cdumm-native-built"
+readonly DESKTOP_MARKER="$VENV_DIR/.cdumm-desktop-installed"
+
+readonly XDG_DATA="${XDG_DATA_HOME:-$HOME/.local/share}"
+readonly DESKTOP_FILE="$XDG_DATA/applications/cdumm.desktop"
+readonly ICON_DEST="$XDG_DATA/icons/cdumm.png"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m==>\033[0m %s\n' "$*" >&2; }
@@ -134,11 +139,60 @@ build_native() {
   log "cdumm_native built and installed in the venv"
 }
 
+# Install a freedesktop ``cdumm.desktop`` + PNG icon under
+# ``$XDG_DATA_HOME/{applications,icons}``. Required for Wayland to
+# show CDUMM's icon — the compositor matches the running window's
+# app_id (set from main.py via QGuiApplication.setDesktopFileName)
+# to the .desktop file's basename, then loads the Icon= field. Also
+# fixes the post-launch icon revert and the missing-icon-on-
+# hide-to-taskbar case RoGreat reported in PR #123.
+#
+# Idempotent — re-runs only when the marker is missing or --reinstall
+# is passed. Both files live under ~/.local/share (user-local), so
+# no sudo and nothing system-wide is touched.
+install_desktop_entry() {
+  if [[ -f "$DESKTOP_MARKER" && $REINSTALL -eq 0 ]]; then
+    return 0
+  fi
+  local src_icon="$REPO_ROOT/assets/cdumm-icon-square.png"
+  if [[ ! -f "$src_icon" ]]; then
+    warn "Icon source $src_icon missing — skipping desktop entry install."
+    return 0
+  fi
+  log "Installing cdumm.desktop + icon (Wayland icon + taskbar entry)"
+  mkdir -p "$(dirname "$DESKTOP_FILE")" "$(dirname "$ICON_DEST")"
+  cp -f "$src_icon" "$ICON_DEST"
+  # Write the .desktop file. Use absolute paths for Exec and Icon so
+  # the entry works regardless of icon-theme cache state and the
+  # user's PATH at click time. StartupWMClass must match the
+  # app_id Qt advertises (the "cdumm" we pass to setDesktopFileName).
+  {
+    echo "[Desktop Entry]"
+    echo "Type=Application"
+    echo "Name=CDUMM"
+    echo "GenericName=Mod Manager"
+    echo "Comment=Crimson Desert Ultimate Mods Manager (native Linux build)"
+    echo "Exec=$REPO_ROOT/scripts/cdumm-linux-native.sh"
+    echo "Icon=$ICON_DEST"
+    echo "Terminal=false"
+    echo "Categories=Game;Utility;"
+    echo "StartupWMClass=cdumm"
+    echo "StartupNotify=true"
+  } > "$DESKTOP_FILE"
+  # Best-effort cache refresh so GNOME / KDE see the entry without
+  # a session restart. Absence of the binary is fine on minimal WMs.
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$(dirname "$DESKTOP_FILE")" >/dev/null 2>&1 || true
+  fi
+  touch "$DESKTOP_MARKER"
+}
+
 # ── main ────────────────────────────────────────────────────────────
 
 provision_venv
 install_deps
 build_native
+install_desktop_entry
 
 # Route Qt file dialogs through the XDG desktop portal.
 #

--- a/scripts/cdumm-linux-native.sh
+++ b/scripts/cdumm-linux-native.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Native Linux launcher for CDUMM. Provisions a Python virtualenv,
+# installs CDUMM + dependencies via pip, optionally builds the Rust
+# native component (cdumm_native) for the ~260x hashing speedup and
+# 60% faster batch imports, then launches the GUI.
+#
+# This is the "no Wine" path: CDUMM runs as native Python on Linux
+# and manages mods for Crimson Desert running under Proton/Steam.
+# The game itself is still a Windows binary that Proton runs via
+# Wine — only the manager goes native. For the Wine-based launcher
+# (CDUMM3.exe under Wine), see scripts/cdumm-linux.sh — that path
+# is still maintained for users who need ASI plugin support.
+#
+# Usage:
+#   ./cdumm-linux-native.sh              Launch CDUMM. Provisions
+#                                        deps on first run.
+#   ./cdumm-linux-native.sh --reinstall  Force-reinstall deps + the
+#                                        Rust native component.
+#   ./cdumm-linux-native.sh --no-native  Skip the Rust native build
+#                                        (pure-Python fallback works
+#                                        but is slower).
+#   ./cdumm-linux-native.sh -- <args>    Pass <args> through to CDUMM.
+#   ./cdumm-linux-native.sh --help       Print this header.
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly VENV_DIR="$REPO_ROOT/.venv"
+readonly DEPS_MARKER="$VENV_DIR/.cdumm-deps-installed"
+readonly NATIVE_MARKER="$VENV_DIR/.cdumm-native-built"
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m==>\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m==>\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── argument parsing ────────────────────────────────────────────────
+
+REINSTALL=0
+BUILD_NATIVE=1
+CDUMM_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reinstall) REINSTALL=1; shift ;;
+    --no-native) BUILD_NATIVE=0; shift ;;
+    --help|-h)
+      # Print the docstring (lines 2..first blank) with the
+      # leading '# ' stripped. Skips the shebang on line 1.
+      sed -n '2,/^$/{ s/^# \?//; p; }' "$0"
+      exit 0
+      ;;
+    --) shift; CDUMM_ARGS=("$@"); break ;;
+    *) CDUMM_ARGS+=("$1"); shift ;;
+  esac
+done
+
+# ── locate a usable Python interpreter ──────────────────────────────
+
+# CDUMM's pyproject.toml requires Python >= 3.10. Some distros ship
+# only ``python3`` without versioned aliases; iterate candidates in
+# rough preference order (newest first) so the version check fast-
+# paths to a known-good interpreter when one is available.
+find_python() {
+  local cand ver
+  for cand in python3.13 python3.12 python3.11 python3.10 python3.14 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      ver=$("$cand" -c \
+        'import sys; print("ok" if sys.version_info >= (3,10) else "old")' \
+        2>/dev/null) || continue
+      if [[ "$ver" == "ok" ]]; then
+        printf '%s' "$cand"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# ── provisioning ────────────────────────────────────────────────────
+
+provision_venv() {
+  if [[ -d "$VENV_DIR" && $REINSTALL -eq 0 ]]; then
+    return 0
+  fi
+  local python_bin
+  python_bin=$(find_python) || die \
+    "Need Python 3.10 or newer. Install via your package manager (e.g. \
+'sudo pacman -S python', 'sudo apt install python3', \
+'sudo dnf install python3') and try again."
+  log "Using $($python_bin --version) ($python_bin)"
+  if [[ -d "$VENV_DIR" ]]; then
+    log "Removing existing venv at $VENV_DIR"
+    rm -rf "$VENV_DIR"
+  fi
+  log "Creating venv at $VENV_DIR"
+  "$python_bin" -m venv "$VENV_DIR"
+}
+
+install_deps() {
+  if [[ -f "$DEPS_MARKER" && $REINSTALL -eq 0 ]]; then
+    return 0
+  fi
+  log "Upgrading pip"
+  "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+  log "Installing CDUMM + dependencies (PySide6 is ~200MB; allow a minute)"
+  "$VENV_DIR/bin/pip" install --quiet -e "$REPO_ROOT"
+  touch "$DEPS_MARKER"
+}
+
+# Build the Rust native component (cdumm_native). The pure-Python
+# fallback paths handle every cdumm_native callsite via
+# ``try: import cdumm_native; except ImportError: ...`` blocks, so
+# this step is best-effort: if cargo isn't installed we just warn
+# and let the user run CDUMM with the slower pure-Python paths.
+build_native() {
+  if [[ $BUILD_NATIVE -eq 0 ]]; then
+    return 0
+  fi
+  if [[ -f "$NATIVE_MARKER" && $REINSTALL -eq 0 ]]; then
+    return 0
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    warn "cargo (Rust toolchain) not on PATH — skipping cdumm_native build."
+    warn "CDUMM will fall back to pure-Python for hashing / batch import"
+    warn "(slower but functional). Install Rust via https://rustup.rs and"
+    warn "re-run with --reinstall to get the speedup."
+    return 0
+  fi
+  log "Installing maturin (Rust ↔ Python build glue)"
+  "$VENV_DIR/bin/pip" install --quiet maturin
+  log "Building cdumm_native (release profile, this takes ~30s)"
+  (cd "$REPO_ROOT/native" \
+    && "$VENV_DIR/bin/maturin" develop --release --quiet)
+  touch "$NATIVE_MARKER"
+  log "cdumm_native built and installed in the venv"
+}
+
+# ── main ────────────────────────────────────────────────────────────
+
+provision_venv
+install_deps
+build_native
+
+log "Launching CDUMM"
+exec "$VENV_DIR/bin/python" -m cdumm.main "${CDUMM_ARGS[@]+"${CDUMM_ARGS[@]}"}"

--- a/scripts/cdumm-linux-native.sh
+++ b/scripts/cdumm-linux-native.sh
@@ -32,7 +32,14 @@ readonly DESKTOP_MARKER="$VENV_DIR/.cdumm-desktop-installed"
 
 readonly XDG_DATA="${XDG_DATA_HOME:-$HOME/.local/share}"
 readonly DESKTOP_FILE="$XDG_DATA/applications/cdumm.desktop"
-readonly ICON_DEST="$XDG_DATA/icons/cdumm.png"
+# Install the icon under the hicolor theme so waybar / wlr-taskbar /
+# any GTK icon-theme lookup (which is what most Wayland taskbars use
+# — they map app_id straight to an icon-theme name, NOT to the
+# .desktop's Icon= path) finds it as ``cdumm``. The earlier flat
+# ~/.local/share/icons/cdumm.png location wasn't in any theme path
+# so the lookup returned nothing on Hyprland+waybar (PR #123).
+readonly ICON_DEST="$XDG_DATA/icons/hicolor/512x512/apps/cdumm.png"
+readonly ICON_DEST_LEGACY="$XDG_DATA/icons/cdumm.png"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m==>\033[0m %s\n' "$*" >&2; }
@@ -159,13 +166,18 @@ install_desktop_entry() {
     warn "Icon source $src_icon missing — skipping desktop entry install."
     return 0
   fi
-  log "Installing cdumm.desktop + icon (Wayland icon + taskbar entry)"
+  log "Installing cdumm.desktop + hicolor icon (Wayland taskbar)"
   mkdir -p "$(dirname "$DESKTOP_FILE")" "$(dirname "$ICON_DEST")"
   cp -f "$src_icon" "$ICON_DEST"
-  # Write the .desktop file. Use absolute paths for Exec and Icon so
-  # the entry works regardless of icon-theme cache state and the
-  # user's PATH at click time. StartupWMClass must match the
-  # app_id Qt advertises (the "cdumm" we pass to setDesktopFileName).
+  # Clean up the pre-fix flat icon location if present (left by an
+  # earlier version of this script that put the PNG outside any
+  # theme path). Harmless leftover otherwise.
+  rm -f "$ICON_DEST_LEGACY"
+  # Write the .desktop file. ``Icon=cdumm`` (theme name, NOT an
+  # absolute path) so taskbars that route through the GTK icon-theme
+  # API resolve it via the hicolor entry above. ``StartupWMClass``
+  # must match the app_id Qt advertises (the "cdumm" string we pass
+  # to setDesktopFileName in main.py).
   {
     echo "[Desktop Entry]"
     echo "Type=Application"
@@ -173,16 +185,21 @@ install_desktop_entry() {
     echo "GenericName=Mod Manager"
     echo "Comment=Crimson Desert Ultimate Mods Manager (native Linux build)"
     echo "Exec=$REPO_ROOT/scripts/cdumm-linux-native.sh"
-    echo "Icon=$ICON_DEST"
+    echo "Icon=cdumm"
     echo "Terminal=false"
     echo "Categories=Game;Utility;"
     echo "StartupWMClass=cdumm"
     echo "StartupNotify=true"
   } > "$DESKTOP_FILE"
-  # Best-effort cache refresh so GNOME / KDE see the entry without
-  # a session restart. Absence of the binary is fine on minimal WMs.
+  # Best-effort cache refreshes. update-desktop-database is for the
+  # applications/ side; gtk-update-icon-cache is what waybar and
+  # GTK-icon-theme consumers re-read. Absence of either binary is
+  # fine on minimal WMs.
   if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database "$(dirname "$DESKTOP_FILE")" >/dev/null 2>&1 || true
+  fi
+  if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -t -f "$XDG_DATA/icons/hicolor" >/dev/null 2>&1 || true
   fi
   touch "$DESKTOP_MARKER"
 }

--- a/src/cdumm/engine/crimson_browser_handler.py
+++ b/src/cdumm/engine/crimson_browser_handler.py
@@ -17,6 +17,7 @@ The handler:
 import json
 import logging
 import shutil
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -31,6 +32,31 @@ if TYPE_CHECKING:
     from cdumm.storage.config import Config
 
 logger = logging.getLogger(__name__)
+
+
+def _rglob_follow(root: Path, pattern: str = "*"):
+    """``root.rglob(pattern)`` that recurses into symlinked directories
+    on every supported Python version.
+
+    Python 3.13 changed ``Path.rglob`` to default ``recurse_symlinks=
+    False`` — it no longer descends into symlinked subdirectories. The
+    frozen Windows build (and the pre-3.13 behaviour this module was
+    written against) DID follow them. On a native Linux run under
+    Python 3.13+, any mod file that lives behind a symlinked directory
+    is silently skipped: ``has_files`` reads False, no PAZ is built,
+    and the mod imports as a stray PATHC instead. Reported by RoGreat
+    on a Nix-packaged build (PR #123), where symlinked paths are
+    pervasive.
+
+    Restoring the follow-symlinks behaviour is safe here because every
+    caller that reads file contents re-checks ``f.resolve()`` stays
+    within the mod's files_dir before reading (the symlink-escape
+    guard), so a malicious symlink pointing outside the tree is still
+    refused — it just no longer takes legitimate files down with it.
+    """
+    if sys.version_info >= (3, 13):
+        return root.rglob(pattern, recurse_symlinks=True)
+    return root.rglob(pattern)
 
 
 def fix_xml_format(
@@ -141,7 +167,7 @@ def detect_crimson_browser(path: Path) -> dict | None:
                 # often omit the format field)
                 files_dir_name = manifest.get("files_dir", "files")
                 files_dir = candidate.parent / files_dir_name
-                if files_dir.exists() and files_dir.is_dir() and any(files_dir.rglob("*")):
+                if files_dir.exists() and files_dir.is_dir() and any(_rglob_follow(files_dir)):
                     manifest.setdefault("files_dir", files_dir_name)
                     manifest["_manifest_path"] = candidate
                     manifest["_base_dir"] = candidate.parent
@@ -179,8 +205,8 @@ def convert_to_paz_mod(
     patches_dir_name = manifest.get("patches_dir")
     patches_dir = base_dir / patches_dir_name if patches_dir_name else None
 
-    has_files = files_dir.exists() and any(files_dir.rglob("*"))
-    has_patches = patches_dir and patches_dir.exists() and any(patches_dir.rglob("*.json"))
+    has_files = files_dir.exists() and any(_rglob_follow(files_dir))
+    has_patches = patches_dir and patches_dir.exists() and any(_rglob_follow(patches_dir, "*.json"))
 
     if not has_files and not has_patches:
         logger.error("CB mod: no files_dir or patches_dir found in %s", base_dir)
@@ -190,7 +216,7 @@ def convert_to_paz_mod(
     patches_succeeded = 0
     if has_patches:
         from cdumm.engine.json_patch_handler import convert_json_patch_to_paz
-        for patch_file in patches_dir.rglob("*.json"):
+        for patch_file in _rglob_follow(patches_dir, "*.json"):
             try:
                 with open(patch_file, "r", encoding="utf-8") as f:
                     patch_data = json.load(f)
@@ -226,14 +252,16 @@ def convert_to_paz_mod(
 
     _SKIP_FILES = {"mod.json", "manifest.json", "modinfo.json"}
     files_dir_resolved = files_dir.resolve()
-    for f in files_dir.rglob("*"):
+    for f in _rglob_follow(files_dir):
         if not f.is_file() or f.name.lower() in _SKIP_FILES:
             continue
-        # Symlink / junction safety: rglob follows links by default
-        # on Windows, so a malicious mod ZIP with a symlink under
-        # files/ pointing outside the extracted dir could expose
+        # Symlink / junction safety: _rglob_follow descends into
+        # symlinked directories (see its docstring re: the Python 3.13
+        # rglob default change), so a malicious mod ZIP with a symlink
+        # under files/ pointing outside the extracted dir could expose
         # arbitrary filesystem content via subsequent read_bytes().
-        # Round 10 audit catch.
+        # Resolve and confirm the file stays within files_dir before
+        # trusting it. Round 10 audit catch.
         try:
             f_resolved = f.resolve()
             f_resolved.relative_to(files_dir_resolved)
@@ -270,7 +298,7 @@ def convert_to_paz_mod(
             continue
         if sibling.name.lower() not in _SIBLING_CONTENT_DIRS:
             continue
-        for f in sibling.rglob("*"):
+        for f in _rglob_follow(sibling):
             if not f.is_file() or f.name.lower() in _SKIP_FILES:
                 continue
             rel = f.relative_to(sibling)

--- a/src/cdumm/engine/crimson_browser_handler.py
+++ b/src/cdumm/engine/crimson_browser_handler.py
@@ -182,6 +182,7 @@ def convert_to_paz_mod(
     game_dir: Path,
     work_dir: Path,
     config: "Config | None" = None,
+    trust_symlinks: bool = False,
 ) -> Path | None:
     """Convert a Crimson Browser mod to a standard PAZ mod directory.
 
@@ -193,6 +194,24 @@ def convert_to_paz_mod(
         manifest: parsed manifest dict (from detect_crimson_browser)
         game_dir: path to game installation root
         work_dir: temporary directory for output
+        config: optional Config (currently unused by this function)
+        trust_symlinks: if True, files whose ``.resolve()`` lands
+            outside ``files_dir`` are READ (following the symlink to
+            its target) instead of skipped. Set this only when the
+            caller knows the mod came from a user-selected local
+            folder (the user chose the directory and could equally
+            point CDUMM at the symlink targets themselves) — never
+            for archive extractions, where a malicious zip could ship
+            symlinks pointing at arbitrary files on disk.
+
+            Default False keeps the Round 10 symlink-escape guard
+            active, so zip/7z extractions stay protected. Folder
+            imports (``import_from_folder``) opt in by passing True.
+            Reported by RoGreat on a Nix-packaged build (PR #123):
+            his mod's individual .dds/.css files are symlinks into
+            the Nix store, which made the previous unconditional
+            guard skip them and force the import down the standalone
+            texture-overlay fallback path.
 
     Returns:
         Path to directory containing modified PAZ files, or None on failure.
@@ -262,14 +281,22 @@ def convert_to_paz_mod(
         # arbitrary filesystem content via subsequent read_bytes().
         # Resolve and confirm the file stays within files_dir before
         # trusting it. Round 10 audit catch.
-        try:
-            f_resolved = f.resolve()
-            f_resolved.relative_to(files_dir_resolved)
-        except (ValueError, OSError):
-            logger.warning(
-                "CB import: skipping %s (resolves outside files_dir, "
-                "possible symlink escape)", f)
-            continue
+        #
+        # ``trust_symlinks=True`` (folder imports only) skips this
+        # check: the user picked a local directory, so a symlinked
+        # file inside it pointing elsewhere on their filesystem is
+        # a legitimate reference (RoGreat's Nix-packaged mods do
+        # exactly this — individual .dds files are symlinks into the
+        # Nix store). PR #123.
+        if not trust_symlinks:
+            try:
+                f_resolved = f.resolve()
+                f_resolved.relative_to(files_dir_resolved)
+            except (ValueError, OSError):
+                logger.warning(
+                    "CB import: skipping %s (resolves outside files_dir, "
+                    "possible symlink escape)", f)
+                continue
         rel = f.relative_to(files_dir)
         parts = rel.parts
         if len(parts) >= 2 and parts[0].isdigit():

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -3518,12 +3518,20 @@ def import_from_folder(
     """Import a mod from a folder of modified files."""
     mod_name = folder_path.name
 
-    # Check for Crimson Browser format and convert if needed
+    # Check for Crimson Browser format and convert if needed.
+    # trust_symlinks=True: the user picked this local folder, so a
+    # mod file that's a symlink to its real target elsewhere on the
+    # filesystem (e.g. RoGreat's Nix-derivation outputs in PR #123)
+    # is a legitimate reference and must be followed rather than
+    # treated as a symlink-escape attack. Archive-extraction call
+    # sites keep the default (False) — see convert_to_paz_mod's
+    # docstring for the threat-model distinction.
     manifest = detect_crimson_browser(folder_path)
     if manifest is not None:
         with import_staging_dir(game_dir) as cb_tmp:
             cb_work = Path(cb_tmp) / "_cb_converted"
-            converted = convert_to_paz_mod(manifest, game_dir, cb_work)
+            converted = convert_to_paz_mod(
+                manifest, game_dir, cb_work, trust_symlinks=True)
             if converted is not None:
                 cb_name = _pick_cb_display_name(manifest.get("id"), mod_name)
                 modinfo = _read_modinfo(folder_path)
@@ -3550,12 +3558,16 @@ def import_from_folder(
                         logger.debug("Sibling JSON scan after CB failed: %s", e)
                 return cb_result
 
-    # Check for loose file mod (mod.json + files/ directory)
+    # Check for loose file mod (mod.json + files/ directory).
+    # trust_symlinks=True: same reasoning as the CB branch above —
+    # user-selected folder, symlinks inside it are trusted local
+    # references.
     lfm = detect_loose_file_mod(folder_path)
     if lfm is not None:
         with import_staging_dir(game_dir) as lfm_tmp:
             lfm_work = Path(lfm_tmp) / "_lfm_converted"
-            converted = convert_to_paz_mod(lfm, game_dir, lfm_work)
+            converted = convert_to_paz_mod(
+                lfm, game_dir, lfm_work, trust_symlinks=True)
             if converted is not None:
                 mi = lfm.get("_modinfo", {})
                 lfm_name = mi.get("title", mod_name)

--- a/src/cdumm/engine/nxm_handler.py
+++ b/src/cdumm/engine/nxm_handler.py
@@ -1,4 +1,4 @@
-"""``nxm://`` URL protocol handler — parse + Windows registry registration.
+"""``nxm://`` URL protocol handler — parse + per-OS registration.
 
 NexusMods uses the ``nxm://`` URL scheme to route "Mod Manager Download"
 button clicks from the website into a registered desktop application.
@@ -15,22 +15,29 @@ downloads carry ``campaign=collection`` instead.
 This module:
 
 1. :func:`parse_nxm_url` — validates + tokenizes an incoming URL.
-2. :func:`register_windows_handler` — writes the HKCU\\Software\\Classes
+2. :func:`register_handler` / :func:`unregister_handler` — generic
+   per-platform dispatchers. Callers should prefer these over the
+   ``_windows_`` / ``_linux_`` variants.
+3. :func:`register_windows_handler` — writes the HKCU\\Software\\Classes
    entries needed so Windows hands ``nxm://...`` URLs to CDUMM.
-3. :func:`unregister_windows_handler` — removes those entries.
-4. :func:`is_handler_registered` — reports whether CDUMM is currently
-   the registered handler (so we don't stomp on Vortex/MO2 without
-   asking the user).
+4. :func:`register_linux_handler` — writes a freedesktop ``.desktop``
+   file under ``~/.local/share/applications`` and associates the
+   ``x-scheme-handler/nxm`` MIME type via ``xdg-mime default``.
+5. :func:`is_handler_registered` — reports whether CDUMM is currently
+   the registered handler on this platform (so we don't stomp on
+   Vortex/MO2 without asking the user).
 """
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from cdumm.platform import IS_WINDOWS
+from cdumm.platform import IS_LINUX, IS_WINDOWS
 
 logger = logging.getLogger(__name__)
 
@@ -223,9 +230,10 @@ def unregister_windows_handler() -> bool:
     return ok
 
 
-def is_handler_registered() -> bool:
-    """True when the nxm:// handler under HKCU points at the current
-    CDUMM executable."""
+def _is_handler_registered_windows() -> bool:
+    """Windows-only branch of :func:`is_handler_registered`. Pulled
+    out so the public function can dispatch cleanly across platforms
+    without growing a nested conditional."""
     if not IS_WINDOWS:
         return False
     try:
@@ -244,6 +252,318 @@ def is_handler_registered() -> bool:
     if current is None or ours is None:
         return False
     return current.casefold() == ours.casefold()
+
+
+def is_handler_registered() -> bool:
+    """True when the nxm:// handler is currently CDUMM on this platform.
+
+    Dispatches to the OS-specific check: Windows reads HKCU\\Software\\
+    Classes\\nxm; Linux runs ``xdg-mime query default x-scheme-handler/
+    nxm`` and compares against our ``.desktop`` filename. Returns False
+    on platforms where CDUMM doesn't (yet) implement URL-scheme
+    registration (e.g. macOS — see MACOS.md).
+    """
+    if IS_WINDOWS:
+        return _is_handler_registered_windows()
+    if IS_LINUX:
+        return _is_handler_registered_linux()
+    return False
+
+
+# ── Linux: freedesktop .desktop + xdg-mime registration ─────────────
+
+
+# The .desktop file name. Kept short and unique so it doesn't collide
+# with another app's installed entry, and so ``xdg-mime query default``
+# returns a stable identifier we can match against.
+LINUX_DESKTOP_FILE_NAME = "cdumm-nxm.desktop"
+
+# The MIME-type token freedesktop uses for ``nxm://`` URLs. NexusMods
+# documents this as ``x-scheme-handler/nxm`` in their Vortex guide and
+# every Linux mod manager that supports nxm registers under this key.
+LINUX_NXM_MIME_TYPE = "x-scheme-handler/nxm"
+
+
+def _linux_applications_dir() -> Path:
+    """Per-user XDG applications directory where the ``.desktop`` file
+    is installed. Respects ``$XDG_DATA_HOME``; falls back to
+    ``~/.local/share`` per the spec."""
+    base = os.environ.get("XDG_DATA_HOME")
+    root = Path(base) if base else Path.home() / ".local" / "share"
+    return root / "applications"
+
+
+def _linux_mimeapps_list_path() -> Path:
+    """Path to the freedesktop ``mimeapps.list`` that ``xdg-mime
+    default`` writes to. Respects ``$XDG_CONFIG_HOME``; falls back
+    to ``~/.config``."""
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path.home() / ".config"
+    return root / "mimeapps.list"
+
+
+def _linux_desktop_file_path() -> Path:
+    return _linux_applications_dir() / LINUX_DESKTOP_FILE_NAME
+
+
+def _linux_exec_command() -> str:
+    """The ``Exec=`` line for the generated ``.desktop`` file.
+
+    Frozen builds (PyInstaller / AppImage) get a direct exe invocation;
+    source builds (``pip install -e .`` or otherwise on PYTHONPATH) get
+    ``<python> -m cdumm.main`` so the package's entry-point logic still
+    runs. The ``%u`` placeholder is the freedesktop token for "the URL
+    that triggered this launch" — xdg-open substitutes the clicked
+    ``nxm://...`` URL into it.
+    """
+    exe = str(Path(sys.executable).resolve())
+    if getattr(sys, "frozen", False):
+        return f"{exe} --nxm %u"
+    return f"{exe} -m cdumm.main --nxm %u"
+
+
+def _linux_desktop_file_content() -> str:
+    """Body of the generated ``.desktop`` file. ``NoDisplay=true``
+    keeps it out of the application menu — CDUMM is launched normally
+    via its own desktop entry (or AppImage); this file exists solely
+    to bind the ``nxm://`` MIME type to our executable."""
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=CDUMM (nxm:// handler)\n"
+        "Comment=Crimson Desert Ultimate Mods Manager — Nexus URL handler\n"
+        f"Exec={_linux_exec_command()}\n"
+        "NoDisplay=true\n"
+        "Terminal=false\n"
+        f"MimeType={LINUX_NXM_MIME_TYPE};\n"
+        "Categories=Game;\n"
+    )
+
+
+def _linux_query_current_handler() -> str | None:
+    """Run ``xdg-mime query default x-scheme-handler/nxm`` and return
+    the .desktop file name (e.g. ``"cdumm-nxm.desktop"``), or ``None``
+    when nothing is registered or xdg-mime isn't installed.
+
+    The call is bounded to a short timeout so an unresponsive desktop
+    environment can't wedge the Settings page; failures fall through
+    to "no handler", which is the safe default for the
+    register-button-state UI."""
+    try:
+        result = subprocess.run(
+            ["xdg-mime", "query", "default", LINUX_NXM_MIME_TYPE],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    name = (result.stdout or "").strip()
+    return name or None
+
+
+def _is_handler_registered_linux() -> bool:
+    """True when xdg-mime reports our ``.desktop`` file as the
+    default for ``x-scheme-handler/nxm``. Checked by comparing the
+    file *name* (not path) because ``xdg-mime`` reports the bare
+    filename."""
+    if not IS_LINUX:
+        return False
+    return _linux_query_current_handler() == LINUX_DESKTOP_FILE_NAME
+
+
+def register_linux_handler(force: bool = False) -> bool:
+    """Register CDUMM as the ``nxm://`` handler via a freedesktop
+    ``.desktop`` file + ``xdg-mime default``.
+
+    Writes ``~/.local/share/applications/cdumm-nxm.desktop`` (or the
+    ``$XDG_DATA_HOME`` equivalent) and runs ``xdg-mime default
+    cdumm-nxm.desktop x-scheme-handler/nxm`` to set CDUMM as the
+    default handler for the current user. Best-effort refreshes the
+    desktop-file database via ``update-desktop-database`` so GNOME /
+    KDE / XFCE pick up the new entry without a session restart.
+
+    When ``force`` is False and another desktop entry already owns
+    the ``nxm://`` scheme (e.g. a previously-installed Vortex flatpak
+    or a competing mod manager), this leaves the existing handler in
+    place and returns False so the caller can prompt the user.
+
+    No-ops on non-Linux. Returns True on success.
+    """
+    if not IS_LINUX:
+        return False
+    if not force:
+        current = _linux_query_current_handler()
+        if current and current != LINUX_DESKTOP_FILE_NAME:
+            logger.info(
+                "nxm handler: another app is registered (%s); skipping",
+                current)
+            return False
+
+    desktop_path = _linux_desktop_file_path()
+    try:
+        desktop_path.parent.mkdir(parents=True, exist_ok=True)
+        desktop_path.write_text(
+            _linux_desktop_file_content(), encoding="utf-8")
+        # Some desktop environments expect the .desktop file to be
+        # executable. Set the bit defensively — owner-rwx + others-rx
+        # mirrors what installer scripts produce.
+        desktop_path.chmod(0o755)
+    except OSError as e:
+        logger.warning(
+            "nxm handler: could not write %s: %s", desktop_path, e)
+        return False
+
+    # Associate the scheme. xdg-mime missing isn't fatal — minimal WMs
+    # (sway, hyprland without a portal) read the .desktop file directly
+    # via xdg-utils when xdg-open is invoked, so the registration may
+    # still work; log and continue.
+    try:
+        subprocess.run(
+            ["xdg-mime", "default",
+             LINUX_DESKTOP_FILE_NAME, LINUX_NXM_MIME_TYPE],
+            check=False, timeout=5,
+            capture_output=True)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.info(
+            "nxm handler: xdg-mime call failed (%s) — .desktop file "
+            "was still written and may be picked up directly", e)
+
+    # Refresh the desktop-database cache. Optional; absence is harmless.
+    try:
+        subprocess.run(
+            ["update-desktop-database", str(_linux_applications_dir())],
+            check=False, timeout=5, capture_output=True)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    logger.info(
+        "nxm handler: registered CDUMM as nxm:// handler (%s)", desktop_path)
+    return True
+
+
+def _linux_strip_mimeapps_entry() -> None:
+    """Remove the ``x-scheme-handler/nxm=cdumm-nxm.desktop`` line from
+    ``mimeapps.list``. xdg-mime has no "unset default" command — it
+    only sets — so we edit the file ourselves. Only lines that match
+    *our* .desktop filename are stripped; entries pointing at other
+    apps are left untouched.
+
+    Idempotent and silently skips a missing file (a user who never
+    registered won't have one). Failures are logged at debug — losing
+    the cleanup step is recoverable (the file we deleted has gone,
+    so the dangling entry resolves to "no handler" anyway)."""
+    mimeapps = _linux_mimeapps_list_path()
+    if not mimeapps.exists():
+        return
+    try:
+        lines = mimeapps.read_text(encoding="utf-8").splitlines()
+    except OSError as e:
+        logger.debug("nxm handler: could not read %s: %s", mimeapps, e)
+        return
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(f"{LINUX_NXM_MIME_TYPE}="):
+            value = stripped.split("=", 1)[1]
+            if LINUX_DESKTOP_FILE_NAME in value:
+                # Drop this line — it pointed at our (now-deleted) file.
+                continue
+        out.append(line)
+    try:
+        mimeapps.write_text("\n".join(out) + "\n", encoding="utf-8")
+    except OSError as e:
+        logger.debug("nxm handler: could not rewrite %s: %s", mimeapps, e)
+
+
+def unregister_linux_handler() -> bool:
+    """Remove the CDUMM ``.desktop`` file and clean up its mimeapps
+    entry. Refuses to act when the current registered handler isn't
+    ours — defense in depth so a future direct caller can't strip
+    Vortex / MO2 out from under the user.
+
+    No-ops on non-Linux. Returns True on success.
+    """
+    if not IS_LINUX:
+        return False
+
+    current = _linux_query_current_handler()
+    if current and current != LINUX_DESKTOP_FILE_NAME:
+        logger.info(
+            "nxm handler: refusing to unregister — current handler "
+            "is %r, not ours", current)
+        return False
+
+    desktop_path = _linux_desktop_file_path()
+    ok = True
+    try:
+        if desktop_path.exists():
+            desktop_path.unlink()
+    except OSError as e:
+        logger.warning(
+            "nxm handler: could not remove %s: %s", desktop_path, e)
+        ok = False
+
+    _linux_strip_mimeapps_entry()
+
+    # Refresh the desktop-database cache so the .desktop disappearance
+    # propagates. Optional.
+    try:
+        subprocess.run(
+            ["update-desktop-database", str(_linux_applications_dir())],
+            check=False, timeout=5, capture_output=True)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    if ok:
+        logger.info("nxm handler: unregistered")
+    return ok
+
+
+# ── Generic dispatchers ─────────────────────────────────────────────
+
+
+def register_handler(force: bool = False) -> bool:
+    """Register CDUMM as the ``nxm://`` handler on the current
+    platform. Dispatches to the OS-specific implementation. Returns
+    False on platforms where URL-scheme registration isn't (yet)
+    implemented (e.g. macOS)."""
+    if IS_WINDOWS:
+        return register_windows_handler(force=force)
+    if IS_LINUX:
+        return register_linux_handler(force=force)
+    return False
+
+
+def unregister_handler() -> bool:
+    """Remove the CDUMM ``nxm://`` handler registration on the current
+    platform. Dispatches to the OS-specific implementation."""
+    if IS_WINDOWS:
+        return unregister_windows_handler()
+    if IS_LINUX:
+        return unregister_linux_handler()
+    return False
+
+
+def existing_handler_description() -> str | None:
+    """Human-readable description of whatever app currently owns the
+    ``nxm://`` scheme on this platform, or ``None`` if nothing does.
+
+    On Windows this is the raw registry command string
+    (``"C:\\...\\Vortex.exe" -d "%1"`` style). On Linux it's the
+    ``.desktop`` filename returned by ``xdg-mime query default``
+    (e.g. ``"net.nexusmods.vortex.desktop"``). The Settings page
+    displays this in the "replace existing handler?" prompt without
+    interpreting it further — the format differs by OS but the user
+    just needs to recognise the other app.
+    """
+    if IS_WINDOWS:
+        try:
+            import winreg
+        except ImportError:
+            return None
+        return _read_command_string(winreg)
+    if IS_LINUX:
+        return _linux_query_current_handler()
+    return None
 
 
 def _read_command_string(winreg_mod) -> str | None:

--- a/src/cdumm/gui/pages/asi_page.py
+++ b/src/cdumm/gui/pages/asi_page.py
@@ -45,7 +45,7 @@ from qfluentwidgets import (
 
 from cdumm.asi.asi_manager import AsiManager, AsiPlugin
 from cdumm.i18n import tr
-from cdumm.platform import IS_MACOS, IS_WINDOWS
+from cdumm.platform import IS_LINUX, IS_MACOS, IS_WINDOWS
 
 logger = logging.getLogger(__name__)
 
@@ -773,13 +773,56 @@ class AsiPluginsPage(QWidget):
         main.setContentsMargins(0, 0, 0, 0)
         main.setSpacing(0)
 
-        # macOS doesn't support ASI plugins (Win32-only winmm.dll proxy
-        # against CrimsonDesert.exe — no Windows exe in the macOS .app
-        # build). Render a placeholder card explaining the gap rather
-        # than the normal scan + card list. Hiding the tab entirely
-        # confused users with downloaded ASI mods (PR #64 review #3).
+        # ASI plugins are a Windows-only mod format (winmm.dll proxy
+        # against CrimsonDesert.exe). Render a placeholder card
+        # explaining the gap rather than the normal scan + card
+        # list on platforms where ASI doesn't apply. Hiding the tab
+        # entirely confused users with downloaded ASI mods (PR #64
+        # review #3) — keep it visible with a clear "not supported"
+        # message instead.
+        #
+        # macOS: no Windows exe in the native .app build, so ASI
+        # has nowhere to inject.
+        #
+        # Linux: the game runs under Proton/Wine where ASI *would*
+        # work in principle, but the loader needs Wine DLL-override
+        # plumbing on Steam's launch options to bind winmm.dll. The
+        # Linux-native CDUMM build deliberately stays out of the
+        # Wine prefix — point users at the upstream LINUX.md if they
+        # really need ASI and tell them to use the Wine build of
+        # CDUMM for that case.
         if IS_MACOS:
-            self._build_macos_placeholder_view(main)
+            self._build_unsupported_placeholder_view(
+                main,
+                title=tr("asi.macos_unavailable_title"),
+                body=tr("asi.macos_unavailable_body"),
+                reassure=tr("asi.macos_unavailable_reassure"),
+                link_label=tr("asi.macos_unavailable_link"),
+                link_url=(
+                    "https://github.com/faisalkindi/CrimsonDesert-"
+                    "UltimateModsManager/blob/master/MACOS.md"))
+            return
+        if IS_LINUX:
+            self._build_unsupported_placeholder_view(
+                main,
+                title="ASI plugins are not supported on Linux",
+                body=(
+                    "ASI mods inject a Windows DLL (winmm.dll proxy) "
+                    "into CrimsonDesert.exe to run code in the game "
+                    "process. The Linux-native CDUMM build runs the "
+                    "manager outside the Proton/Wine prefix, so it "
+                    "can't safely wire up the WINEDLLOVERRIDES that "
+                    "the loader needs on Steam's launch options."),
+                reassure=(
+                    "Texture, XML, JSON, PAZ overlay, and ReShade "
+                    "mods all work normally — only ASI / .addon64 "
+                    "plugins are skipped on Linux. If you need ASI "
+                    "support, run the Windows build of CDUMM under "
+                    "Wine instead (see LINUX.md)."),
+                link_label="Read more (LINUX.md)",
+                link_url=(
+                    "https://github.com/faisalkindi/CrimsonDesert-"
+                    "UltimateModsManager/blob/master/LINUX.md"))
             return
 
         # Summary bar (pinned top)
@@ -863,20 +906,35 @@ class AsiPluginsPage(QWidget):
         main.addLayout(body, 1)
 
     # ------------------------------------------------------------------
-    # macOS placeholder
+    # Unsupported-platform placeholder (macOS / Linux)
     # ------------------------------------------------------------------
 
-    def _build_macos_placeholder_view(self, main: QVBoxLayout) -> None:
+    def _build_unsupported_placeholder_view(
+            self,
+            main: QVBoxLayout,
+            title: str,
+            body: str,
+            reassure: str,
+            link_label: str,
+            link_url: str,
+    ) -> None:
         """Render a Windows-only-feature explanation in place of the
-        normal ASI card list when running on macOS.
+        normal ASI card list.
 
         Mirrors the structure of ``ReshadePage._build_not_installed_view``
         for visual consistency: a single CardWidget with a strong-weight
         title, word-wrapped body paragraph, and a primary action button
-        that opens the macOS docs in the user's browser. Avoids
+        that opens platform-specific docs in the user's browser. Avoids
         instantiating any of the engine-side ASI machinery
         (``_summary_bar``, ``_asi_manager``, scan timers) so the page
         is cheap and never tries to scan a non-existent ``bin64/``.
+
+        Strings are passed in by the caller because the macOS path
+        uses translated keys (``asi.macos_unavailable_*``) and the
+        Linux path uses literal English copy until the i18n catalogues
+        get a ``linux_unavailable_*`` set — keeping the parameterised
+        form means adding translations later is one edit to the
+        caller, not a refactor here.
         """
         import webbrowser
 
@@ -890,27 +948,24 @@ class AsiPluginsPage(QWidget):
         card_lay.setContentsMargins(32, 24, 32, 24)
         card_lay.setSpacing(12)
 
-        title = StrongBodyLabel(tr("asi.macos_unavailable_title"), card)
-        tf = title.font()
+        title_lbl = StrongBodyLabel(title, card)
+        tf = title_lbl.font()
         tf.setPixelSize(18)
-        title.setFont(tf)
-        card_lay.addWidget(title)
+        title_lbl.setFont(tf)
+        card_lay.addWidget(title_lbl)
         card_lay.addSpacing(4)
 
-        body_text = BodyLabel(tr("asi.macos_unavailable_body"), card)
-        body_text.setWordWrap(True)
-        card_lay.addWidget(body_text)
+        body_lbl = BodyLabel(body, card)
+        body_lbl.setWordWrap(True)
+        card_lay.addWidget(body_lbl)
 
-        reassure = BodyLabel(tr("asi.macos_unavailable_reassure"), card)
-        reassure.setWordWrap(True)
-        card_lay.addWidget(reassure)
+        reassure_lbl = BodyLabel(reassure, card)
+        reassure_lbl.setWordWrap(True)
+        card_lay.addWidget(reassure_lbl)
 
         card_lay.addSpacing(8)
-        link_btn = PrimaryPushButton(
-            FluentIcon.LINK, tr("asi.macos_unavailable_link"), card)
-        link_btn.clicked.connect(lambda: webbrowser.open(
-            "https://github.com/faisalkindi/CrimsonDesert-"
-            "UltimateModsManager/blob/master/MACOS.md"))
+        link_btn = PrimaryPushButton(FluentIcon.LINK, link_label, card)
+        link_btn.clicked.connect(lambda: webbrowser.open(link_url))
         btn_row = QHBoxLayout()
         btn_row.addWidget(link_btn)
         btn_row.addStretch()

--- a/src/cdumm/gui/pages/asi_page.py
+++ b/src/cdumm/gui/pages/asi_page.py
@@ -982,11 +982,15 @@ class AsiPluginsPage(QWidget):
     def set_managers(self, game_dir: Path | None = None, db=None, **kwargs) -> None:
         """Receive engine references from CdummWindow.
 
-        On macOS the page renders a "Windows-only" placeholder and
-        never touches the engine, so we early-return without wiring
-        AsiManager or kicking off a refresh.
+        On macOS / Linux the page renders a "Windows-only" placeholder
+        and never touches the engine (no ``_scroll_layout``, no
+        ``_summary_bar``, no ``_asi_manager``), so we early-return
+        without wiring AsiManager or kicking off a refresh. Without
+        this guard fluent_window's unconditional ``set_managers``
+        call during startup crashes the GUI before the main window
+        appears.
         """
-        if IS_MACOS:
+        if IS_MACOS or IS_LINUX:
             return
         self._game_dir = game_dir
         if db is not None:
@@ -1246,15 +1250,17 @@ class AsiPluginsPage(QWidget):
     def refresh(self) -> None:
         """Rescan ASI plugins and rebuild the card list with folder groups.
 
-        No-op on macOS where ``_build_ui`` rendered the platform-not-
-        supported placeholder instead of the normal scroll/card UI —
-        none of the widgets refresh() touches (``_scroll_layout``,
-        ``_summary_bar`` etc.) exist on the placeholder page.
-        ``fluent_window`` calls refresh() unconditionally during
-        startup; without this guard the AttributeError gets caught at
-        the call site but logs a noisy DEBUG line.
+        No-op on macOS / Linux where ``_build_ui`` rendered the
+        platform-not-supported placeholder instead of the normal
+        scroll/card UI — none of the widgets refresh() touches
+        (``_scroll_layout``, ``_summary_bar`` etc.) exist on the
+        placeholder page. ``fluent_window`` calls refresh()
+        unconditionally during startup; without this guard the
+        AttributeError crashes the whole window (seen on Linux: GUI
+        booted, found Crimson Desert, then died on the asi_plugins_page
+        refresh inside _init_navigation).
         """
-        if IS_MACOS:
+        if IS_MACOS or IS_LINUX:
             return
         from cdumm.gui.components.mod_card import FolderGroup
 
@@ -1396,10 +1402,11 @@ class AsiPluginsPage(QWidget):
         Args:
             updates: {nexus_mod_id: ModUpdateStatus}
 
-        No-op on macOS — the placeholder page has no version pills to
-        update and ``_db`` is never wired up by ``set_managers``.
+        No-op on macOS / Linux — the placeholder page has no version
+        pills to update and ``_db`` is never wired up by
+        ``set_managers``.
         """
-        if IS_MACOS:
+        if IS_MACOS or IS_LINUX:
             return
         self._nexus_updates = updates
         if not self._db:

--- a/src/cdumm/gui/pages/settings_page.py
+++ b/src/cdumm/gui/pages/settings_page.py
@@ -317,15 +317,17 @@ class SettingsPage(SmoothScrollArea):
         # Populate label/button state for the current key.
         self._refresh_sso_button()
 
-        # nxm:// scheme registration is OS-specific and CDUMM only
-        # implements the Windows registry path today. macOS would need
+        # nxm:// scheme registration is OS-specific. Windows uses the
+        # registry path under HKCU\Software\Classes\nxm; Linux writes
+        # a freedesktop ``.desktop`` file under
+        # ``~/.local/share/applications`` and calls ``xdg-mime
+        # default`` to associate the ``x-scheme-handler/nxm`` MIME
+        # type with it. macOS would need
         # ``LSSetDefaultHandlerForURLScheme`` + a packaged .app
-        # (see MACOS.md); Linux would need an ``nxm.desktop`` install
-        # under ``~/.local/share/applications`` plus ``xdg-mime
-        # default``. Until those are in place, hide the row entirely
-        # on non-Windows so users don't tap a button that does nothing.
-        from cdumm.platform import IS_WINDOWS
-        if IS_WINDOWS:
+        # (see MACOS.md) and isn't yet implemented — hide the row
+        # there so users don't tap a button that does nothing.
+        from cdumm.platform import IS_LINUX, IS_WINDOWS
+        if IS_WINDOWS or IS_LINUX:
             nxm_row = QWidget()
             nxm_layout = QHBoxLayout(nxm_row)
             nxm_layout.setContentsMargins(6, 4, 6, 4)
@@ -807,23 +809,24 @@ class SettingsPage(SmoothScrollArea):
         auto-retried with ``force=True`` in the same click, defeating
         the explicit-opt-in contract documented in ``nxm_handler.py``.
 
-        macOS / Linux: nxm:// scheme registration is per-OS and
-        ``register_windows_handler`` is a no-op there. The button
-        is hidden by ``set_managers`` on those platforms; this
-        early-return is belt-and-braces for any direct caller.
+        macOS: nxm:// scheme registration isn't yet implemented
+        (see MACOS.md). The button is hidden by ``set_managers`` on
+        that platform; the early-return below is belt-and-braces
+        for any direct caller.
         """
-        from cdumm.platform import IS_WINDOWS
-        if not IS_WINDOWS:
+        from cdumm.platform import IS_LINUX, IS_WINDOWS
+        if not (IS_WINDOWS or IS_LINUX):
             self._set_nexus_status(
-                "nxm:// handler registration is Windows-only.",
+                "nxm:// handler registration isn't supported on this "
+                "platform yet.",
                 InfoLevel.INFOAMTION)
             return
         from cdumm.engine.nxm_handler import (
-            is_handler_registered, register_windows_handler,
-            unregister_windows_handler, _read_command_string,
+            existing_handler_description, is_handler_registered,
+            register_handler, unregister_handler,
         )
         if is_handler_registered():
-            ok = unregister_windows_handler()
+            ok = unregister_handler()
             msg = ("nxm:// handler unregistered." if ok
                    else "Could not fully unregister nxm:// handler — check the log.")
             self._set_nexus_status(msg, InfoLevel.SUCCESS if ok else InfoLevel.ERROR)
@@ -831,7 +834,7 @@ class SettingsPage(SmoothScrollArea):
             return
 
         # Try non-destructive register first.
-        ok = register_windows_handler(force=False)
+        ok = register_handler(force=False)
         if ok:
             self._set_nexus_status(
                 "CDUMM is now the nxm:// handler for your user account.",
@@ -840,11 +843,7 @@ class SettingsPage(SmoothScrollArea):
             return
 
         # Another mod manager owns the scheme — ask before stomping.
-        try:
-            import winreg
-            existing_cmd = _read_command_string(winreg) or "(unknown)"
-        except Exception:
-            existing_cmd = "(unknown)"
+        existing_cmd = existing_handler_description() or "(unknown)"
         from PySide6.QtWidgets import QMessageBox
         box = QMessageBox(self.window())
         box.setIcon(QMessageBox.Icon.Warning)
@@ -868,11 +867,11 @@ class SettingsPage(SmoothScrollArea):
             self._refresh_nxm_button()
             return
 
-        ok = register_windows_handler(force=True)
+        ok = register_handler(force=True)
         msg = ("CDUMM is now the nxm:// handler for your user "
                "account." if ok else "Registration failed — CDUMM "
-               "must be running as the packaged .exe, not the dev "
-               "source, to register as a handler.")
+               "must be running from a stable install path (packaged "
+               "build or editable install) to register as a handler.")
         self._set_nexus_status(msg, InfoLevel.SUCCESS if ok else InfoLevel.ERROR)
         self._refresh_nxm_button()
 

--- a/src/cdumm/main.py
+++ b/src/cdumm/main.py
@@ -7,7 +7,7 @@ import threading
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
-from cdumm.platform import IS_WINDOWS, app_data_dir
+from cdumm.platform import IS_LINUX, IS_WINDOWS, app_data_dir
 
 APP_DATA_DIR = app_data_dir()
 
@@ -315,10 +315,29 @@ def main() -> int:
 
     # Minimal import for QApplication — everything else is lazy
     from PySide6.QtWidgets import QApplication
+    from PySide6.QtGui import QGuiApplication
     app = QApplication(sys.argv)
     # Fix PySide6 6.7+ Win11 style causing double borders on menus/shadows
     app.setStyle("fusion")
     app.setApplicationName("Crimson Desert Ultimate Mods Manager")
+
+    # Wayland: bind this process to ``cdumm.desktop`` so the
+    # compositor uses its ``Icon=`` field for both the window
+    # decoration and the taskbar entry. Without this, the
+    # ``setWindowIcon`` call below has no visible effect on Wayland —
+    # the compositor ignores client-set icons and reverts to the
+    # default app icon shortly after the window first appears
+    # (reported by RoGreat on a Sway + Nix-packaged setup, PR #123).
+    # Also fixes the "no icon in the taskbar after hide-on-launch"
+    # case: Wayland matches the iconified app to ``cdumm.desktop``
+    # via the app_id this call sets.
+    #
+    # The launcher (``scripts/cdumm-linux-native.sh``) installs the
+    # corresponding ``cdumm.desktop`` and PNG icon under
+    # ``$XDG_DATA_HOME`` on first run. X11 picks the same name up via
+    # ``StartupWMClass`` in that file.
+    if IS_LINUX:
+        QGuiApplication.setDesktopFileName("cdumm")
 
     # Set application-level icon (shows in taskbar)
     from PySide6.QtGui import QIcon
@@ -326,6 +345,16 @@ def main() -> int:
         _app_ico = Path(sys._MEIPASS) / "cdumm.ico"
     else:
         _app_ico = Path(__file__).resolve().parents[2] / "cdumm.ico"
+    # On Linux prefer the source PNG over the Windows .ico: Qt's ICO
+    # plugin reads the file but produces a lower-fidelity QIcon than
+    # loading the native 735x735 PNG directly. The .desktop entry
+    # installed by the launcher uses the same PNG so the in-window
+    # and taskbar icons match.
+    if IS_LINUX:
+        _app_png = (Path(__file__).resolve().parents[2]
+                    / "assets" / "cdumm-icon-square.png")
+        if _app_png.exists():
+            _app_ico = _app_png
     if _app_ico.exists():
         app.setWindowIcon(QIcon(str(_app_ico)))
 

--- a/src/cdumm/storage/game_finder.py
+++ b/src/cdumm/storage/game_finder.py
@@ -4,7 +4,7 @@ import re
 import sys
 from pathlib import Path
 
-from cdumm.platform import IS_MACOS, IS_WINDOWS
+from cdumm.platform import IS_LINUX, IS_MACOS, IS_WINDOWS
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +19,26 @@ STEAM_DEFAULT_PATHS = [
 # the Linux-style scan below picks those up.
 STEAM_DEFAULT_PATHS_MACOS = [
     Path.home() / "Library" / "Application Support" / "Steam",
+]
+
+# Linux Steam install locations. Steam can live in a few places
+# depending on whether the user installed the native distro package,
+# the Flatpak, or the Snap. ``~/.steam/steam`` is a long-standing
+# symlink most distros maintain pointing at the active install; we
+# still probe the canonical paths so we don't miss installs where
+# the symlink is broken or absent. Crimson Desert itself runs under
+# Proton — the bin64/CrimsonDesert.exe layout that Steam ships on
+# Windows is identical on Linux because Steam doesn't rewrite game
+# files, Proton runs the Windows binary directly.
+STEAM_DEFAULT_PATHS_LINUX = [
+    Path.home() / ".local" / "share" / "Steam",
+    Path.home() / ".steam" / "steam",
+    Path.home() / ".steam" / "root",
+    Path.home() / ".var" / "app" / "com.valvesoftware.Steam"
+    / "data" / "Steam",
+    Path.home() / ".var" / "app" / "com.valvesoftware.Steam"
+    / ".local" / "share" / "Steam",
+    Path.home() / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
 ]
 
 # Common macOS game install locations users pick when not using Steam.
@@ -426,6 +446,66 @@ def _find_macos_game_directories() -> list[Path]:
     return candidates
 
 
+def _find_linux_steam_libraries() -> list[Path]:
+    """Search Linux Steam libraries for Crimson Desert.
+
+    Steam on Linux uses the same ``steamapps/libraryfolders.vdf``
+    layout as Windows and macOS, but lives at different default roots
+    depending on how Steam was installed (native distro package,
+    Flatpak, Snap). The Crimson Desert install layout is identical
+    to the Windows install — Steam doesn't rewrite game files, and
+    Proton runs ``bin64/CrimsonDesert.exe`` directly via Wine. So
+    detection only needs to find the install directory and verify
+    ``bin64/CrimsonDesert.exe`` is present, exactly as on Windows.
+    """
+    candidates: list[Path] = []
+    seen_roots: set[str] = set()
+    for root in STEAM_DEFAULT_PATHS_LINUX:
+        try:
+            if not root.exists():
+                continue
+            # ``~/.steam/steam`` and ``~/.steam/root`` are usually
+            # symlinks to ``~/.local/share/Steam``; resolve once and
+            # dedup so we don't parse the same libraryfolders.vdf
+            # three times.
+            key = str(root.resolve())
+        except OSError:
+            continue
+        if key in seen_roots:
+            continue
+        seen_roots.add(key)
+
+        library_dirs: list[Path] = [root]
+        vdf = root / LIBRARY_FOLDERS_VDF
+        if vdf.exists():
+            library_dirs.extend(_parse_library_folders(vdf))
+        for lib in library_dirs:
+            game_dir = lib / "steamapps" / "common" / "Crimson Desert"
+            try:
+                if (game_dir / GAME_EXE).exists():
+                    candidates.append(game_dir)
+                    logger.info(
+                        "Found Crimson Desert (Steam Linux) at %s", game_dir)
+            except OSError:
+                continue
+    return candidates
+
+
+def _find_linux_game_directories() -> list[Path]:
+    """Native Linux auto-detect.
+
+    Walks the well-known Steam install locations on Linux (native
+    package, Flatpak, Snap) and returns every plausible Crimson
+    Desert install. Crimson Desert runs under Proton, so the game
+    directory layout is identical to the Windows install — only the
+    Steam host paths differ. No Epic or Xbox detection on Linux:
+    Epic doesn't ship a native Linux launcher and Xbox Game Pass for
+    PC is Windows-only. Users who run Epic via Heroic or similar
+    have to point CDUMM at the install directory manually.
+    """
+    return _find_linux_steam_libraries()
+
+
 def find_game_directories() -> list[Path]:
     """Search Steam, Epic Games Store, and Xbox for Crimson Desert install."""
     # macOS native build: scan Steam macOS + ~/Games + ~/Applications +
@@ -435,6 +515,27 @@ def find_game_directories() -> list[Path]:
     if IS_MACOS:
         candidates = _find_macos_game_directories()
         # Dedup by resolved path (same as the Windows path below).
+        seen: set[str] = set()
+        unique: list[Path] = []
+        for c in candidates:
+            try:
+                key = str(c.resolve()).lower()
+            except Exception:
+                key = str(c).lower()
+            if key not in seen:
+                seen.add(key)
+                unique.append(c)
+        return unique
+
+    # Native Linux: Steam only. Crimson Desert runs under Proton so
+    # the bin64/CrimsonDesert.exe layout is preserved; detection
+    # mirrors the Windows VDF parse but rooted at Linux Steam paths.
+    # Epic and Xbox detection short-circuits here because neither
+    # has a native Linux launcher whose install dirs we'd recognise
+    # — the Windows fallbacks below would iterate A-Z drive letters
+    # against literal nonexistent paths, which is wasted work.
+    if IS_LINUX:
+        candidates = _find_linux_game_directories()
         seen: set[str] = set()
         unique: list[Path] = []
         for c in candidates:

--- a/tests/test_asi_loader_auto_install_toggle.py
+++ b/tests/test_asi_loader_auto_install_toggle.py
@@ -21,12 +21,15 @@ from cdumm.storage.database import Database
 pytest_qt = pytest.importorskip("pytestqt")
 
 # The ASI loader installs a Win32 ``winmm.dll`` proxy that hooks
-# ``CrimsonDesert.exe``. There's no equivalent on the native macOS
-# build (no Windows exe to inject into) so ``_install_bundled_loader``
-# short-circuits on non-Windows. The toggle-gating tests below
-# assume the install path actually fires; skip them on darwin.
+# ``CrimsonDesert.exe``. There's no equivalent outside Windows —
+# the native macOS build has no Windows exe to inject into, and
+# the native Linux build deliberately stays out of the Proton/Wine
+# prefix that would otherwise host such a proxy. Accordingly,
+# ``_install_bundled_loader`` short-circuits on ``not IS_WINDOWS``.
+# The toggle-gating tests below assume the install path actually
+# fires; skip them on every non-Windows host.
 pytestmark = pytest.mark.skipif(
-    sys.platform == "darwin",
+    sys.platform != "win32",
     reason="ASI loader auto-install short-circuits on non-Windows; "
            "the toggle gating logic is Windows-only.")
 

--- a/tests/test_ctx_open_source_fires_startfile.py
+++ b/tests/test_ctx_open_source_fires_startfile.py
@@ -28,11 +28,11 @@ def _make_fake_self(tmp_path: Path) -> SimpleNamespace:
 
 
 @pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="On macOS, _ctx_open_source goes through cdumm.platform.open_path "
-           "→ subprocess.Popen(['open', ...]) rather than os.startfile, so "
-           "monkey-patching os.startfile has no effect. The Windows path "
-           "still asserts here.")
+    sys.platform != "win32",
+    reason="On macOS / Linux, _ctx_open_source goes through "
+           "cdumm.platform.open_path → subprocess.Popen(['open' / 'xdg-open', "
+           "...]) rather than os.startfile, so monkey-patching os.startfile "
+           "has no effect. The Windows path still asserts here.")
 def test_ctx_open_source_calls_startfile_when_path_exists(qtbot, tmp_path, monkeypatch):
     """Happy path: source_path exists, os.startfile gets called with it."""
     from cdumm.gui.pages.mods_page import ModsPage
@@ -76,11 +76,11 @@ def test_ctx_open_source_shows_infobar_when_no_path(qtbot, tmp_path, monkeypatch
 
 
 @pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="On macOS the open_path() helper catches the OSError internally "
-           "and logs it; the InfoBar.error path is wired off `open_path` "
-           "returning False from a different cause (no opener available). "
-           "Same control flow as Windows, different trigger.")
+    sys.platform != "win32",
+    reason="On macOS / Linux the open_path() helper catches the OSError "
+           "internally and logs it; the InfoBar.error path is wired off "
+           "open_path returning False from a different cause (no opener "
+           "available). Same control flow as Windows, different trigger.")
 def test_ctx_open_source_shows_error_infobar_when_startfile_raises(qtbot, tmp_path, monkeypatch):
     """os.startfile raises OSError -> InfoBar.error, no crash."""
     from cdumm.gui.pages.mods_page import ModsPage

--- a/tests/test_linux_asi_page.py
+++ b/tests/test_linux_asi_page.py
@@ -1,0 +1,96 @@
+"""Linux placeholder-mode regression tests for ``AsiPluginsPage``.
+
+When the ASI page builds in placeholder mode (macOS / Linux), the
+normal scroll/card/summary-bar widgets are never created. Methods
+that the host (``fluent_window``) invokes unconditionally during
+startup — ``set_managers``, ``refresh``, ``set_nexus_updates`` —
+must early-return rather than reach into widgets that don't exist.
+
+Lesson learned the hard way: an earlier pass added the Linux branch
+to ``_build_ui`` but forgot to widen the three corresponding
+``if IS_MACOS: return`` guards to also cover Linux. CDUMM booted
+all the way through the welcome wizard, populated its database,
+loaded schemas, then crashed inside ``_init_navigation`` when
+``set_managers`` walked through to ``refresh`` and hit
+``AttributeError: 'AsiPluginsPage' object has no attribute
+'_scroll_layout'``. These tests pin the contract so that bug
+can't come back.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from cdumm.gui.pages import asi_page  # noqa: E402
+
+
+@pytest.fixture
+def linux_host(monkeypatch):
+    """Flip the module-level platform flags so the Linux branches in
+    ``AsiPluginsPage`` run regardless of the host OS the tests are
+    invoked on (the upstream Windows regression box, macOS, etc.)."""
+    monkeypatch.setattr(asi_page, "IS_LINUX", True)
+    monkeypatch.setattr(asi_page, "IS_MACOS", False)
+    monkeypatch.setattr(asi_page, "IS_WINDOWS", False)
+
+
+class TestLinuxPlaceholderMode:
+    """Methods invoked during normal startup must not crash when the
+    page is in placeholder mode."""
+
+    def test_set_managers_is_a_noop_on_linux(
+            self, qtbot, tmp_path: Path, linux_host) -> None:
+        """``fluent_window._init_navigation`` calls ``set_managers``
+        on every page during boot. On Linux the ASI page is a
+        placeholder; ``set_managers`` must NOT try to wire up
+        ``AsiManager`` (the engine machinery is intentionally absent)
+        and must NOT call ``refresh`` (which would touch the
+        non-existent ``_scroll_layout``)."""
+        page = asi_page.AsiPluginsPage()
+        qtbot.addWidget(page)
+        # Should return without touching the engine. No exception,
+        # no _asi_manager assignment.
+        page.set_managers(game_dir=tmp_path, db=None)
+        assert page._asi_manager is None, (
+            "set_managers must not wire up AsiManager in Linux "
+            "placeholder mode — the engine is intentionally absent")
+
+    def test_refresh_is_a_noop_on_linux(
+            self, qtbot, linux_host) -> None:
+        """``refresh`` walks ``_scroll_layout`` and ``_summary_bar``.
+        Neither exists on the placeholder page. The method must
+        early-return before touching them."""
+        page = asi_page.AsiPluginsPage()
+        qtbot.addWidget(page)
+        # No exception even though _scroll_layout doesn't exist.
+        page.refresh()
+        assert not hasattr(page, "_scroll_layout"), (
+            "Placeholder page should never construct _scroll_layout — "
+            "if this assertion fails, _build_ui is no longer "
+            "short-circuiting on Linux")
+
+    def test_set_nexus_updates_is_a_noop_on_linux(
+            self, qtbot, linux_host) -> None:
+        """``fluent_window`` calls ``set_nexus_updates`` after every
+        Nexus poll. The placeholder page has no version pills to
+        update; the method must early-return."""
+        page = asi_page.AsiPluginsPage()
+        qtbot.addWidget(page)
+        # Pass a non-empty dict to make sure the method actually
+        # gets exercised (an empty dict could short-circuit elsewhere).
+        page.set_nexus_updates({12345: object()})
+
+    def test_full_init_navigation_sequence_does_not_crash(
+            self, qtbot, tmp_path: Path, linux_host) -> None:
+        """End-to-end: construct the page, wire managers, refresh,
+        push a Nexus updates dict — the exact sequence that
+        ``fluent_window._init_navigation`` invokes. Locks in the
+        whole startup-time contract, not just one method."""
+        page = asi_page.AsiPluginsPage()
+        qtbot.addWidget(page)
+        page.set_managers(game_dir=tmp_path, db=None)
+        page.refresh()
+        page.set_nexus_updates({})

--- a/tests/test_linux_cb_symlink_import.py
+++ b/tests/test_linux_cb_symlink_import.py
@@ -1,0 +1,122 @@
+"""Regression tests for symlinked-directory traversal in
+``crimson_browser_handler`` on Linux.
+
+Background (PR #123, reported by RoGreat on a Nix-packaged build):
+folder-based Crimson Browser mod imports silently dropped files that
+lived behind a symlinked directory, so no PAZ was built and the mod
+came in as a stray PATHC. Root cause: Python 3.13 changed
+``Path.rglob`` to default ``recurse_symlinks=False`` — it no longer
+descends into symlinked subdirectories. The frozen Windows build and
+the pre-3.13 behaviour this module was written for DID follow them.
+A zip import dodges the bug because extraction materialises plain
+files; a folder import reads the user's real tree, symlinks and all.
+
+``_rglob_follow`` restores the follow-symlinks behaviour on all Python
+versions. These tests pin that, and confirm the symlink-escape guard
+that the file-reading callers apply still rejects a symlink pointing
+outside the mod tree.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from cdumm.engine.crimson_browser_handler import _rglob_follow
+
+
+def _make_files_with_symlinked_dir(base: Path) -> Path:
+    """Build files/ where the numbered PAZ dir (0008) is a symlink to
+    a sibling real directory — the shape that vanished on Python 3.13+."""
+    files_dir = base / "files"
+    files_dir.mkdir(parents=True)
+    real = base / "realdata" / "0008"
+    real.mkdir(parents=True)
+    (real / "texture.paz").write_bytes(b"PAZ")
+    (files_dir / "0008").symlink_to(real, target_is_directory=True)
+    return files_dir
+
+
+class TestRglobFollow:
+    def test_finds_file_behind_symlinked_directory(self, tmp_path: Path) -> None:
+        """The core regression: a file inside a symlinked subdir must be
+        discovered. Plain rglob on 3.13+ returns it as zero results."""
+        files_dir = _make_files_with_symlinked_dir(tmp_path)
+        found = [f for f in _rglob_follow(files_dir) if f.is_file()]
+        names = {f.name for f in found}
+        assert "texture.paz" in names, (
+            "file behind a symlinked directory must be discovered — "
+            "this is the PR #123 folder-import regression")
+
+    def test_documents_the_stdlib_default_that_caused_the_bug(
+            self, tmp_path: Path) -> None:
+        """Guard rail: if a future stdlib/refactor makes plain rglob find
+        these again, _rglob_follow is still correct — but this test
+        documents *why* the helper exists. On 3.13+ the plain default
+        misses the file; on <=3.12 it would find it. Either way
+        _rglob_follow must find it (covered above)."""
+        files_dir = _make_files_with_symlinked_dir(tmp_path)
+        plain = [f for f in files_dir.rglob("*") if f.is_file()]
+        if sys.version_info >= (3, 13):
+            assert plain == [], (
+                "expected the 3.13+ rglob default to miss files behind "
+                "symlinked dirs — if this fails the stdlib behaviour "
+                "changed and the helper's version guard can be revisited")
+        else:
+            assert any(f.name == "texture.paz" for f in plain)
+
+    def test_plain_folder_unaffected(self, tmp_path: Path) -> None:
+        """No symlinks: helper behaves like ordinary rglob."""
+        files_dir = tmp_path / "files" / "0008"
+        files_dir.mkdir(parents=True)
+        (files_dir / "a.paz").write_bytes(b"x")
+        found = [f.name for f in _rglob_follow(tmp_path / "files") if f.is_file()]
+        assert found == ["a.paz"]
+
+
+class TestSymlinkEscapeGuardStillHolds:
+    """The file-reading caller (convert_to_paz_mod) resolves each file
+    and refuses any that escape files_dir. Following symlinks must not
+    weaken that — a symlink pointing outside the tree is still caught."""
+
+    def test_escaping_symlink_file_is_detected(self, tmp_path: Path) -> None:
+        files_dir = tmp_path / "files" / "0008"
+        files_dir.mkdir(parents=True)
+        outside = tmp_path / "outside_secret.paz"
+        outside.write_bytes(b"SECRET")
+        (files_dir / "evil.paz").symlink_to(outside)
+
+        files_root = tmp_path / "files"
+        files_root_resolved = files_root.resolve()
+        escaped, safe = [], []
+        for f in _rglob_follow(files_root):
+            if not f.is_file():
+                continue
+            try:
+                f.resolve().relative_to(files_root_resolved)
+                safe.append(f.name)
+            except ValueError:
+                escaped.append(f.name)
+        assert "evil.paz" in escaped, (
+            "a symlink pointing outside files_dir must still be flagged "
+            "as escaping so the caller can skip it")
+
+    def test_internal_symlink_alias_is_allowed(self, tmp_path: Path) -> None:
+        """A symlink that stays *within* files_dir (a legit alias) is not
+        flagged as an escape."""
+        files_dir = tmp_path / "files" / "0008"
+        files_dir.mkdir(parents=True)
+        (files_dir / "real.paz").write_bytes(b"x")
+        (files_dir / "alias.paz").symlink_to(files_dir / "real.paz")
+
+        files_root = tmp_path / "files"
+        files_root_resolved = files_root.resolve()
+        safe = []
+        for f in _rglob_follow(files_root):
+            if not f.is_file():
+                continue
+            try:
+                f.resolve().relative_to(files_root_resolved)
+                safe.append(f.name)
+            except ValueError:
+                pass
+        assert "real.paz" in safe and "alias.paz" in safe

--- a/tests/test_linux_cb_symlink_import.py
+++ b/tests/test_linux_cb_symlink_import.py
@@ -18,10 +18,11 @@ outside the mod tree.
 """
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
-from cdumm.engine.crimson_browser_handler import _rglob_follow
+from cdumm.engine.crimson_browser_handler import _rglob_follow, convert_to_paz_mod
 
 
 def _make_files_with_symlinked_dir(base: Path) -> Path:
@@ -120,3 +121,90 @@ class TestSymlinkEscapeGuardStillHolds:
             except ValueError:
                 pass
         assert "real.paz" in safe and "alias.paz" in safe
+
+
+class TestTrustSymlinksParameter:
+    """``convert_to_paz_mod(trust_symlinks=...)`` distinguishes folder
+    imports (user picked the directory — symlinks are trusted local
+    references) from archive extractions (untrusted — the escape
+    guard must stay active).
+
+    Reported by RoGreat on a Nix-packaged build (PR #123): his mod's
+    individual .dds files are symlinks into the Nix store. Before
+    this fix, the escape guard refused every such file and the
+    import fell through to the standalone-texture-overlay fallback
+    instead of producing a proper CB PAZ build.
+    """
+
+    def _build_cb_mod_with_escaping_symlink(
+            self, base: Path) -> tuple[dict, Path]:
+        """Construct a minimal CB-format mod folder where one file is
+        a symlink pointing OUTSIDE the mod's files/ tree (mirrors the
+        Nix-store-into-mod-folder layout). Returns the manifest dict
+        and the files/ Path."""
+        mod_dir = base / "ModRoot"
+        files_dir = mod_dir / "files" / "0008"
+        files_dir.mkdir(parents=True)
+        (files_dir / "real.dds").write_bytes(b"REAL")
+        outside = base / "elsewhere" / "stash.dds"
+        outside.parent.mkdir(parents=True)
+        outside.write_bytes(b"STASH")
+        (files_dir / "linked.dds").symlink_to(outside)
+        manifest = {
+            "id": "test_mod",
+            "files_dir": "files",
+            "_base_dir": mod_dir,
+        }
+        return manifest, mod_dir / "files"
+
+    def _run_convert(self, manifest: dict, tmp_path: Path,
+                     *, trust_symlinks: bool) -> None:
+        """Call convert_to_paz_mod with the given flag. The function's
+        post-loop machinery needs a real game_dir + vanilla PAZ files
+        which we don't have here, so the call typically raises after
+        the symlink-handling loop runs. We only care about the
+        in-loop warning, so swallow any exception."""
+        game_dir = tmp_path / "junk_game_dir"
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        try:
+            convert_to_paz_mod(
+                manifest, game_dir, work_dir,
+                trust_symlinks=trust_symlinks)
+        except Exception:
+            pass
+
+    def test_default_keeps_escape_guard_active(
+            self, tmp_path: Path, caplog) -> None:
+        """``trust_symlinks=False`` (default — what every zip /
+        extraction call site uses) still emits the symlink-escape
+        warning for files whose target resolves outside files_dir.
+        The 6 archive-extraction callers in import_handler.py rely
+        on this default to stay protected against malicious archives
+        with symlinks pointing at arbitrary filesystem locations."""
+        manifest, _ = self._build_cb_mod_with_escaping_symlink(tmp_path)
+        caplog.set_level(
+            logging.WARNING,
+            logger="cdumm.engine.crimson_browser_handler")
+        self._run_convert(manifest, tmp_path, trust_symlinks=False)
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "CB import: skipping" in msgs and "linked.dds" in msgs, (
+            "default trust_symlinks=False must emit the symlink-escape "
+            "warning for files resolving outside files_dir; got: "
+            + msgs)
+
+    def test_trust_symlinks_true_suppresses_escape_warning(
+            self, tmp_path: Path, caplog) -> None:
+        """``trust_symlinks=True`` (folder-import call sites only)
+        follows the symlink to its target rather than refusing it.
+        The escape warning must NOT fire — Nix-store-symlinked mod
+        files are legitimate user content, not a security threat."""
+        manifest, _ = self._build_cb_mod_with_escaping_symlink(tmp_path)
+        caplog.set_level(
+            logging.WARNING,
+            logger="cdumm.engine.crimson_browser_handler")
+        self._run_convert(manifest, tmp_path, trust_symlinks=True)
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "CB import: skipping" not in msgs, (
+            "trust_symlinks=True must NOT emit symlink-escape warnings; "
+            "got: " + msgs)

--- a/tests/test_linux_game_finder.py
+++ b/tests/test_linux_game_finder.py
@@ -1,0 +1,238 @@
+"""Tests for the Linux-specific paths in ``cdumm.storage.game_finder``.
+
+Crimson Desert has no native Linux build — it runs under Proton, and
+the ``bin64/CrimsonDesert.exe`` layout on disk is identical to the
+Windows install (Steam doesn't rewrite game files; Proton runs the
+Windows binary via Wine). The Linux port only changes *where Steam
+itself lives* on the host filesystem, not what Steam ships into the
+library. So the validation rules from ``test_game_finder.py`` still
+hold — these tests cover the Linux-side auto-detect that walks the
+distro-specific Steam install locations (native package, Flatpak,
+Snap) and resolves the ``libraryfolders.vdf`` chain.
+
+Uses ``monkeypatch`` to override the module-level
+``STEAM_DEFAULT_PATHS_LINUX`` constant and the ``IS_LINUX`` /
+``IS_MACOS`` flags so the suite runs on any host CI (including the
+maintainer's Windows regression box) without needing a real Linux
+Steam install.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cdumm.storage import game_finder
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+
+def _make_game_install(library_root: Path) -> Path:
+    """Build a fixture Steam library layout that ``_find_linux_steam_libraries``
+    will accept: ``<library>/steamapps/common/Crimson Desert/bin64/CrimsonDesert.exe``.
+    Returns the game directory (the one CDUMM treats as the install root).
+    """
+    game_dir = library_root / "steamapps" / "common" / "Crimson Desert"
+    (game_dir / "bin64").mkdir(parents=True)
+    (game_dir / "bin64" / "CrimsonDesert.exe").write_bytes(b"EXE")
+    return game_dir
+
+
+def _make_libraryfolders_vdf(steam_root: Path, library_paths: list[Path]) -> None:
+    """Write a libraryfolders.vdf that lists ``library_paths``. Matches
+    the exact format Steam itself produces — quoted ``path`` keys
+    inside numbered library blocks. The parser is regex-based and
+    only cares about the ``"path"`` tokens, so whitespace and the
+    surrounding scaffolding can be sparse."""
+    vdf = steam_root / "steamapps" / "libraryfolders.vdf"
+    vdf.parent.mkdir(parents=True, exist_ok=True)
+    blocks = []
+    for i, p in enumerate(library_paths):
+        # Steam stores paths with forward slashes on Linux/macOS;
+        # the parser handles either. Escape backslashes in case a
+        # contributor copies a Windows-style fixture in.
+        escaped = str(p).replace("\\", "\\\\")
+        blocks.append(f'    "{i}"\n    {{\n        "path"\t\t"{escaped}"\n    }}\n')
+    vdf.write_text(
+        '"libraryfolders"\n{\n' + "".join(blocks) + "}\n",
+        encoding="utf-8")
+
+
+@pytest.fixture
+def linux_host(monkeypatch):
+    """Make the module believe it's running on Linux."""
+    monkeypatch.setattr(game_finder, "IS_LINUX", True)
+    monkeypatch.setattr(game_finder, "IS_MACOS", False)
+    monkeypatch.setattr(game_finder, "IS_WINDOWS", False)
+
+
+# ── _find_linux_steam_libraries ──────────────────────────────────────
+
+
+class TestFindLinuxSteamLibraries:
+    """Steam-on-Linux detection: walk ``STEAM_DEFAULT_PATHS_LINUX``,
+    parse each install's ``libraryfolders.vdf``, return every
+    Crimson Desert install whose ``bin64/CrimsonDesert.exe`` exists."""
+
+    def test_finds_game_in_default_linux_steam_root(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """The common case: native distro Steam install at
+        ``~/.local/share/Steam`` with CD in its primary library."""
+        steam_root = tmp_path / "local-share-Steam"
+        steam_root.mkdir()
+        game_dir = _make_game_install(steam_root)
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX", [steam_root])
+
+        found = game_finder._find_linux_steam_libraries()
+        assert found == [game_dir]
+
+    def test_follows_libraryfolders_vdf_to_secondary_drive(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """Steam at ``~/.local/share/Steam`` but the user added a
+        second library on another drive — typical Steam Deck +
+        microSD setup, or anyone with games split across SSDs.
+        libraryfolders.vdf is the source of truth, not the primary
+        install."""
+        steam_root = tmp_path / "primary-Steam"
+        steam_root.mkdir()
+        secondary = tmp_path / "external-disk" / "SteamLibrary"
+        secondary.mkdir(parents=True)
+        game_dir = _make_game_install(secondary)
+        _make_libraryfolders_vdf(steam_root, [steam_root, secondary])
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX", [steam_root])
+
+        found = game_finder._find_linux_steam_libraries()
+        assert game_dir in found
+
+    def test_returns_empty_when_no_steam_install_present(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """Fresh box / Steam not installed: probe every default path,
+        find nothing, return empty list. Must not raise."""
+        nowhere = tmp_path / "nothing-here"
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX",
+            [nowhere, nowhere / "also-missing"])
+
+        assert game_finder._find_linux_steam_libraries() == []
+
+    def test_dedupes_symlinked_steam_roots(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """``~/.steam/steam`` and ``~/.steam/root`` are usually
+        symlinks to ``~/.local/share/Steam``. Probing all three
+        without dedup would parse the same libraryfolders.vdf
+        repeatedly and return the same game three times. The dedup
+        is by ``Path.resolve()`` so symlinks collapse to a single
+        canonical root."""
+        real_root = tmp_path / "local-share-Steam"
+        real_root.mkdir()
+        _make_game_install(real_root)
+
+        symlink_a = tmp_path / "dot-steam-steam"
+        symlink_b = tmp_path / "dot-steam-root"
+        symlink_a.symlink_to(real_root, target_is_directory=True)
+        symlink_b.symlink_to(real_root, target_is_directory=True)
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX",
+            [real_root, symlink_a, symlink_b])
+
+        found = game_finder._find_linux_steam_libraries()
+        # One unique resolved root, one game install, one result.
+        assert len(found) == 1
+
+    def test_handles_broken_symlink_in_default_paths(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """A broken symlink (target removed after install) must not
+        crash the scan. Pre-bcachefs-migration Steam Deck and
+        post-distro-reinstall systems can both leave these around."""
+        broken = tmp_path / "broken-symlink"
+        broken.symlink_to(tmp_path / "target-deleted",
+                          target_is_directory=True)
+
+        real_root = tmp_path / "real-Steam"
+        real_root.mkdir()
+        game_dir = _make_game_install(real_root)
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX", [broken, real_root])
+
+        found = game_finder._find_linux_steam_libraries()
+        assert found == [game_dir]
+
+    def test_flatpak_steam_install_location_is_probed(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """Flatpak Steam stores its data under
+        ``~/.var/app/com.valvesoftware.Steam/...``. The default
+        path list must include this so Flatpak users get
+        auto-detected; this test pins the contract."""
+        flatpak_root = (tmp_path / ".var" / "app"
+                        / "com.valvesoftware.Steam" / "data" / "Steam")
+        flatpak_root.mkdir(parents=True)
+        game_dir = _make_game_install(flatpak_root)
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX", [flatpak_root])
+
+        found = game_finder._find_linux_steam_libraries()
+        assert found == [game_dir]
+
+
+# ── find_game_directories (Linux dispatcher branch) ─────────────────
+
+
+class TestFindGameDirectoriesLinux:
+    """The top-level entry point must short-circuit to the Linux
+    helpers when running on Linux — otherwise the Windows fallback
+    iterates A-Z drive letters against literal nonexistent paths,
+    which is wasted work and pollutes the logs."""
+
+    def test_uses_linux_branch_on_linux(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        steam_root = tmp_path / "Steam"
+        steam_root.mkdir()
+        game_dir = _make_game_install(steam_root)
+
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX", [steam_root])
+
+        found = game_finder.find_game_directories()
+        assert game_dir in found
+
+    def test_returns_empty_when_no_install_found(
+            self, tmp_path: Path, monkeypatch, linux_host) -> None:
+        """Linux + no Steam install present + no Crimson Desert
+        anywhere = empty result. Must not fall through to the
+        Windows drive-scan code (which would iterate ``A:/Steam``
+        through ``Z:/Steam`` and waste time)."""
+        monkeypatch.setattr(
+            game_finder, "STEAM_DEFAULT_PATHS_LINUX",
+            [tmp_path / "no-such-dir"])
+
+        assert game_finder.find_game_directories() == []
+
+
+# ── validate_game_directory on Linux ────────────────────────────────
+
+
+class TestValidateGameDirectoryLinux:
+    """Linux validation uses the same ``bin64/CrimsonDesert.exe``
+    check as Windows — Proton runs the Windows binary directly, so
+    the install layout is identical. These tests pin that contract
+    so a future refactor doesn't accidentally route Linux through
+    the macOS ``.app`` resolver."""
+
+    def test_accepts_steam_install_with_bin64_exe(
+            self, tmp_path: Path, linux_host) -> None:
+        game_dir = _make_game_install(tmp_path / "Steam")
+        assert game_finder.validate_game_directory(game_dir) is True
+
+    def test_rejects_directory_without_exe(
+            self, tmp_path: Path, linux_host) -> None:
+        game_dir = tmp_path / "Empty"
+        game_dir.mkdir()
+        assert game_finder.validate_game_directory(game_dir) is False

--- a/tests/test_linux_nxm_handler.py
+++ b/tests/test_linux_nxm_handler.py
@@ -1,0 +1,340 @@
+"""Tests for the Linux ``nxm://`` handler in ``cdumm.engine.nxm_handler``.
+
+The Linux registration path:
+
+1. Writes ``$XDG_DATA_HOME/applications/cdumm-nxm.desktop``.
+2. Runs ``xdg-mime default cdumm-nxm.desktop x-scheme-handler/nxm``.
+3. Runs ``update-desktop-database`` (best-effort, optional).
+
+Unregister deletes the .desktop file and strips the corresponding
+line from ``$XDG_CONFIG_HOME/mimeapps.list``.
+
+These tests monkeypatch ``subprocess.run`` and the XDG env vars so the
+suite runs on any host — including the upstream Windows regression
+box — without touching the real freedesktop state. The fake
+``subprocess.run`` records every invocation so each assertion can
+check the exact command line that would have been sent to xdg-mime.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cdumm.engine import nxm_handler
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def linux_xdg(tmp_path: Path, monkeypatch):
+    """Isolate XDG_DATA_HOME / XDG_CONFIG_HOME under tmp_path so the
+    .desktop write and mimeapps.list edit don't touch the user's
+    real freedesktop state. Also flips IS_LINUX/IS_WINDOWS so the
+    Linux branches run regardless of the actual host OS."""
+    xdg_data = tmp_path / "data"
+    xdg_config = tmp_path / "config"
+    xdg_data.mkdir()
+    xdg_config.mkdir()
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    monkeypatch.setattr(nxm_handler, "IS_LINUX", True)
+    monkeypatch.setattr(nxm_handler, "IS_WINDOWS", False)
+    yield {"data": xdg_data, "config": xdg_config}
+
+
+class FakeSubprocess:
+    """Stand-in for ``subprocess.run`` that records every invocation
+    and lets a test simulate the response of ``xdg-mime query
+    default x-scheme-handler/nxm``. Real xdg-mime is unavailable on
+    Windows CI; tests on Linux developers' boxes mustn't mutate the
+    actual user mimeapps either, so we never want to call through."""
+
+    def __init__(self, current_handler: str = ""):
+        self.calls: list[list[str]] = []
+        self.current_handler = current_handler
+
+    def __call__(self, args, **kwargs) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(args))
+        stdout = ""
+        if (len(args) >= 4
+                and args[0] == "xdg-mime"
+                and args[1] == "query"
+                and args[2] == "default"):
+            stdout = self.current_handler
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def fake_subprocess(monkeypatch):
+    """Patches both ``subprocess.run`` references the module touches:
+    the top-level ``subprocess.run`` import via ``subprocess``, and
+    the symbol bound inside nxm_handler. Tests get a ``FakeSubprocess``
+    instance back to inspect calls / set the simulated current
+    handler."""
+    fake = FakeSubprocess()
+    monkeypatch.setattr(nxm_handler.subprocess, "run", fake)
+    return fake
+
+
+# ── register_linux_handler ──────────────────────────────────────────
+
+
+class TestRegisterLinuxHandler:
+    """Writing the .desktop file, calling xdg-mime, refusing to
+    stomp on an existing handler."""
+
+    def test_writes_desktop_file_with_correct_content(
+            self, linux_xdg, fake_subprocess) -> None:
+        ok = nxm_handler.register_linux_handler()
+        assert ok is True
+
+        desktop = (linux_xdg["data"] / "applications"
+                   / "cdumm-nxm.desktop")
+        assert desktop.exists()
+        body = desktop.read_text(encoding="utf-8")
+        assert "[Desktop Entry]" in body
+        # MimeType binds the nxm:// scheme — this is what xdg-mime
+        # actually reads. Pin the exact freedesktop token.
+        assert "MimeType=x-scheme-handler/nxm;" in body
+        # NoDisplay keeps the entry out of the Activities/menu —
+        # CDUMM proper has its own desktop entry.
+        assert "NoDisplay=true" in body
+        # Exec must contain the URL placeholder so xdg-open passes
+        # the nxm:// URL through when the user clicks Mod Manager
+        # Download.
+        assert "%u" in body
+        assert "--nxm" in body
+
+    def test_marks_desktop_file_executable(
+            self, linux_xdg, fake_subprocess) -> None:
+        """Some desktop environments (Plasma 5 historically) skip
+        .desktop files without the executable bit. Mirror what an
+        installer would do."""
+        nxm_handler.register_linux_handler()
+        desktop = (linux_xdg["data"] / "applications"
+                   / "cdumm-nxm.desktop")
+        assert desktop.stat().st_mode & 0o111  # any exec bit set
+
+    def test_runs_xdg_mime_default_with_our_desktop_filename(
+            self, linux_xdg, fake_subprocess) -> None:
+        nxm_handler.register_linux_handler()
+        # Look for the xdg-mime default call. Other calls (query,
+        # update-desktop-database) are also expected.
+        default_calls = [
+            c for c in fake_subprocess.calls
+            if c[:2] == ["xdg-mime", "default"]]
+        assert len(default_calls) == 1
+        assert default_calls[0] == [
+            "xdg-mime", "default",
+            "cdumm-nxm.desktop", "x-scheme-handler/nxm"]
+
+    def test_refuses_to_overwrite_existing_handler_without_force(
+            self, linux_xdg, fake_subprocess) -> None:
+        """Vortex / MO2 / any other already-registered handler must
+        not be silently displaced. With ``force=False`` the function
+        returns False and writes nothing."""
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        ok = nxm_handler.register_linux_handler(force=False)
+        assert ok is False
+        desktop = (linux_xdg["data"] / "applications"
+                   / "cdumm-nxm.desktop")
+        assert not desktop.exists()
+        # No xdg-mime *default* call should have happened — only the
+        # initial query that detected the existing handler.
+        default_calls = [
+            c for c in fake_subprocess.calls
+            if c[:2] == ["xdg-mime", "default"]]
+        assert default_calls == []
+
+    def test_force_overrides_existing_handler(
+            self, linux_xdg, fake_subprocess) -> None:
+        """``force=True`` is the explicit-user-opt-in path from the
+        Settings page confirmation dialog. It must write the file
+        and call xdg-mime even when another handler is registered."""
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        ok = nxm_handler.register_linux_handler(force=True)
+        assert ok is True
+        desktop = (linux_xdg["data"] / "applications"
+                   / "cdumm-nxm.desktop")
+        assert desktop.exists()
+
+    def test_skips_when_xdg_data_home_unwritable(
+            self, linux_xdg, fake_subprocess, monkeypatch) -> None:
+        """Read-only home / immutable XDG dir / permission-denied is
+        rare but real (locked-down corporate Linux boxes). Must not
+        raise — log + return False."""
+        apps_dir = linux_xdg["data"] / "applications"
+        apps_dir.mkdir(parents=True, exist_ok=True)
+
+        def fail_write_text(*args, **kwargs):
+            raise OSError("simulated EACCES")
+
+        monkeypatch.setattr(Path, "write_text", fail_write_text)
+        assert nxm_handler.register_linux_handler() is False
+
+
+# ── unregister_linux_handler ────────────────────────────────────────
+
+
+class TestUnregisterLinuxHandler:
+
+    def test_deletes_desktop_file_when_we_own_the_scheme(
+            self, linux_xdg, fake_subprocess) -> None:
+        # Pre-stage as if we registered earlier.
+        fake_subprocess.current_handler = "cdumm-nxm.desktop"
+        apps_dir = linux_xdg["data"] / "applications"
+        apps_dir.mkdir()
+        desktop = apps_dir / "cdumm-nxm.desktop"
+        desktop.write_text("[Desktop Entry]\nName=CDUMM\n")
+
+        ok = nxm_handler.unregister_linux_handler()
+        assert ok is True
+        assert not desktop.exists()
+
+    def test_refuses_when_another_app_owns_the_scheme(
+            self, linux_xdg, fake_subprocess) -> None:
+        """Pre-condition: somehow our .desktop is on disk but
+        xdg-mime now reports a different default handler (user
+        registered Vortex after us via Vortex's UI). Removing our
+        file is fine, but we must not delete an unrelated app's
+        registration. Defence in depth — the function refuses
+        entirely so the operator can investigate."""
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        apps_dir = linux_xdg["data"] / "applications"
+        apps_dir.mkdir()
+        desktop = apps_dir / "cdumm-nxm.desktop"
+        desktop.write_text("[Desktop Entry]\nName=CDUMM\n")
+
+        ok = nxm_handler.unregister_linux_handler()
+        assert ok is False
+        # File NOT removed — current handler isn't us, so unregister
+        # bailed before touching anything.
+        assert desktop.exists()
+
+    def test_strips_mimeapps_list_entry_pointing_at_us(
+            self, linux_xdg, fake_subprocess) -> None:
+        """mimeapps.list has [Default Applications] / [Added
+        Associations] sections. ``xdg-mime default`` writes
+        ``x-scheme-handler/nxm=cdumm-nxm.desktop`` under one of them;
+        unregister must drop that line so a later
+        ``is_handler_registered()`` call doesn't see a stale
+        reference. Other lines (unrelated mime types, other
+        handlers) must survive untouched."""
+        fake_subprocess.current_handler = "cdumm-nxm.desktop"
+        mimeapps = linux_xdg["config"] / "mimeapps.list"
+        mimeapps.write_text(
+            "[Default Applications]\n"
+            "x-scheme-handler/nxm=cdumm-nxm.desktop;\n"
+            "application/pdf=org.gnome.Evince.desktop;\n"
+            "text/html=firefox.desktop;\n",
+            encoding="utf-8")
+        # Pre-create the .desktop so the unlink path succeeds.
+        apps = linux_xdg["data"] / "applications"
+        apps.mkdir()
+        (apps / "cdumm-nxm.desktop").write_text("[Desktop Entry]\n")
+
+        nxm_handler.unregister_linux_handler()
+
+        rewritten = mimeapps.read_text(encoding="utf-8")
+        assert "cdumm-nxm.desktop" not in rewritten
+        # Unrelated lines are preserved.
+        assert "org.gnome.Evince.desktop" in rewritten
+        assert "firefox.desktop" in rewritten
+
+    def test_leaves_mimeapps_lines_for_other_handlers_alone(
+            self, linux_xdg, fake_subprocess) -> None:
+        """If a future Vortex Flatpak install rewrites the
+        x-scheme-handler/nxm line to point at *itself* after we
+        registered, an attempt to unregister ours must NOT remove
+        Vortex's binding — we'd be stripping a third party's
+        registration without their consent."""
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        mimeapps = linux_xdg["config"] / "mimeapps.list"
+        mimeapps.write_text(
+            "[Default Applications]\n"
+            "x-scheme-handler/nxm=net.nexusmods.vortex.desktop;\n",
+            encoding="utf-8")
+
+        ok = nxm_handler.unregister_linux_handler()
+        # Function bails out (current handler isn't ours) so the
+        # mimeapps file is never touched.
+        assert ok is False
+        assert ("x-scheme-handler/nxm=net.nexusmods.vortex.desktop"
+                in mimeapps.read_text(encoding="utf-8"))
+
+
+# ── is_handler_registered + dispatcher ──────────────────────────────
+
+
+class TestIsHandlerRegisteredLinux:
+
+    def test_true_when_xdg_mime_returns_our_desktop_filename(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = "cdumm-nxm.desktop"
+        assert nxm_handler.is_handler_registered() is True
+
+    def test_false_when_xdg_mime_returns_different_handler(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        assert nxm_handler.is_handler_registered() is False
+
+    def test_false_when_nothing_registered(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = ""
+        assert nxm_handler.is_handler_registered() is False
+
+    def test_false_when_xdg_mime_missing(
+            self, linux_xdg, monkeypatch) -> None:
+        """``xdg-mime`` not on PATH (minimal container, NixOS without
+        ``xdg-utils``) raises ``FileNotFoundError``. Must not crash
+        the Settings page — treat as "no handler"."""
+        def missing_subprocess(*args, **kwargs):
+            raise FileNotFoundError("xdg-mime")
+        monkeypatch.setattr(
+            nxm_handler.subprocess, "run", missing_subprocess)
+        assert nxm_handler.is_handler_registered() is False
+
+
+# ── existing_handler_description ────────────────────────────────────
+
+
+class TestExistingHandlerDescription:
+
+    def test_returns_xdg_mime_output_on_linux(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = "net.nexusmods.vortex.desktop"
+        assert (nxm_handler.existing_handler_description()
+                == "net.nexusmods.vortex.desktop")
+
+    def test_returns_none_when_no_handler_registered(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = ""
+        assert nxm_handler.existing_handler_description() is None
+
+
+# ── generic dispatchers ─────────────────────────────────────────────
+
+
+class TestGenericDispatchersLinux:
+
+    def test_register_handler_dispatches_to_linux(
+            self, linux_xdg, fake_subprocess) -> None:
+        ok = nxm_handler.register_handler()
+        assert ok is True
+        desktop = (linux_xdg["data"] / "applications"
+                   / "cdumm-nxm.desktop")
+        assert desktop.exists()
+
+    def test_unregister_handler_dispatches_to_linux(
+            self, linux_xdg, fake_subprocess) -> None:
+        fake_subprocess.current_handler = "cdumm-nxm.desktop"
+        apps = linux_xdg["data"] / "applications"
+        apps.mkdir()
+        (apps / "cdumm-nxm.desktop").write_text("[Desktop Entry]\n")
+        ok = nxm_handler.unregister_handler()
+        assert ok is True

--- a/tests/test_linux_nxm_handler.py
+++ b/tests/test_linux_nxm_handler.py
@@ -18,6 +18,7 @@ check the exact command line that would have been sent to xdg-mime.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -110,6 +111,11 @@ class TestRegisterLinuxHandler:
         assert "%u" in body
         assert "--nxm" in body
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows file mode has no POSIX exec bit; Path.chmod "
+        "to 0o755 is a no-op on NTFS, so the assertion always fails "
+        "even though the underlying Linux behaviour is correct.")
     def test_marks_desktop_file_executable(
             self, linux_xdg, fake_subprocess) -> None:
         """Some desktop environments (Plasma 5 historically) skip


### PR DESCRIPTION
# PR title

Native Linux support (no Wine)

---

# PR body

## Summary

Adds a native Linux path for CDUMM — the manager runs as native Python on
Linux instead of as `CDUMM3.exe` under Wine. Crimson Desert itself still
runs under Proton/Steam; only the manager goes native. This sidesteps the
Wine-prefix friction documented in `LINUX.md` (Python-on-Wine hangs, prefix
provisioning, Wine version churn).

The codebase was already most of the way there — `platform.py` has the
`IS_LINUX` abstraction, the GUI is PySide6, the Rust native component is
pure-`pyo3`. This PR fills in the platform-specific gaps and adds a launcher.

8 commits, each self-contained and individually reviewable. Nothing here
changes Windows behaviour — every new branch is gated behind `IS_LINUX` or
added alongside the existing Windows path.

## What's included

**`feat(linux): native Steam install detection`**
Adds a Linux branch to `game_finder.find_game_directories()` parallel to the
existing macOS branch. Walks the known Steam install roots on Linux
(`~/.local/share/Steam`, the `~/.steam` symlinks, Flatpak, Snap), parses each
install's `libraryfolders.vdf`, dedupes symlinked roots by `Path.resolve()`.
No Epic/Xbox detection on Linux (no native launchers). +10 tests.

**`feat(linux): nxm:// scheme handler via .desktop + xdg-mime`**
Linux registration path for the NexusMods `nxm://` URL scheme, parallel to
the Windows registry implementation. Writes a `.desktop` file under
`~/.local/share/applications` and calls `xdg-mime default`. Unregister
deletes the file and cleans `mimeapps.list`. Refuses to displace an existing
Vortex/MO2 registration without explicit confirmation. Adds generic
`register_handler` / `unregister_handler` / `existing_handler_description`
dispatchers; the Settings page now shows the nxm:// row on Linux. +18 tests.

**`feat(linux): show ASI placeholder card on Linux instead of scan UI`**
ASI plugins are Windows DLL injection — they only work when the manager and
game share a Wine prefix. The native build runs outside the prefix, so the
ASI page renders the existing "not supported" placeholder card (generalised
from the macOS one) instead of the scan UI.

**`feat(linux): native launcher script + docs`**
`scripts/cdumm-linux-native.sh` — provisions a venv, `pip install`s CDUMM +
deps, optionally builds `cdumm_native` via maturin, launches the GUI. Marker
files make subsequent runs near-instant. `LINUX.md` updated with a Native vs.
Wine comparison and a native quick-start.

**`fix(tests): widen ASI / os.startfile skips from darwin to all non-Windows`**
Two test files had `skipif(sys.platform == "darwin")` guards, but the code
paths they cover short-circuit on every non-Windows platform. Widened to
`!= "win32"`. These were silently failing on Linux CI-equivalent runs.

**`fix(linux): widen ASI page IS_MACOS guards`**
`set_managers` / `refresh` / `set_nexus_updates` in `asi_page.py` had
`if IS_MACOS: return` guards, but the placeholder-mode build path applies to
Linux too. Without the widened guard, `refresh()` reaches into a never-
constructed `_scroll_layout` and crashes the window during `_init_navigation`.
+4 regression tests pinning the startup-time contract.

**`fix(linux): route Qt file dialogs through the XDG portal`**
The launcher exports `QT_QPA_PLATFORMTHEME=xdgdesktopportal` for the CDUMM
process. Without it, on a `qt6ct` platform-theme setup Qt falls back to its
built-in `QFileDialog` widget, which doesn't inherit the qfluentwidgets dark
theme and opens in light mode. Overridable via `CDUMM_QT_PLATFORMTHEME`.

**`chore: gitignore runtime *.log files`**
The worker subprocess writes `cdumm_worker.log` into the source tree on a
run-from-source launch.

## Out of scope

**ASI plugin support.** Making ASI work on a Proton-run game means the
manager has to manage `WINEDLLOVERRIDES` on Steam's launch options — exactly
the Wine-prefix plumbing the native build exists to avoid. Users who need
ASI can still use the Wine path (`scripts/cdumm-linux.sh`). The ASI page
clearly says so on Linux.

## Testing

- New: 32 Linux-specific tests across `test_linux_game_finder.py`,
  `test_linux_nxm_handler.py`, `test_linux_asi_page.py`.
- The `nxm`/`asi` Linux tests monkeypatch `subprocess.run` / the platform
  flags so they run on any host, including Windows CI.
- Existing `test_game_finder.py`, `test_macos_game_finder.py`,
  `test_nxm_handler.py` all still pass on Linux.
- Verified end-to-end on Arch Linux + Python 3.14.4: provisioning runs clean,
  `cdumm_native` builds via maturin, CDUMM boots, detects a real Crimson
  Desert install via the `libraryfolders.vdf` chain, file dialogs render
  through the portal.

One pre-existing failure unrelated to this PR:
`test_platform.py::test_oserror_logs_path_and_reason` fails on Python 3.14
due to a `caplog.records` attribute behaviour change — present on the base
commit, not touched here.