### PR TITLE
fix: two latent bugs caught by static analysis (settings UnboundLocalError, duplicate resizeEvent)

### DIFF
--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>Two latent bugs fixed (found via static analysis).</b> (1) Picking an invalid game directory in Settings raised an <code>UnboundLocalError</code> instead of showing the invalid-directory warning -- a redundant local <code>InfoBar</code>/<code>InfoBarPosition</code> import shadowed the module-level one, leaving the name unbound on that path. (2) The main window defined <code>resizeEvent</code> twice; the second silently overrode the first, so the update banner stopped following the window on resize. Both restored.",
 ]
 
 CHANGELOG = [

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -2310,10 +2310,6 @@ class CdummWindow(FluentWindow):
         self._update_banner.setGeometry(0, self.titleBar.height(),
                                          self.width(), 36)
 
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
-        self._position_update_banner()
-
     # ------------------------------------------------------------------
     # DB watcher helpers
     # ------------------------------------------------------------------
@@ -8058,6 +8054,10 @@ class CdummWindow(FluentWindow):
 
     def resizeEvent(self, event) -> None:  # noqa: N802
         super().resizeEvent(event)
+        # Reposition the update banner on resize. This lived in an earlier
+        # resizeEvent that this method silently overrode, so it had stopped
+        # running; fold it back in here.
+        self._position_update_banner()
         if hasattr(self, '_drop_overlay'):
             self._drop_overlay.resize(self.size())
         # Center title label across the full window width

--- a/src/cdumm/gui/pages/settings_page.py
+++ b/src/cdumm/gui/pages/settings_page.py
@@ -907,7 +907,6 @@ class SettingsPage(SmoothScrollArea):
             pointer_file.parent.mkdir(parents=True, exist_ok=True)
             pointer_file.write_text(str(new_path), encoding="utf-8")
         except Exception as e:
-            from qfluentwidgets import InfoBar, InfoBarPosition
             logger.error(
                 "settings: failed to write game_dir pointer at %s: %s",
                 pointer_file, e)


### PR DESCRIPTION
﻿Two latent correctness bugs surfaced by a static-analysis pass (ruff F-codes). Both are tiny and independent — happy to split into two PRs if you''d prefer.

### 1. `settings_page._on_game_dir_browse` — `UnboundLocalError` on an invalid game dir

`InfoBar`/`InfoBarPosition` are imported at module level (lines 22–23), but the function also has a redundant local `from qfluentwidgets import InfoBar, InfoBarPosition` in its pointer-write `except` block. That local import makes both names function-local for the whole function, so `InfoBar.warning(...)` on the *invalid directory* path (used earlier than the import) raises `UnboundLocalError` — the user gets a crash instead of the invalid-directory warning. (ruff F823.)

I reproduced the exact scoping in isolation: calling the invalid-dir path throws `UnboundLocalError: local variable 'InfoBar' referenced before assignment`; removing the redundant import makes the warning display. Fix = delete the redundant local import (module-level ones are already in scope).

### 2. `fluent_window` — duplicate `resizeEvent` drops update-banner repositioning

`CdummWindow` defines `resizeEvent` twice. Python keeps the later one (drop-overlay resize + title centering), silently overriding the earlier one whose body was `super().resizeEvent(event); self._position_update_banner()`. So the update banner stopped following the window on resize. (ruff F811.) Fix = fold `_position_update_banner()` into the surviving `resizeEvent` and delete the dead duplicate.

_No `CONTRIBUTING`; followed the `_UNRELEASED_NOTES` changelog convention. The resizeEvent change is a GUI behaviour fix I couldn''t run-verify headlessly._
