### PR TITLE
fix(import): preserve a mod's folder group_id across updates (#161)

### DIFF
--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>A mod's folder group is no longer lost when you update it.</b> Updating a mod (dropping a new version, or click-to-update) dup-removes the old row and re-imports; the post-import state restore re-applied <code>priority</code> and <code>enabled</code> but not the user's folder <code>group_id</code>, so updated mods silently fell out of their group. The group is now snapshotted with the rest of the update state and restored. Reported on GitHub (#161).",
 ]
 
 CHANGELOG = [

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -514,6 +514,7 @@ def _clear_pending_post_import_state(win, path) -> None:
     for attr in (
         "_update_priority",
         "_update_enabled",
+        "_update_group_id",
         "_configurable_source",
         "_configurable_labels",
         "_original_drop_path",
@@ -3998,6 +3999,7 @@ class CdummWindow(FluentWindow):
                             if m["id"] == mid:
                                 self._update_priority = m.get("priority")
                                 self._update_enabled = m.get("enabled")
+                                self._update_group_id = m.get("group_id")
                                 break
                         # Bug 34: snapshot the configurable mod's
                         # selected_labels BEFORE the old row goes away.
@@ -5384,15 +5386,20 @@ class CdummWindow(FluentWindow):
                 except Exception:
                     pass
 
-            # Post-import: restore update state (priority/enabled)
+            # Post-import: restore update state (priority/enabled/group).
+            # #161: the user's folder group_id must be re-applied too --
+            # the old row is dup-removed on update, so without this the
+            # mod silently falls out of its group after every update.
             upri = _ctx.get("update_priority")
             if upri is not None:
                 try:
                     mod_id = _primary_id()
                     if mod_id is not None:
                         self._db.connection.execute(
-                            "UPDATE mods SET priority = ?, enabled = ? WHERE id = ?",
-                            (upri, _ctx.get("update_enabled") or 0, mod_id))
+                            "UPDATE mods SET priority = ?, enabled = ?, "
+                            "group_id = ? WHERE id = ?",
+                            (upri, _ctx.get("update_enabled") or 0,
+                             _ctx.get("update_group_id"), mod_id))
                         self._db.connection.commit()
                 except Exception:
                     pass

--- a/src/cdumm/gui/import_context.py
+++ b/src/cdumm/gui/import_context.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 IMPORT_CONTEXT_KEYS: tuple[str, ...] = (
     "update_priority",
     "update_enabled",
+    "update_group_id",
     "configurable_source",
     "configurable_labels",
     "variant_leaf_rel",
@@ -38,6 +39,7 @@ def snapshot_and_clear_import_context(win) -> dict:
     ctx = {k: getattr(win, f"_{k}", None) for k in IMPORT_CONTEXT_KEYS}
     win._update_priority = None
     win._update_enabled = None
+    win._update_group_id = None
     win._configurable_source = None
     win._configurable_labels = None
     win._variant_leaf_rel = None

--- a/tests/test_import_context_group_id.py
+++ b/tests/test_import_context_group_id.py
@@ -1,0 +1,29 @@
+﻿"""#161: the user's folder group must ride through the import context so
+the post-import restore can re-apply it after the old mod row is
+dup-removed on update."""
+from cdumm.gui.import_context import (
+    IMPORT_CONTEXT_KEYS,
+    snapshot_and_clear_import_context,
+)
+
+
+class _FakeWin:
+    pass
+
+
+def test_update_group_id_is_a_context_key() -> None:
+    assert "update_group_id" in IMPORT_CONTEXT_KEYS
+
+
+def test_snapshot_captures_and_clears_update_group_id() -> None:
+    win = _FakeWin()
+    win._update_priority = 5
+    win._update_enabled = 1
+    win._update_group_id = 7
+    win._configurable_source = None
+    win._configurable_labels = None
+    win._variant_leaf_rel = None
+    win._original_drop_path = None
+    ctx = snapshot_and_clear_import_context(win)
+    assert ctx["update_group_id"] == 7
+    assert win._update_group_id is None


### PR DESCRIPTION
﻿### Problem (#161)

A mod''s folder group is lost whenever you update it.

### Root cause

Updating a mod (drop a new version / click-to-update) dup-removes the old row and re-imports. The post-import state restore in `_on_finished` re-applies `priority` and `enabled` from the pre-remove snapshot, but the snapshot never captured the user''s folder `group_id`, so it came back `NULL` (ungrouped) after every update.

### Fix

Carry `update_group_id` through the import context — snapshot it at update-detection, let it ride on the `_cdumm_ctx` proc dict (`IMPORT_CONTEXT_KEYS`), and restore it in the post-import `UPDATE`, exactly alongside the existing `priority`/`enabled` restore. Three small additions + the restore SQL.

### Tests

Adds `tests/test_import_context_group_id.py` for the carryover (snapshot captures `update_group_id`, window slot cleared). Green locally.

### Notes

I can''t exercise the full GUI update flow without the app + a grouped mod, so I unit-tested the carryover mechanism (the part that was missing) and traced the restore SQL by hand. _No `CONTRIBUTING` in the repo; followed the `_UNRELEASED_NOTES` changelog + `tests/` pytest conventions._
