### PR TITLE
feat(skill): add skill primitive schema and indexed TID selection

### DIFF
--- a/field_schema/skill.json
+++ b/field_schema/skill.json
@@ -1,4 +1,8 @@
 {
+  "_credit": "Initial entries for skill.pabgb primitive Format 3 mods contributed by voiddoiv via Nexus comments on 2026-05-08. CDUMM ships these as community-curated values; correctness verified against author's working build, not independently re-derived from a vanilla skill.pabgb dump.",
+  "_format": "JMM-compatible field_schema. Each entry maps a Format 3 'field' name to a tid (0xNNNNNNNN little-endian type tag the engine writes before the value), value_offset (bytes from the tid to the actual value), and type (i8/u8/i16/u16/i32/u32/f32/i64/u64/f64).",
+  "_contribute": "Open a PR at https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager with new entries for skill primitives you have verified.",
+
   "worker_skill_farming": {
     "tid": "0x0F427600",
     "value_offset": 5,

--- a/field_schema/skill.json
+++ b/field_schema/skill.json
@@ -48,5 +48,25 @@
     "tid": "0x0F427500",
     "value_offset": 5,
     "type": "i64"
+  },
+  "skill_stamina_cost": {
+    "tid": "0x0F425A03",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "skill_spirit_cost": {
+    "tid": "0x0F425B03",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "skill_stamina_amount": {
+    "tid": "0x0F425A00",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "skill_spirit_amount": {
+    "tid": "0x0F425B00",
+    "value_offset": 5,
+    "type": "i64"
   }
 }

--- a/field_schema/skill.json
+++ b/field_schema/skill.json
@@ -2,7 +2,6 @@
   "_credit": "Initial entries for skill.pabgb primitive Format 3 mods contributed by voiddoiv via Nexus comments on 2026-05-08. CDUMM ships these as community-curated values; correctness verified against author's working build, not independently re-derived from a vanilla skill.pabgb dump.",
   "_format": "JMM-compatible field_schema. Each entry maps a Format 3 'field' name to a tid (0xNNNNNNNN little-endian type tag the engine writes before the value), value_offset (bytes from the tid to the actual value), and type (i8/u8/i16/u16/i32/u32/f32/i64/u64/f64).",
   "_contribute": "Open a PR at https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager with new entries for skill primitives you have verified.",
-
   "worker_skill_farming": {
     "tid": "0x0F427600",
     "value_offset": 5,

--- a/field_schema/skill.json
+++ b/field_schema/skill.json
@@ -63,12 +63,12 @@
     "value_offset": 5,
     "type": "i64"
   },
-  "skill_stamina_amount": {
+  "skill_stamina_delta": {
     "tid": "0x0F425A00",
     "value_offset": 5,
     "type": "i64"
   },
-  "skill_spirit_amount": {
+  "skill_spirit_delta": {
     "tid": "0x0F425B00",
     "value_offset": 5,
     "type": "i64"

--- a/field_schema/skill.json
+++ b/field_schema/skill.json
@@ -1,10 +1,51 @@
 {
-  "_credit": "Initial entries for skill.pabgb primitive Format 3 mods contributed by voiddoiv via Nexus comments on 2026-05-08. CDUMM ships these as community-curated values; correctness verified against author's working build, not independently re-derived from a vanilla skill.pabgb dump.",
-  "_format": "JMM-compatible field_schema. Each entry maps a Format 3 'field' name to a tid (0xNNNNNNNN little-endian type tag the engine writes before the value), value_offset (bytes from the tid to the actual value), and type (i8/u8/i16/u16/i32/u32/f32/i64/u64/f64).",
-  "_contribute": "Open a PR at https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager with new entries for skill primitives you have verified.",
-
-  "mission_eff_farming_i": {
+  "worker_skill_farming": {
     "tid": "0x0F427600",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_ranching": {
+    "tid": "0x0F427700",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_logging": {
+    "tid": "0x0F427800",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_mining": {
+    "tid": "0x0F427400",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_forging": {
+    "tid": "0x0F427900",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_strengthening": {
+    "tid": "0x0F426600",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_fishing": {
+    "tid": "0x0F426100",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_gathering": {
+    "tid": "0x0F428100",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_banking": {
+    "tid": "0x0F427500",
+    "value_offset": 5,
+    "type": "i64"
+  },
+  "worker_skill_superworker": {
+    "tid": "0x0F427500",
     "value_offset": 5,
     "type": "i64"
   }

--- a/src/cdumm/engine/field_schema.py
+++ b/src/cdumm/engine/field_schema.py
@@ -53,6 +53,7 @@ class FieldSchemaEntry:
     value_offset: int = 5
     tid: int | None = None
     rel_offset: int | None = None
+    tid_index: int | None = None
 
 
 def _coerce_tid(raw) -> int | None:
@@ -198,11 +199,23 @@ def load_field_schema(table_name: str,
                 key, table_name, value_offset)
             continue
 
+        tid_index = val.get("tid_index")
+        if tid_index is not None:
+            if (isinstance(tid_index, bool)
+                    or not isinstance(tid_index, int)
+                    or tid_index < 0):
+                logger.warning(
+                    "field_schema entry '%s' in '%s' has invalid "
+                    "tid_index=%r; skipping",
+                    key, table_name, tid_index)
+                continue
+
         result[key] = FieldSchemaEntry(
             tid=tid,
             rel_offset=rel_offset,
             value_offset=value_offset,
             data_type=data_type,
+            tid_index=tid_index,
         )
 
     if result:
@@ -213,43 +226,44 @@ def load_field_schema(table_name: str,
 
 
 def locate_field(body: bytes, blob_start: int, blob_end: int,
-                 entry: FieldSchemaEntry) -> int | None:
+                 entry: FieldSchemaEntry,
+                 tid_index: int | None = None) -> int | None:
     """Return the absolute byte offset where the field's value
     should be written, or None if it can't be located.
-
-    Two modes (matching JMM's IteminfoBlobPatcher):
-      * ``rel_offset``: ``blob_start + rel_offset``
-      * ``tid``: search ``[blob_start, blob_end)`` for the 4-byte
-        TID marker, return ``tid_pos + value_offset``
-
-    Multi-match safety: when a TID appears more than once inside
-    the entry blob (real risk on 4-byte search patterns —
-    integer constants, CString bytes, neighboring fields can all
-    coincidentally match), refuse to guess which match was meant.
-    JMM takes the first match silently; we surface this case as
-    None so the caller can skip with a clear reason. The mod
-    author can disambiguate by switching to ``rel_offset`` or
-    picking a more unique TID.
-
-    ``blob_end`` is the exclusive upper bound — the search must
-    not match a TID belonging to the next entry.
     """
     if entry.rel_offset is not None:
         return blob_start + entry.rel_offset
 
     if entry.tid is not None:
         tid_bytes = struct.pack("<I", entry.tid & 0xFFFFFFFF)
-        # bytes.count + bytes.find both bounded by [start, end).
-        n_matches = body.count(tid_bytes, blob_start, blob_end)
-        if n_matches == 0:
+        matches: list[int] = []
+        pos = body.find(tid_bytes, blob_start, blob_end)
+        while pos != -1:
+            matches.append(pos)
+            pos = body.find(tid_bytes, pos + 1, blob_end)
+
+        if not matches:
             return None
-        if n_matches > 1:
+
+        selected_index = (
+            tid_index if tid_index is not None else entry.tid_index
+        )
+        if selected_index is not None:
+            if selected_index >= len(matches):
+                logger.warning(
+                    "TID 0x%08X tid_index=%d out of range "
+                    "(%d match(es)) in entry blob [%d, %d)",
+                    entry.tid, selected_index, len(matches),
+                    blob_start, blob_end)
+                return None
+            return matches[selected_index] + entry.value_offset
+
+        if len(matches) > 1:
             logger.warning(
                 "TID 0x%08X appears %d times in entry blob "
-                "[%d, %d); refusing to guess which match — "
-                "use rel_offset or a more unique TID",
-                entry.tid, n_matches, blob_start, blob_end)
+                "[%d, %d); use tid_index or rel_offset",
+                entry.tid, len(matches), blob_start, blob_end)
             return None
-        return body.find(tid_bytes, blob_start, blob_end) + entry.value_offset
+        return matches[0] + entry.value_offset
 
     return None

--- a/src/cdumm/engine/field_schema.py
+++ b/src/cdumm/engine/field_schema.py
@@ -280,7 +280,7 @@ def locate_field(body: bytes, blob_start: int, blob_end: int,
         if len(matches) > 1:
             logger.warning(
                 "TID 0x%08X appears %d times in entry blob "
-                "[%d, %d); use tid_index or rel_offset",
+                "[%d, %d); use tid_index, rel_offset, or a more unique TID",
                 entry.tid, len(matches), blob_start, blob_end)
             return None
         return matches[0] + entry.value_offset

--- a/src/cdumm/engine/field_schema.py
+++ b/src/cdumm/engine/field_schema.py
@@ -245,7 +245,7 @@ def locate_field(body: bytes, blob_start: int, blob_end: int,
     unless ``tid_index`` is supplied. JMM takes the first match
     silently; we surface this case as None so the caller can skip
     with a clear reason. The mod author can disambiguate by switching
-    to ``tid_index`` or ``rel_offset``.
+    to ``tid_index``, ``rel_offset``, or picking a more unique TID.
 
     ``blob_end`` is the exclusive upper bound — the search must
     not match a TID belonging to the next entry.

--- a/src/cdumm/engine/field_schema.py
+++ b/src/cdumm/engine/field_schema.py
@@ -230,6 +230,25 @@ def locate_field(body: bytes, blob_start: int, blob_end: int,
                  tid_index: int | None = None) -> int | None:
     """Return the absolute byte offset where the field's value
     should be written, or None if it can't be located.
+
+    Two modes (matching JMM's IteminfoBlobPatcher):
+      * ``rel_offset``: ``blob_start + rel_offset``
+      * ``tid``: search ``[blob_start, blob_end)`` for the 4-byte
+        TID marker, return ``tid_pos + value_offset``
+      * ``tid_index``: when a TID appears more than once, select the
+        zero-based occurrence before applying ``value_offset``
+
+    Multi-match safety: when a TID appears more than once inside
+    the entry blob (real risk on 4-byte search patterns —
+    integer constants, CString bytes, neighboring fields can all
+    coincidentally match), refuse to guess which match was meant
+    unless ``tid_index`` is supplied. JMM takes the first match
+    silently; we surface this case as None so the caller can skip
+    with a clear reason. The mod author can disambiguate by switching
+    to ``tid_index`` or ``rel_offset``.
+
+    ``blob_end`` is the exclusive upper bound — the search must
+    not match a TID belonging to the next entry.
     """
     if entry.rel_offset is not None:
         return blob_start + entry.rel_offset

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -465,7 +465,8 @@ def _intents_to_v2_changes(
                     fmt_ns, size_ns = fmt_size
                     abs_off_ns = locate_field(
                         vanilla_body, payload_off_ns,
-                        entry_end_ns, fs_entry)
+                        entry_end_ns, fs_entry,
+                        tid_index=intent.tid_index)
                     if abs_off_ns is None:
                         continue
                     if abs_off_ns + size_ns > entry_end_ns:
@@ -1049,7 +1050,8 @@ def _resolve_write_pos(
             return None
         fmt, size = fmt_size
         abs_off = locate_field(
-            body, payload_off, entry_end, fs_entry)
+            body, payload_off, entry_end, fs_entry,
+            tid_index=intent.tid_index)
         if abs_off is None:
             return None
         return abs_off, size, fmt

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -126,6 +126,7 @@ class Format3Intent:
     op: str
     new: Any
     old: str | None = None
+    tid_index: int | None = None
 
 
 @dataclass
@@ -220,6 +221,16 @@ def _parse_intents_block(
                 f"({type(raw_old).__name__}); 'old' must be a hex "
                 f"string when present"
             )
+        raw_tid_index = raw.get("tid_index")
+        if raw_tid_index is not None:
+            if (isinstance(raw_tid_index, bool)
+                    or not isinstance(raw_tid_index, int)
+                    or raw_tid_index < 0):
+                raise ValueError(
+                    f"{label} intent #{i} has invalid tid_index "
+                    f"{raw_tid_index!r}; tid_index must be a "
+                    f"non-negative integer"
+                )
         intents.append(Format3Intent(
             entry=str(raw["entry"]),
             key=raw_key,
@@ -227,6 +238,7 @@ def _parse_intents_block(
             op=str(raw.get("op", "set")),
             new=raw["new"],
             old=raw_old,
+            tid_index=raw_tid_index,
         ))
     return intents
 


### PR DESCRIPTION
## Summary

Adds `skill.pabgb` primitive schema entries and supports optional `tid_index` selection for repeated TID matches.

## Changes

- Add worker skill primitive fields for worker skill style mods.
- Add stamina and spirit primitive fields for stamina and spirit style mods.
- Add optional `tid_index` parsing on Format 3 intents.
- Add optional `tid_index` support in `field_schema` entries.
- Pass `tid_index` through the Format 3 apply path.
- Preserve the existing safe behavior when `tid_index` is not supplied.

## Why

Some skill primitives are uniquely resolved by `entry`, `key`, and `tid`.

Other skill primitives can use the same TID more than once inside one entry. In that case, CDUMM should not guess which match to patch. `tid_index` provides an explicit zero-based selector for those repeated primitive matches.

## Validation

- Existing single-match TID behavior remains unchanged.
- Multi-match TID behavior still refuses to guess when `tid_index` is absent.
- `tid_index` selects the intended repeated TID occurrence when supplied.

## Known Limitation

`tid_index` is less durable than a fully unique TID because it depends on repeated TID order remaining stable.

It is included for cases where the best available primitive marker is reused inside the same entry.

## Merge note

The worker skill fields and cost fields are safe without `tid_index` support:

- `worker_skill_*`
- `skill_stamina_cost`
- `skill_spirit_cost`

The delta fields should only be merged if optional `tid_index` support is also merged:

- `skill_stamina_delta`
- `skill_spirit_delta`

Those two TIDs can appear multiple times inside the same `skill.pabgb` entry. Without `tid_index`, CDUMM correctly refuses to guess which repeated TID occurrence should be patched.