### PR TITLE
fix: detect Character Creator 0.pamt body-type variants (#189)

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -1529,14 +1529,16 @@ def _find_loose_file_candidates(path: Path, max_depth: int = 5) -> list[dict]:
         if base_key in seen_bases:
             return None
         # Pattern 5: mod.json at this folder + 2+ sibling subfolders
-        # each carrying a NNNN/0.paz layout. Surface one candidate
-        # per sibling so the GUI's variant picker fires. Used by
-        # Character Creator (mod 837): CharacterCreator/mod.json
-        # alongside HumanFemale/0036/0.paz, GoblinMale/0036/0.paz,
-        # etc. Must run BEFORE Pattern 2 because Pattern 2 would
-        # otherwise match the top-level mod.json + sibling json/asi
-        # files at root and stop the walk before the body-type
-        # subfolders get a chance.
+        # each carrying a NNNN/0.paz OR NNNN/0.pamt layout. Surface
+        # one candidate per sibling so the GUI's variant picker fires.
+        # Used by Character Creator (mod 837): CharacterCreator/mod.json
+        # alongside HumanFemale/0036/..., GoblinMale/0036/..., etc.
+        # v6.3+ ships each body type as 0036/0.pamt (no 0.paz), so the
+        # marker check accepts either archive form — both are valid game
+        # files per _GAME_FILE_RE (GitHub #189). Must run BEFORE Pattern
+        # 2 because Pattern 2 would otherwise match the top-level
+        # mod.json + sibling json/asi files at root and stop the walk
+        # before the body-type subfolders get a chance.
         mod_json = candidate / "mod.json"
         if mod_json.exists():
             try:
@@ -1564,7 +1566,8 @@ def _find_loose_file_candidates(path: Path, max_depth: int = 5) -> list[dict]:
                             if (d.is_dir()
                                     and d.name.isdigit()
                                     and len(d.name) == 4
-                                    and (d / "0.paz").exists()):
+                                    and ((d / "0.paz").exists()
+                                         or (d / "0.pamt").exists())):
                                 variant_subdirs.append(sub)
                                 break
                     except OSError:

--- a/tests/test_variant_pack_with_modjson_at_root.py
+++ b/tests/test_variant_pack_with_modjson_at_root.py
@@ -110,3 +110,70 @@ def test_normal_single_mod_still_returns_one_variant(tmp_path):
         f"normal Pattern 1 mod must return one candidate; got "
         f"{len(variants)}: {[v['id'] for v in variants]}"
     )
+
+
+def _make_pamt_only_variant_pack(tmp_path: Path) -> Path:
+    """Character Creator 837 as shipped in v6.3+ (GitHub #189).
+
+    The author switched each body-type folder from a packed ``0.paz``
+    to a ``0.pamt`` index plus ``_directory_table.bin`` /
+    ``_file_names.bin`` and a sibling ``meta/0.papgt`` -- there is no
+    ``0.paz`` anywhere. ``0.pamt`` is a valid game file per
+    ``_GAME_FILE_RE`` and each body-type folder imports fine on its own
+    (Pattern 4), so the variant detector must still surface all six.
+    """
+    root = tmp_path / "CharacterCreator"
+    root.mkdir()
+    (root / "mod.json").write_text(
+        '{"modinfo": {"title": "Character Creator", "version": "7.0"}}',
+        encoding="utf-8")
+    (root / "Female Animations.json").write_bytes(b"{}")
+    (root / "Female Rapier and Shield Module.json").write_bytes(b"{}")
+    (root / "CharacterCreatorHead.asi").write_bytes(b"\x00")
+    for variant in ("HumanFemale", "HumanMale", "GoblinFemale",
+                    "GoblinMale", "OrcFemale", "OrcMale"):
+        data_dir = root / variant / "0036"
+        data_dir.mkdir(parents=True)
+        # 0.pamt index only -- NO 0.paz (the v6.3+ packaging change).
+        (data_dir / "0.pamt").write_bytes(b"\x00")
+        (data_dir / "_directory_table.bin").write_bytes(b"\x00")
+        (data_dir / "_file_names.bin").write_bytes(b"\x00")
+        meta_dir = root / variant / "meta"
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "0.papgt").write_bytes(b"\x00")
+    return tmp_path
+
+
+def test_pamt_only_variants_surface(tmp_path):
+    """v6.3+ Character Creator ships each body type as 0036/0.pamt with
+    no 0.paz. All six body types must still surface as variants
+    (GitHub #189). Before the fix the 0.paz-only marker check found
+    zero variant subdirs, Pattern 5 was skipped, only the JSON modules
+    + ASI imported, and the body-type picker never fired -- forcing the
+    reporter to extract and drop each body-type folder by hand."""
+    from cdumm.engine.import_handler import find_loose_file_variants
+
+    _make_pamt_only_variant_pack(tmp_path)
+    variants = find_loose_file_variants(tmp_path)
+
+    ids = sorted(v["id"] for v in variants)
+    expected = sorted([
+        "HumanFemale", "HumanMale", "GoblinFemale",
+        "GoblinMale", "OrcFemale", "OrcMale",
+    ])
+    assert len(variants) == 6, (
+        f"expected 6 pamt-only body-type variants, got {len(variants)}: {ids}"
+    )
+    bodytype_hits = sum(
+        1 for v in variants
+        if any(bt in v["id"] for bt in expected)
+    )
+    assert bodytype_hits == 6, (
+        f"every pamt-only variant must surface its body-type name; "
+        f"got: {ids}"
+    )
+    bases = {Path(v["_base_dir"]).name for v in variants}
+    assert bases == set(expected), (
+        f"each variant's _base_dir must be its body-type subfolder; "
+        f"got: {sorted(bases)}"
+    )


