### PR TITLE
fix(asi): recognise bare .addon64 ReShade mods in contains_asi gate (#202)

### DIFF
--- a/src/cdumm/asi/asi_manager.py
+++ b/src/cdumm/asi/asi_manager.py
@@ -475,16 +475,31 @@ class AsiManager:
 
     @staticmethod
     def contains_asi(path: Path) -> bool:
-        """Check if a path contains ASI plugin files (searches subdirectories and archives)."""
+        """Check if a path contains ASI plugin or ReShade addon files
+        (searches subdirectories and archives).
+
+        #202: ReShade ``.addon64`` mods are loose-loader files that
+        install into bin64 exactly like ``.asi`` plugins (hence
+        ``LOOSE_LOADER_SUFFIXES``); scan(), install() and the import
+        staging path already treat both. This gate did not -- it only
+        matched ``.asi``, so a bare ``.addon64`` drop, or a zip/7z whose
+        only loader content was a ReShade addon, failed the check and was
+        never routed to install. The addon showed as detected/staged but
+        never landed in bin64. Both loose-loader suffixes now count.
+        """
+        def _is_loader(name: str) -> bool:
+            lo = name.lower()
+            return any(lo.endswith(s) for s in LOOSE_LOADER_SUFFIXES)
+
         if path.is_file():
-            if path.suffix.lower() == ASI_SUFFIX:
+            if _is_loader(path.name):
                 return True
             # Check inside zip files
             if path.suffix.lower() == ".zip":
                 import zipfile
                 try:
                     with zipfile.ZipFile(path) as zf:
-                        return any(n.lower().endswith(ASI_SUFFIX) for n in zf.namelist())
+                        return any(_is_loader(n) for n in zf.namelist())
                 except (zipfile.BadZipFile, Exception):
                     return False
             # Check inside 7z files
@@ -492,11 +507,13 @@ class AsiManager:
                 try:
                     import py7zr
                     with py7zr.SevenZipFile(path, 'r') as zf:
-                        return any(n.lower().endswith(ASI_SUFFIX) for n in zf.getnames())
+                        return any(_is_loader(n) for n in zf.getnames())
                 except Exception:
                     return False
         if path.is_dir():
-            return any(path.rglob(f"*{ASI_SUFFIX}"))
+            return any(
+                _is_loader(p.name)
+                for p in path.rglob("*") if p.is_file())
         return False
 
     def open_config(self, plugin: AsiPlugin) -> bool:

--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>Bare ReShade <code>.addon64</code> mods now import and install into bin64 instead of being detected but never applied.</b> The loose-loader gate <code>AsiManager.contains_asi()</code> still only recognised <code>.asi</code>, even though staging, install and scan were all extended to handle <code>.addon64</code> via <code>LOOSE_LOADER_SUFFIXES</code>. A bare <code>.addon64</code> drop, or a zip/7z whose only loader content was a ReShade addon, therefore failed the gate and was never routed to install -- the addon showed up as detected/staged but never landed in bin64. The gate now counts both loose-loader suffixes. Reported on GitHub (#202).",
 ]
 
 CHANGELOG = [

--- a/tests/test_asi_manager.py
+++ b/tests/test_asi_manager.py
@@ -180,3 +180,51 @@ def test_parse_hook_targets_handles_utf8_bom(tmp_path: Path) -> None:
     target = next(p for p in plugins if p.name == "SuperAxiomForce")
     assert target.hook_targets, "BOM INI produced no hook targets"
     assert any("xinput1_3.dll" in t for t in target.hook_targets)
+
+
+def test_contains_asi_detects_bare_addon64(tmp_path: Path) -> None:
+    """#202: a bare ReShade ``.addon64`` is a loose-loader file that
+    installs into bin64 like an ``.asi``. ``contains_asi`` gates whether
+    a drop/import is routed to the ASI-install path, so it must accept
+    ``.addon64`` -- otherwise the addon is detected/staged but never
+    copied into bin64.
+    """
+    addon = tmp_path / "CrimsonWeather.addon64"
+    addon.write_bytes(b"DLL_DATA")
+    assert AsiManager.contains_asi(addon) is True
+
+
+def test_contains_asi_detects_addon64_only_zip(tmp_path: Path) -> None:
+    """#202: a zip whose only loader content is a ``.addon64`` (no
+    ``.asi``, no PAZ/JSON) must still be recognised as ASI/addon content.
+    """
+    import zipfile
+    z = tmp_path / "crimson_weather.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("CrimsonWeather.addon64", b"DLL_DATA")
+        zf.writestr("CrimsonWeather.ini", b"[General]\n")
+    assert AsiManager.contains_asi(z) is True
+
+
+def test_contains_asi_detects_addon64_in_dir(tmp_path: Path) -> None:
+    """#202: a folder whose only loader content is a ``.addon64`` must
+    be detected (mixed-extract drops land as a directory)."""
+    d = tmp_path / "moddir"
+    d.mkdir()
+    (d / "CrimsonWeather.addon64").write_bytes(b"DLL_DATA")
+    assert AsiManager.contains_asi(d) is True
+
+
+def test_contains_asi_still_matches_asi(tmp_path: Path) -> None:
+    """Regression guard: broadening for #202 must not lose ``.asi``
+    detection."""
+    asi = tmp_path / "Foo.asi"
+    asi.write_bytes(b"DLL_DATA")
+    assert AsiManager.contains_asi(asi) is True
+
+
+def test_contains_asi_rejects_non_loader(tmp_path: Path) -> None:
+    """A plain file with no loose-loader content is not ASI/addon."""
+    txt = tmp_path / "readme.txt"
+    txt.write_text("hi")
+    assert AsiManager.contains_asi(txt) is False


### PR DESCRIPTION
﻿### Problem (#202)

ReShade `.addon64` mods are detected/staged but never installed into `bin64`. A bare `.addon64` drop — or a zip/7z whose only loader content is a ReShade addon — produces an entry but the file never lands in `bin64`.

### Root cause

`.addon64` support was added to `scan()`, `install()` and the import-staging path via `LOOSE_LOADER_SUFFIXES = (".asi", ".addon64")`, but `AsiManager.contains_asi()` — the gate several drop/import paths use to decide whether something is ASI/addon content — was never updated and still only matched `.asi`. So addon-only inputs fail the gate and are never routed to install. (Same "extended the helper but missed a sibling check" pattern as #120.)

### Fix

`contains_asi()` now uses `LOOSE_LOADER_SUFFIXES`, so `.asi` and `.addon64` both count — for direct files, `.zip`/`.7z` archive contents, and directories. `.asi` behaviour is unchanged.

### Tests

Adds 5 cases to `tests/test_asi_manager.py` (the gate had no coverage): bare `.addon64`, addon-only `.zip`, addon-only directory -> detected; `.asi` still detected; non-loader file rejected. `test_asi_manager.py` passes (18).

### Honest caveat

I don't have a ReShade-addon repro setup, so I couldn't confirm this end-to-end in-game. The "since 3.3.19" timing isn't explained by this gate alone (it likely always only matched `.asi`), so there may be a second factor — but this is a real gap matching the symptom and worth closing regardless. Quick check: drop a bare `.addon64` and confirm it installs.

_No `CONTRIBUTING` in the repo, so I followed the de-facto conventions: `_UNRELEASED_NOTES` changelog entry, `tests/` pytest style, ruff line-length 100._
