### PR TITLE
feat(ci): auto-upload releases to NexusMods on publish

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -133,6 +133,12 @@ jobs:
         with:
           files: dist/CDUMM-*-macos-arm64.dmg
           fail_on_unmatched_files: true
+          # Keep the release in draft until the maintainer attaches
+          # CDUMM3.exe and clicks Publish — that click fires
+          # release-nexusmods.yml, which mirrors both files to
+          # NexusMods. Auto-publishing here would fire the upload
+          # before the .exe is attached.
+          draft: true
           # Don't auto-create the release body — the maintainer's
           # manual release notes (matching the RELEASE_NOTES_*.md
           # files in the repo) are richer than anything we'd

--- a/.github/workflows/release-nexusmods.yml
+++ b/.github/workflows/release-nexusmods.yml
@@ -14,13 +14,13 @@ name: Upload release to NexusMods
 # v1.0.0-beta.6 is the latest tag (no stable release exists yet) and is
 # the first version with archive_existing_file (added in v1.0.0-beta.5).
 #
-# File group IDs come from repo Variables (not Secrets) — they are not
-# sensitive but should be editable in the GitHub UI without a code
-# change. The maintainer must set, under Settings → Secrets and
-# variables → Actions:
-#   Secret    NEXUSMODS_API_KEY            (nexusmods.com/settings/api-keys)
-#   Variable  NEXUS_FILE_GROUP_ID_MACOS    (file group ID on mod 2253)
-#   Variable  NEXUS_FILE_GROUP_ID_WINDOWS  (file group ID on mod 207)
+# The maintainer must set, under Settings → Secrets and variables →
+# Actions → Secrets:
+#   NEXUSMODS_API_KEY            (nexusmods.com/settings/api-keys)
+#   NEXUS_FILE_GROUP_ID_MACOS    (file group ID on mod 2253)
+#   NEXUS_FILE_GROUP_ID_WINDOWS  (file group ID on mod 207)
+# All three are stored as Secrets so they're masked (***) in workflow
+# logs and rotatable via the GitHub UI without a code change.
 
 on:
   release:
@@ -64,7 +64,7 @@ jobs:
         uses: Nexus-Mods/upload-action@v1.0.0-beta.6
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID_MACOS }}
+          file_group_id: ${{ secrets.NEXUS_FILE_GROUP_ID_MACOS }}
           filename: ${{ steps.prep.outputs.filename }}
           version: ${{ steps.prep.outputs.version }}
           display_name: CDUMM macOS
@@ -98,7 +98,7 @@ jobs:
         uses: Nexus-Mods/upload-action@v1.0.0-beta.6
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID_WINDOWS }}
+          file_group_id: ${{ secrets.NEXUS_FILE_GROUP_ID_WINDOWS }}
           filename: artifacts/CDUMM3.exe
           version: ${{ steps.prep.outputs.version }}
           display_name: CDUMM3 ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-nexusmods.yml
