### PR TITLE
docs: README housekeeping + close already-fixed issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 
 ---
 
-## New in v3.2.9
+## What's New
+
+CDUMM ships frequent updates. For the complete per-version history, see the [Releases](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/releases) page (the in-app updater also shows release notes after each update). Recent highlights:
 
 - **Buff mods now apply.** Field-name `.field.json` mods that target `buffinfo.pabgb` (NoCooldownForALLItems, Double Resource Buff, etc.) used to import cleanly and then quietly do nothing in game. CDUMM now decodes the actual on-disk layout instead of relying on a structurally wrong schema, and a 4185-intent test mod goes from 0% applying to 100%. If you installed any buffinfo `.field.json` mod on an older build, run Settings > Fix Everything before re-applying because the old code was silently corrupting unrelated bytes.
 - **SKIPPED badge surfaces partial-apply state (v3.2.9 series).** When a game patch drifts a mod's bytes off, the card shows a yellow pill with the dropped patch count and a tooltip naming each affected file. Right-click > Reimport from source clears it. Active and SKIPPED never both show; one mod is either fully active or fully off.


### PR DESCRIPTION
## Housekeeping

**README:** the `## New in v3.2.9` heading implied v3.2.9 was the current release, but CDUMM now ships v3.4.1, so that section was perpetually stale. Replaced the version-pinned heading with an evergreen **What's New** + a link to the Releases page (always current), and kept the existing highlights as "recent highlights." No content removed.

**Stale issues:** while triaging the tracker I found several issues that are already fixed in shipped releases but were never closed. Closing them here as housekeeping — evidence is in a per-issue comment I left on each. Feel free to drop any `Closes` line you'd rather keep open.

- Closes #169 — self-update partial-exe crash, fixed v3.3.12 (`.part` + atomic rename)
- Closes #170 — update-download UI freeze, fixed via the `_UpdateDLDispatcher` main-thread routing (regression test `test_update_dl_dispatcher_thread_affinity`)
- Closes #174 — female-armor "31 bytes don't match", reporter self-resolved via Steam file-verify (version-mismatch guard working as intended)
- Closes #186 — launch fail on 1.09+, fixed v3.3.19 (Game-exe / skip-Steam launch option), reporter confirmed "issue solved"
- Closes #203 — configurable mods vanish when re-picking options, fixed v3.4.1
- Closes #205 — Remove ReShade from inside CDUMM, added v3.4.1
- Closes #218 — large-mod apply cut off partway, fixed v3.4.1 (stderr-heartbeat watchdog)