### PR TITLE
fix: accurate skip message for Format 3 variable-length string fields (stringinfo buffer) (#224)

### DIFF
--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -945,13 +945,25 @@ def _classify_intent(
         # the loaded schema, so the field-not-found path can't tell
         # "really doesn't exist" from "exists but is an array we
         # can't write yet". Hit the raw schema for a better message.
-        raw = _raw_field_metadata(table_name, intent.field)
+        # Try the same name candidates the field_specs lookup used,
+        # so an engine-internal underscore/camelCase name (user
+        # 'buffer' -> schema '_buffer') resolves to its raw metadata
+        # and yields the accurate variable-length message instead of a
+        # misleading "add a field_schema entry" the author cannot act
+        # on for a variable-length field (#224).
+        raw = None
+        raw_name = intent.field
+        for _cand in candidate_names:
+            _meta = _raw_field_metadata(table_name, _cand)
+            if _meta is not None:
+                raw, raw_name = _meta, _cand
+                break
         if raw is not None and (
             raw.get("stream") is None
             or raw.get("type") is None
         ):
             return (
-                f"field '{intent.field}' is a variable-length / "
+                f"field '{raw_name}' is a variable-length / "
                 f"array field (stream=None in schema); writing "
                 f"variable-length data lands in a later phase"
             )

--- a/src/cdumm/gui/changelog.py
+++ b/src/cdumm/gui/changelog.py
@@ -15,6 +15,7 @@ from cdumm.i18n import tr
 # move them up under a real {"version": "X.Y.Z", "date": "..."} block.
 # This keeps __version__ stable until you actually cut a release.
 _UNRELEASED_NOTES: list[str] = [
+    "<b>Clearer status for Format 3 mods that edit variable-length string fields (such as stringinfo <code>buffer</code>).</b> Mods like the Female Armor Module set string fields CDUMM stores as variable-length (engine name <code>_buffer</code>), which CDUMM cannot write yet. They were rejected with a misleading 'add a field_schema entry' instruction that cannot work for a variable-length field. CDUMM now resolves the engine-internal field name and reports the accurate 'variable-length field, lands in a later phase' status, so authors are not sent down a dead end. GitHub #224. The compiled-PAZ variant of these mods still applies today.",
 ]
 
 CHANGELOG = [

--- a/tests/test_format3_varlen_field_message.py
+++ b/tests/test_format3_varlen_field_message.py
@@ -1,0 +1,35 @@
+"""Variable-length fields exported under their DMM (no-underscore) name
+must get the accurate "variable-length, lands in a later phase" skip
+message, not the misleading "add a field_schema entry" one.
+
+GitHub #224: the Female Armor Module ships Format 3 intents on
+stringinfo.pabgb with field "buffer". CDUMM's schema calls that field
+"_buffer" and marks it variable-length (stream=None), so it is dropped
+from the loaded field_specs. The classifier's raw-metadata fallback
+only probed the bare name "buffer" (a miss), so every intent was
+rejected with "no field_schema entry, author needs to add one" -- advice
+that cannot work for a variable-length string field, and that sent a
+community contributor down a dead-end reader_4B schema. The fallback now
+tries the same underscore/camelCase candidates the field_specs lookup
+uses, so "buffer" resolves to "_buffer" and the accurate message fires.
+"""
+from __future__ import annotations
+
+from cdumm.engine.format3_handler import Format3Intent, validate_intents
+
+
+def _buffer_intent(key: int = 2253925176, value: str = "khione_test") -> Format3Intent:
+    return Format3Intent(
+        entry="", key=key, field="buffer", op="set", new=value, old=None
+    )
+
+
+def test_stringinfo_buffer_reports_variable_length_not_field_schema() -> None:
+    res = validate_intents("stringinfo.pabgb", [_buffer_intent()])
+    assert not res.supported
+    assert len(res.skipped) == 1
+    _, reason = res.skipped[0]
+    assert "variable-length" in reason
+    assert "_buffer" in reason
+    assert "field_schema" not in reason
+    assert "add a field_schema" not in reason


### PR DESCRIPTION
Re #224. **Scope: this corrects the misleading skip message; it does not yet make these mods apply** (that needs a variable-length writer — see below).

## What the mod actually does

The Female Armor Module ships Format 3 intents on `stringinfo.pabgb` like:

```json
{ "entry": "", "field": "buffer", "key": 2253925176, "new": "khione1_cd_phw_00_ub_00_0205_u", "op": "set" }
```

(159 of them in the v2.3 "With Icons" file; 85 in the No-Icon file.) These are **variable-length string writes** located by numeric key — `new` is a string, there is no `old`.

## The bug this PR fixes

`buffer` is the DMM export name; CDUMM's schema calls it `_buffer` and marks it variable-length (`stream=None`), so `parser.py` drops it from `field_specs`. `_classify_intent`'s raw-metadata fallback only probed the **bare** name `buffer` (a miss), so every intent was rejected with:

> field 'buffer' has no field_schema entry... Author needs to add a field_schema/stringinfo.json entry mapping 'buffer' to a tid or rel_offset

That advice **cannot work** for a variable-length string (a `tid`/`rel_offset` entry only locates a fixed-width primitive), and it sent a contributor down a dead-end `reader_4B` schema (which is why `_stringKey` came out empty in their dump — treating a variable-length field as fixed 4-byte misaligns everything after it).

The fix probes the same underscore/camelCase candidates the `field_specs` lookup already uses, so `buffer` resolves to `_buffer` and the **accurate** message fires:

> field '_buffer' is a variable-length / array field (stream=None in schema); writing variable-length data lands in a later phase

Verified against the real mod: all 159 intents now report the accurate status. A truly-unknown field still gets the original "no field_schema" message (regression-guarded test included).

## What full enablement needs (the "later phase")

A `stringinfo` native writer that parses the record `[_key u32, _isBlocked u8, _buffer (length-prefixed string), _stringKey u32]`, rewrites `_buffer`, and rebuilds the table + PABGH offset index (records change length), with a byte-perfect round-trip guard against vanilla `stringinfo.pabgb` — the same bar the iteminfo/skill writers meet. Happy to take that on as a follow-up if it's wanted.

## Workaround today

The compiled-PAZ variant of these mods (e.g. the v2.3 "With Icons" `0036/0.paz`) applies normally — the Format 3 path is the only one affected.