### PR TITLE
fix(gui): cap TogglePickerDialog scroll height so action buttons stay on-screen (#196)

### DIFF
--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>Mod preset/toggle picker no longer traps the app off-screen.</b> A JSON mod whose preset opens the toggle picker with many options grew the modal taller than the window, pushing the Apply/Cancel buttons off the bottom -- the dialog was unclickable and the whole app looked frozen, forcing an End Task. The toggle picker now caps its scroll height to the parent window the same way the import preset picker already does (#200), so the list scrolls internally and the buttons stay visible. Reported on GitHub (#196).",
 ]
 
 CHANGELOG = [

--- a/src/cdumm/gui/preset_picker.py
+++ b/src/cdumm/gui/preset_picker.py
@@ -1009,6 +1009,22 @@ class TogglePickerDialog(MessageBoxBase):
 
         self.widget.setMinimumWidth(500)
 
+    def _cap_scroll_height(self, scroll):
+        """#196: keep the dialog inside the parent window so a mod with
+        many presets/toggles doesn't grow the modal past the screen and
+        push the Apply/Cancel buttons off the bottom (the same screen-fit
+        cap PresetPickerDialog got for #200). Without it the dialog is
+        unclickable and the whole app appears frozen."""
+        try:
+            par = self.parent()
+            par_h = par.window().height() if par else 0
+        except Exception:
+            par_h = 0
+        if par_h:
+            avail = max(160, par_h - 300)
+            scroll.setMaximumHeight(avail)
+            scroll.setMinimumHeight(min(250, avail))
+
     def _build_preset_mode(self):
         """Mutually exclusive presets — radio buttons."""
         from PySide6.QtWidgets import QRadioButton
@@ -1021,6 +1037,7 @@ class TogglePickerDialog(MessageBoxBase):
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(SingleDirectionScrollArea.Shape.NoFrame)
         scroll.setMinimumHeight(250)
+        self._cap_scroll_height(scroll)
         scroll_widget = QWidget()
         if isDarkTheme():
             scroll_widget.setStyleSheet("QWidget { background: #1C2028; } "
@@ -1117,6 +1134,7 @@ class TogglePickerDialog(MessageBoxBase):
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(SingleDirectionScrollArea.Shape.NoFrame)
         scroll.setMinimumHeight(250)
+        self._cap_scroll_height(scroll)
         scroll_widget = QWidget()
         if isDarkTheme():
             scroll_widget.setStyleSheet("QWidget { background: #1C2028; } "


### PR DESCRIPTION
﻿### Problem (#196)

Mods with a preset can make the picker window un-clickable — you can''t hit Apply/Cancel and can''t click anywhere else in the app, so it looks frozen and has to be killed from Task Manager.

### Root cause

`TogglePickerDialog` (the "choose which labeled changes to apply" modal) sets only a **minimum** scroll height (250) and no maximum. A mod with many presets/toggles grows the modal taller than the window, pushing the Apply/Cancel row off the bottom of the screen. Being modal, it blocks the rest of the app too. `PresetPickerDialog` already fixed exactly this for the import picker (#200) by capping its scroll to the parent-window height; `TogglePickerDialog` never got the same cap.

### Fix

Add a `_cap_scroll_height()` helper that caps the scroll to `parent_window_height - chrome` (mirroring #200) and call it in both build modes (`_build_preset_mode`, `_build_toggle_mode`). The list scrolls internally and the buttons stay visible.

### Notes

GUI sizing change — I can''t drive the Qt dialog headlessly here, so it isn''t run-verified locally; it''s a direct mirror of the existing #200 cap on the sibling dialog. _No `CONTRIBUTING`; followed the `_UNRELEASED_NOTES` changelog convention._