### PR DESCRIPTION
## Problem

Character Creator (Nexus mod 837) ships a `mod.json` wrapper alongside six body-type subfolders — HumanFemale, HumanMale, GoblinFemale, GoblinMale, OrcFemale, OrcMale. Dropping the archive is meant to pop the body-type picker so the user chooses one.

On v6.3+ the picker never appears. Per #189 (xenoi60), the only workaround is to manually extract the archive and drag-and-drop each body-type folder one at a time.

## Root cause

`_find_loose_file_candidates` Pattern 5 detects each variant subfolder by requiring a 4-digit numbered dir that contains **`0.paz`**:

    and (d / "0.paz").exists()):

I extracted the real v7.01 archive: each body type is now `<BodyType>/0036/0.pamt` (+ `_directory_table.bin`, `_file_names.bin`, `meta/0.papgt`) — **no `0.paz`**. So the check finds zero variant subdirs, Pattern 5 is skipped, the mod falls through to Pattern 2 as a single "Character Creator" candidate, and the picker never fires.

`0.pamt` is already a valid game file per the importer's own `_GAME_FILE_RE` (`NNNN/N.paz` **or** `NNNN/N.pamt`) — Pattern 5 was simply stricter than the rest of the importer.

## Fix

Accept either `0.paz` or `0.pamt` as the variant marker.

## Verification

`find_loose_file_variants` on a pamt-only pack mirroring the real v7.01 layout:

| | result |
|---|---|
| before | `1` → `["Character Creator"]` (picker never fires) |
| after | `6` → all body types incl. `HumanFemale` |

- New `test_pamt_only_variants_surface` regression test.
- Existing `0.paz` variant-pack tests still pass (fix is additive).
- 30 import/variant engine tests green.

## Related (not changed here)

The same `0.paz`-only assumption appears in sibling checks (`_has_paz_dirs` for the #34 compound layout, `is_standalone_paz`, `has_standalone_paz`). None is on this mod's import path — `_has_paz_dirs` inspects the dropped folder's *direct* children and CC's numbered dirs are nested under the body-type folders — so they're left untouched to keep this surgical. Flagging in case a future mod ships a single pamt-only body-type folder beside a `.json` sibling.

Closes #189

---

## Housekeeping — also closes #172

#172 ("cdumm crash report") is the self-update GUI freeze already fixed in **v3.3.15** (commit `02ea723`): the three `UpdateDownloadWorker` slots now connect with `QueuedConnection` so the success InfoBar is built on the main thread, plus the `.old` rename-swap so a running `CDUMM3.exe` can be replaced on Windows. Covered by `test_update_dl_dispatcher_thread_affinity` + `test_update_checker_atomic_write` and present in this PR's base (`e9bf230`). The v3.3.15 release commit referenced #172 without a closing keyword, so it stayed open — tidying it up here.

Closes #172

---

## Housekeeping — also closes #181

#181 ("v3 field.json won't apply") — mod 2508 `Mask Only QoL Suite` imported with a **0-byte iteminfo delta** on v3.3.15. Reproduced against current `master`: **2688/5009** Format-3 iteminfo intents now validate and apply. The 0-byte delta was the pre-2026-06-10 gap where the iteminfo whole-table writer (`build_iteminfo_intent_change`) wasn't wired into the apply path, plus the `max_stack_count` offset fix — both shipped after the reporter's v3.3.15 build. Apply side verified resolved; the residual "applies but crashes on startup" socket case stays tracked in #191.

Closes #181

---

## Housekeeping — also closes #194

#194 ("Check for Mod Updates not working") had two causes. The original (GabrielNunesIT, v3.3.16) was a real bug — the check found updates then a follow-up pass discarded them — fixed in **v3.3.19** (`a9a2ae8`). The v3.4.0 recurrence (HaZt-Panda) was mods imported with no `nexus_mod_id`: the checker has nothing to look them up against, so they silently stay unflagged. Adding the Nexus links restores tracking — both reporters resolved.

Closes #194

---

## Housekeeping — also closes #224

#224 ("New female armor module mod does not install") — the Female Armor Module edits variable-length string entries in `stringinfo.pabgb` that CDUMM was silently skipping. Fixed in **v3.4.2** (`3424e2e` — the variable-length `_buffer` writer — plus PR #227 for the accurate skip message), present in this PR's base (`e9bf230`). Stale-open after the fix shipped; closing it here.

Closes #224