### PR TITLE
fix: guard zipfile metadata_encoding for Python 3.10 compatibility

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -44,6 +44,12 @@ def _open_zip_utf8(zip_path) -> "zipfile.ZipFile":
     raises at open, and we fall back to the cp437 default so those
     archives keep working exactly as before.
     """
+    if sys.version_info < (3, 11):
+        # metadata_encoding was added in Python 3.11; on 3.10 it raises
+        # TypeError (not UnicodeDecodeError), which the handler below
+        # would not catch. Fall back to zipfile's cp437 default (the
+        # documented pre-3.11 behaviour) so imports keep working on 3.10.
+        return zipfile.ZipFile(zip_path)
     try:
         return zipfile.ZipFile(zip_path, metadata_encoding="utf-8")
     except UnicodeDecodeError:

--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>CDUMM no longer crashes when importing a .zip mod on Python 3.10.</b> The zip reader requested a UTF-8 filename-decoding option that only exists on Python 3.11 and newer, so on 3.10 (still a supported version) every .zip import failed with an unhandled error before the mod could load. That option is now used only where the running Python provides it, with a clean fallback on 3.10.",
 ]
 
 CHANGELOG = [

--- a/tests/test_open_zip_utf8_py310.py
+++ b/tests/test_open_zip_utf8_py310.py
@@ -1,0 +1,35 @@
+"""_open_zip_utf8 must not crash on Python 3.10.
+
+zipfile's ``metadata_encoding=`` parameter only exists on Python 3.11+.
+The helper used to pass it unconditionally and guard only against
+UnicodeDecodeError, so on 3.10 -- a supported version per pyproject's
+``requires-python = ">=3.10"`` -- every .zip import raised an uncaught
+TypeError at ZipFile construction, before any name was decoded. This
+opens a real archive (with a non-ASCII member name, the case
+metadata_encoding targets) and asserts the helper returns a usable
+ZipFile on the running interpreter.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from cdumm.engine.import_handler import _open_zip_utf8
+
+
+def test_open_zip_utf8_opens_archive_on_any_supported_python(tmp_path: Path) -> None:
+    # Katakana folder/file name built from code points, so this source
+    # file stays pure ASCII while the archived name is genuinely
+    # non-ASCII (the case metadata_encoding is meant to handle).
+    folder = "".join(map(chr, (0x30D5, 0x30A9, 0x30EB, 0x30C0)))
+    stem = "".join(map(chr, (0x30C6, 0x30AF, 0x30B9, 0x30C1, 0x30E3)))
+    member = f"{folder}/{stem}.dds"
+
+    zp = tmp_path / "mod.zip"
+    with zipfile.ZipFile(zp, "w") as z:
+        z.writestr(member, b"payload")
+
+    with _open_zip_utf8(zp) as zf:
+        names = zf.namelist()
+
+    assert any(n.endswith(".dds") for n in names)


### PR DESCRIPTION
## Problem

`_open_zip_utf8` in `src/cdumm/engine/import_handler.py` calls `zipfile.ZipFile(zip_path, metadata_encoding="utf-8")`.

The `metadata_encoding` parameter was added to `zipfile.ZipFile` in **Python 3.11**. `pyproject.toml` declares `requires-python = ">=3.10"`, so on Python 3.10 this call raises:

```
TypeError: ZipFile.__init__() got an unexpected keyword argument 'metadata_encoding'
```

The surrounding handler only catches `UnicodeDecodeError`, so the `TypeError` propagates. `_open_zip_utf8` is on the import path (used for `.zip` imports and by multi-variant import), so every `.zip` mod import crashes on Python 3.10.

## Fix

Guard the `metadata_encoding` path behind `sys.version_info >= (3, 11)` and fall back to zipfile's cp437 default on 3.10 - the documented pre-3.11 behaviour the helper's own docstring already describes. No behaviour change on 3.11+.

## Test

Adds `tests/test_open_zip_utf8_py310.py`: it opens a real archive with a non-ASCII (katakana) member name and asserts `_open_zip_utf8` returns a usable `ZipFile`. Verified on Python 3.10.12 - the test fails on the old code with the TypeError above (import_handler.py:48) and passes after the guard.

## How it was found

A static-analysis (mypy) sweep flagged the `metadata_encoding` kwarg against the declared minimum Python; confirmed by running the real 3.10 stdlib. A changelog entry was added under `_UNRELEASED_NOTES`.