### PR TITLE
fix(#225): name the mod behind a 'Missing directory' verification issue

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -99,6 +99,29 @@ class _UpdateDLDispatcher(QObject):
             logger.warning("update-dl dispatcher failed raised: %s", e)
 
 
+def _papgt_dir_owners(conn):
+    """Map each modded top-level directory (e.g. ``"0123"``) to the set of
+    mod names that write into it.
+
+    Used by the post-apply verification so a "Missing directory NNNN" issue
+    can name the mod that left the dangling PAPGT entry instead of the bare
+    ``PAPGT`` category tag (GitHub #225). Disabled mods are included on
+    purpose: a missing directory is almost always the directory of a mod the
+    user just disabled, whose overlay was removed while its PAPGT index entry
+    lingered, so an enabled-only query would never name it.
+    """
+    owners = {}
+    for fp, mod_name in conn.execute(
+        "SELECT DISTINCT md.file_path, m.name "
+        "FROM mod_deltas md JOIN mods m ON md.mod_id = m.id "
+        "WHERE md.file_path NOT LIKE 'meta/%'"
+    ).fetchall():
+        parts = fp.split("/")
+        if len(parts) >= 2 and parts[0].isdigit():
+            owners.setdefault(parts[0], set()).add(mod_name)
+    return owners
+
+
 def _quiet_qprocess(proc) -> None:
     """Suppress the brief console window flash when ``QProcess`` spawns
     a Windows subprocess.
@@ -6371,6 +6394,9 @@ class CdummWindow(FluentWindow):
         from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
 
         issues = []
+        # GitHub #225: map dirs -> owning mod so a 'Missing directory'
+        # issue can name the mod (the dialog promises a mod name).
+        dir_owners = _papgt_dir_owners(self._db.connection)
 
         # 1. Check PAPGT hash
         papgt_path = self._game_dir / "meta" / "0.papgt"
@@ -6400,11 +6426,13 @@ class CdummWindow(FluentWindow):
                                 issues.append(("PAPGT", f"{dir_name} PAMT hash mismatch"))
                         elif not (self._game_dir / dir_name).exists():
                             # Skip vanilla placeholder dirs (< 0036) that don't exist on disk
+                            _owners = dir_owners.get(dir_name)
+                            _src = ", ".join(sorted(_owners)) if _owners else "PAPGT"
                             try:
                                 if int(dir_name) >= 36:
-                                    issues.append(("PAPGT", f"Missing directory {dir_name}"))
+                                    issues.append((_src, f"Missing directory {dir_name}"))
                             except (ValueError, TypeError):
-                                issues.append(("PAPGT", f"Missing directory {dir_name}"))
+                                issues.append((_src, f"Missing directory {dir_name}"))
 
         # 2. Get all files modified by enabled mods
         modded_files = self._db.connection.execute(

--- a/tests/test_papgt_missing_dir_names_mod.py
+++ b/tests/test_papgt_missing_dir_names_mod.py
@@ -1,0 +1,49 @@
+"""GitHub #225 ("All Color Tabs Unlocked", nexus 2281): disabling a PAPGT mod
+can leave a dangling "Missing directory NNNN" entry in meta/0.papgt. The
+post-apply verification dialog told the user "the mod name in brackets
+indicates the likely cause" while the bracket only ever showed the bare
+"PAPGT" category tag -- never a mod name.
+
+_papgt_dir_owners maps each modded top-level directory to the mod(s) that
+write into it, INCLUDING disabled mods (the dangling dir is almost always a
+just-disabled mod's), so the dialog can name the responsible mod.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE mods (id INTEGER PRIMARY KEY, name TEXT, enabled INTEGER)")
+    conn.execute("CREATE TABLE mod_deltas (mod_id INTEGER, file_path TEXT)")
+    return conn
+
+
+def test_missing_dir_names_the_owning_mod_even_when_disabled():
+    from cdumm.gui.fluent_window import _papgt_dir_owners
+    conn = _db()
+    # disabled mod -- the #225 scenario (user just disabled it)
+    conn.execute("INSERT INTO mods VALUES (1, 'All Color Tabs Unlocked', 0)")
+    conn.execute("INSERT INTO mod_deltas VALUES (1, '0207/0.paz')")
+    conn.execute("INSERT INTO mod_deltas VALUES (1, '0207/0.pamt')")
+    assert _papgt_dir_owners(conn).get("0207") == {"All Color Tabs Unlocked"}
+
+
+def test_meta_and_nondigit_dirs_are_ignored():
+    from cdumm.gui.fluent_window import _papgt_dir_owners
+    conn = _db()
+    conn.execute("INSERT INTO mods VALUES (1, 'M', 1)")
+    conn.execute("INSERT INTO mod_deltas VALUES (1, 'meta/0.papgt')")
+    conn.execute("INSERT INTO mod_deltas VALUES (1, 'bin64/plugin.asi')")
+    assert _papgt_dir_owners(conn) == {}
+
+
+def test_multiple_mods_sharing_a_dir_are_all_named():
+    from cdumm.gui.fluent_window import _papgt_dir_owners
+    conn = _db()
+    conn.execute("INSERT INTO mods VALUES (1, 'A', 1)")
+    conn.execute("INSERT INTO mods VALUES (2, 'B', 0)")
+    conn.execute("INSERT INTO mod_deltas VALUES (1, '0099/0.paz')")
+    conn.execute("INSERT INTO mod_deltas VALUES (2, '0099/0.pamt')")
+    assert _papgt_dir_owners(conn).get("0099") == {"A", "B"}


### PR DESCRIPTION
## #225 — "Missing directory" verification never names a mod

Disabling certain PAPGT mods (e.g. [All Color Tabs Unlocked](https://www.nexusmods.com/crimsondesert/mods/2281)) can leave a dangling directory entry in `meta/0.papgt`. The post-apply verification correctly flags it as `Missing directory NNNN`, but the dialog says *"the mod name in brackets indicates the likely cause"* while every PAPGT issue was tagged with the bare `PAPGT` category — so the bracket never showed a mod name. That's the empty/unhelpful bracket the reporter hit.

**Fix:** `_papgt_dir_owners()` maps each modded top-level directory to the mod(s) that write into it, **including disabled mods** — the dangling directory is almost always the directory of a mod the user just disabled, whose overlay was removed while its PAPGT index entry lingered, so an enabled-only lookup would never name it. The "Missing directory" issue now carries that mod name into the bracket.

Adds `tests/test_papgt_missing_dir_names_mod.py` (3 cases: disabled-mod ownership, meta/non-digit dirs ignored, multiple mods sharing a dir).

> The deeper root cause — disable leaving the PAPGT entry behind, which is also why a Steam re-verify fixes it — ties into the active `meta/0.papgt` corruption work under #191, so I kept this PR to the user-facing "name the mod" fix and left that to you.