+++ b/.github/workflows/release-nexusmods.yml
@@ -1,0 +1,105 @@
+name: Upload release to NexusMods
+
+# Fires once when the maintainer publishes a GitHub Release (which
+# release-macos.yml leaves as draft so the .exe can be attached first).
+# That single Publish click mirrors both release assets to NexusMods:
+#   * macOS .dmg  → zipped → nexusmods.com/crimsondesert/mods/2253
+#   * Windows .exe → as-is → nexusmods.com/crimsondesert/mods/207
+#
+# NexusMods rejects .dmg, so the macOS file is wrapped in a .zip whose
+# base name matches the .dmg (e.g. CDUMM-3.3.15-macos-arm64.zip). The
+# Windows .exe is accepted directly — no repackaging.
+#
+# Uses Nexus-Mods/upload-action — the upstream-maintained uploader.
+# v1.0.0-beta.6 is the latest tag (no stable release exists yet) and is
+# the first version with archive_existing_file (added in v1.0.0-beta.5).
+#
+# File group IDs come from repo Variables (not Secrets) — they are not
+# sensitive but should be editable in the GitHub UI without a code
+# change. The maintainer must set, under Settings → Secrets and
+# variables → Actions:
+#   Secret    NEXUSMODS_API_KEY            (nexusmods.com/settings/api-keys)
+#   Variable  NEXUS_FILE_GROUP_ID_MACOS    (file group ID on mod 2253)
+#   Variable  NEXUS_FILE_GROUP_ID_WINDOWS  (file group ID on mod 207)
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read # gh release download reads release assets
+
+jobs:
+  macos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download .dmg from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'CDUMM-*-macos-arm64.dmg' \
+            --dir artifacts
+
+      - name: Wrap .dmg in a .zip
+        id: prep
+        run: |
+          dmg_file=$(ls artifacts/CDUMM-*-macos-arm64.dmg)
+          base=$(basename "$dmg_file" .dmg)
+          zip_path="artifacts/${base}.zip"
+          # -j strips the artifacts/ path so the zip contains the .dmg
+          # at its root, matching how the macOS archiver wraps it for
+          # the manual upload flow this workflow replaces.
+          zip -j "$zip_path" "$dmg_file"
+          tag="${{ github.event.release.tag_name }}"
+          {
+            echo "filename=$zip_path"
+            echo "version=${tag#v}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload to NexusMods (macOS, mod 2253)
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.6
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID_MACOS }}
+          filename: ${{ steps.prep.outputs.filename }}
+          version: ${{ steps.prep.outputs.version }}
+          display_name: CDUMM macOS
+          description: Unzip the .dmg and install like any other apps packaged in a .dmg
+          archive_existing_file: true
+          allow_mod_manager_download: false
+
+  windows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download .exe from release
+        id: prep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          # `|| true` so a release published before CDUMM3.exe is
+          # attached doesn't fail the job — the upload step's hashFiles
+          # guard then skips cleanly. The maintainer attaches the .exe
+          # and re-runs just this job from the Actions UI.
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'CDUMM3.exe' \
+            --dir artifacts || true
+          tag="${{ github.event.release.tag_name }}"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to NexusMods (Windows, mod 207)
+        if: hashFiles('artifacts/CDUMM3.exe') != ''
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.6
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID_WINDOWS }}
+          filename: artifacts/CDUMM3.exe
+          version: ${{ steps.prep.outputs.version }}
+          display_name: CDUMM3 ${{ github.event.release.tag_name }}
+          archive_existing_file: true


### PR DESCRIPTION
## Summary
- New `release-nexusmods.yml` triggers on `release: published` and mirrors both release assets to NexusMods using [`Nexus-Mods/upload-action@v1.0.0-beta.6`](https://github.com/Nexus-Mods/upload-action): `CDUMM-<v>-macos-arm64.dmg` is wrapped in a matching `.zip` (NexusMods rejects `.dmg`) and uploaded to [mod 2253](https://www.nexusmods.com/crimsondesert/mods/2253); `CDUMM3.exe` is uploaded as-is to [mod 207](https://www.nexusmods.com/crimsondesert/mods/207). Both use `archive_existing_file: true` and the version stripped of its leading `v`.
- `release-macos.yml` now leaves the GitHub Release in **draft** (one-line `draft: true` on the existing `softprops/action-gh-release` step) so `CDUMM3.exe` can be attached before the Publish click that fires the mirror.
- API key and both file group IDs are repo Secrets (`NEXUSMODS_API_KEY`, `NEXUS_FILE_GROUP_ID_MACOS`, `NEXUS_FILE_GROUP_ID_WINDOWS`) so they're masked in workflow logs and rotatable in the GitHub UI without a code change.
- Windows job is guarded by `hashFiles('artifacts/CDUMM3.exe') != ''` so publishing without the `.exe` skips the upload cleanly; re-run the job from the Actions UI after attaching.

## New release flow
1. `git tag vX.Y.Z && git push --tags` (unchanged).
2. `release-macos.yml` builds the `.dmg` and attaches it to a **draft** release.
3. Build `CDUMM3.exe` locally and attach it to the draft (unchanged).
4. Fill in release notes and click **Publish** (was auto-published; now a click).
5. `release-nexusmods.yml` mirrors both files to NexusMods.

## Required one-time config (in repo Settings → Secrets and variables → Actions → Secrets)
- `NEXUSMODS_API_KEY` (from nexusmods.com/settings/api-keys)
- `NEXUS_FILE_GROUP_ID_MACOS` (file group ID on mod 2253)
- `NEXUS_FILE_GROUP_ID_WINDOWS` (file group ID on mod 207)

## Test plan
- [ ] Set all three secrets in repo settings
- [ ] Cut a throwaway prerelease tag (e.g. `v3.3.16-rc.1`) and confirm `release-macos.yml` produces a **draft** release containing `CDUMM-<v>-macos-arm64.dmg`
- [ ] Attach `CDUMM3.exe` (a prior version is fine for the test) and click **Publish**
- [ ] Verify `release-nexusmods.yml` runs both jobs green and both NexusMods mod pages show the new file with the prior file moved to "Archived"
- [ ] Negative path: publish without attaching `CDUMM3.exe`, confirm the Windows job skips cleanly (green), attach the `.exe`, re-run just that job, confirm upload succeeds
- [ ] Clean up: delete the throwaway release and tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)