### PR TITLE
chore: add community-health files (LICENSE, SECURITY, CONTRIBUTING, CoC, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report something in CDUMM that's broken or behaving wrong.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        **Please generate a bug report inside CDUMM and paste it below.** It
+        captures your app version, game version, storage layout, installed
+        mods, and the recent log — which is almost always what's needed to
+        diagnose the problem.
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: CDUMM bug report
+      description: Paste the full report from CDUMM's built-in report generator.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: mod
+    attributes:
+      label: Which mod, and its Nexus page?
+      description: >
+        Name the specific mod and link its Nexus page. "A mod won't apply" or
+        "updates don't work" is very hard to chase down — one concrete example
+        is what actually gets fixed.
+      placeholder: "Example: Bigger Minimap — https://www.nexusmods.com/crimsondesert/mods/275"
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What did you do, and what went wrong?
+      description: >
+        Steps to reproduce, what you expected, and what actually happened.
+        Exact error text (or a screenshot) helps a lot.
+    validations:
+      required: true
+  - type: checkboxes
+    id: environment
+    attributes:
+      label: Environment checks
+      description: >
+        The report's own TL;DR flags these — they break mod installs and are
+        not CDUMM bugs. Please rule them out first.
+      options:
+        - label: CDUMM is **not** running as administrator
+        - label: The game is **not** installed under `Program Files`
+        - label: The game exe does **not** have the "Run as administrator" compatibility flag set
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I'm on the latest CDUMM release
+          required: true
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,32 @@ body:
         captures your app version, game version, storage layout, installed
         mods, and the recent log — which is almost always what's needed to
         diagnose the problem.
+  - type: dropdown
+    id: problem-type
+    attributes:
+      label: Type of problem
+      description: Pick the closest match — it helps route the issue.
+      options:
+        - A mod won't install / only partly applies
+        - Install or drag-and-drop fails
+        - Game crashes (launch or in-game)
+        - Wrong or missing result in-game
+        - Update check / Nexus
+        - Interface / other
+    validations:
+      required: true
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: Game install source
+      options:
+        - Steam
+        - Xbox / Microsoft Store (Game Pass)
+        - Epic Games Store
+        - Standalone / other
+        - Not sure
+    validations:
+      required: false
   - type: textarea
     id: bug-report
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Releases & changelog
+    url: https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/releases
+    about: Check the latest release and per-version notes — your issue may already be fixed.
+  - name: Support CDUMM (Ko-fi)
+    url: https://ko-fi.com/kindiboy
+    about: CDUMM is free. If it's useful to you, a tip is appreciated.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: FAQ — read this first
+    url: https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/236
+    about: Mods not applying, install fails, crashes, updates — the most common questions, answered.
   - name: Releases & changelog
     url: https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/releases
     about: Check the latest release and per-version notes — your issue may already be fixed.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,47 @@
+name: Crash report
+description: CDUMM crashed, or the game crashes after applying mods.
+title: "[Crash]: "
+labels: ["crash"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For **game-launch** crashes after applying mods, the pinned **FAQ**
+        covers the two usual causes (a missing `meta/` file, or a snapshot taken
+        before a game update). Please try those first, then file this if it
+        still crashes.
+  - type: dropdown
+    id: when
+    attributes:
+      label: When does it crash?
+      options:
+        - CDUMM crashes on startup
+        - CDUMM crashes during import or Apply
+        - Game crashes at launch (after applying mods)
+        - Game crashes in-game
+    validations:
+      required: true
+  - type: textarea
+    id: report
+    attributes:
+      label: CDUMM bug report (includes crash trace)
+      description: >
+        Paste the full report from CDUMM's generator. If CDUMM itself crashed,
+        its report includes the crash trace from the previous session.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: What were you doing when it crashed?
+    validations:
+      required: false
+  - type: checkboxes
+    id: tried
+    attributes:
+      label: Already tried
+      options:
+        - label: Verified game files via Steam
+        - label: Rescanned game files in CDUMM and re-applied
+        - label: I'm on the latest CDUMM release

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest an improvement or a new capability for CDUMM.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that's awkward or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like CDUMM to do?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Anything you've tried or considered instead.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,20 @@ description: Suggest an improvement or a new capability for CDUMM.
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of CDUMM does this touch?
+      options:
+        - Mod install / apply
+        - Conflict handling & load order
+        - Updates / Nexus integration
+        - Backups & safety
+        - Interface / usability
+        - Other
+    validations:
+      required: false
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/mod_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/mod_compatibility.yml
@@ -1,0 +1,71 @@
+name: Mod won't install or apply
+description: A specific mod fails to install, or only part of it applies (often a game-version mismatch).
+title: "[Mod]: "
+labels: ["mod-compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when **one specific mod** doesn't install or only partly applies.
+
+        If CDUMM showed a "patches skipped" warning after Apply, that usually
+        means the mod was built for a different game version — see the pinned
+        **FAQ**. Paste the skipped-patch text below so we can confirm.
+  - type: input
+    id: mod
+    attributes:
+      label: Mod name + Nexus page
+      placeholder: "Example: Even Faster Vanilla Animations Trimmer — https://www.nexusmods.com/crimsondesert/mods/774"
+    validations:
+      required: true
+  - type: input
+    id: mod-version
+    attributes:
+      label: Mod version
+    validations:
+      required: false
+  - type: dropdown
+    id: mod-type
+    attributes:
+      label: Mod type (if known)
+      options:
+        - PAZ (game data / archive)
+        - ASI plugin
+        - JSON / Format 3 patch
+        - Preset / configurable
+        - Not sure
+    validations:
+      required: false
+  - type: textarea
+    id: skipped
+    attributes:
+      label: Skipped-patch / error text
+      description: Paste the post-Apply warning (the "expected … got …" lines) or any error CDUMM showed.
+      render: text
+    validations:
+      required: false
+  - type: input
+    id: game-version
+    attributes:
+      label: Your game version
+      description: Shown in CDUMM's bug report (Game Version Hash) or via Steam.
+    validations:
+      required: false
+  - type: dropdown
+    id: other-manager
+    attributes:
+      label: Does the mod work in another manager (e.g. DMM) on the same game version?
+      options:
+        - Haven't tried
+        - Yes, it works there
+        - No, it fails there too
+    validations:
+      required: false
+  - type: textarea
+    id: report
+    attributes:
+      label: CDUMM bug report
+      description: Paste the full report from CDUMM's built-in generator (it scrubs your Windows username).
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,23 @@
+name: Question / how-to
+description: Ask how to do something, or whether a behavior is expected.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Many common questions are answered in the pinned **FAQ** — please check
+        it first. If it's not covered there, ask away.
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Before asking
+      options:
+        - label: I checked the pinned FAQ and didn't find the answer
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Thanks for contributing to CDUMM! Keep PRs surgical and on-topic. -->
+
+## What & why
+
+<!-- What does this change, and why? Link the issue it addresses. -->
+
+Fixes #
+
+## Changes
+
+<!-- A brief list of the changes in this PR. -->
+
+-
+
+## Verification
+
+<!-- How did you test this? Paste relevant output if useful. -->
+
+- [ ] `python -m pytest` passes
+- [ ] `ruff check .` is clean
+- [ ] Added or updated a regression test (fails before, passes after)
+
+## Notes
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, screenshots. -->

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,47 @@
+# Dedicated issue labels for CDUMM triage (in addition to GitHub's defaults
+# such as bug / enhancement / question / documentation / duplicate / wontfix).
+#
+# These can't be created through a pull request directly — labels live in repo
+# settings, not in files. A maintainer can apply this set either way:
+#   • run the `gh label create` commands listed in this PR's description, or
+#   • point a label-sync action (e.g. EndBug/label-sync, additive / skip-delete)
+#     at this file.
+#
+# Colors are hex without the leading '#'.
+
+- name: mod-compatibility
+  color: "5319e7"
+  description: A specific mod won't install or only partly applies
+- name: version-drift
+  color: "b60205"
+  description: Mod built for a different game version; byte offsets moved
+- name: install-failure
+  color: "d93f0b"
+  description: Install / drag-and-drop / Apply fails (often admin or Program Files)
+- name: crash
+  color: "e11d21"
+  description: CDUMM or the game crashes
+- name: update-check
+  color: "0e8a16"
+  description: Nexus update detection / linking
+- name: paz
+  color: "1d76db"
+  description: PAZ (game data / archive) mod
+- name: asi
+  color: "fbca04"
+  description: ASI plugin / loader
+- name: format3
+  color: "c5def5"
+  description: JSON / Format 3 (.field.json) mods
+- name: ui
+  color: "bfd4f2"
+  description: Interface / usability
+- name: needs-info
+  color: "d4c5f9"
+  description: Waiting on more detail from the reporter (repro / bug report)
+- name: not-a-bug
+  color: "ededed"
+  description: Working as intended (e.g. a mismatched patch was safely skipped)
+- name: upstream-game
+  color: "fef2c0"
+  description: Caused by a game update, not by CDUMM

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples include using an official email address, posting via an official social
+media account, or acting as an appointed representative at an online or offline
+event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer responsible for enforcement (@faisalkindi)
+via GitHub. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to CDUMM
+
+Thanks for your interest in improving the Crimson Desert Ultimate Mods Manager.
+Bug reports, fixes, and well-scoped features are all welcome.
+
+## Reporting bugs
+
+CDUMM has a built-in report generator — use it. It captures your app version,
+game version, storage layout, installed mods, and the recent log, which is
+almost always what's needed to diagnose an issue.
+
+1. In CDUMM, generate a bug report (the report screen / "Copy bug report").
+2. Open a [bug report issue](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/new/choose)
+   and paste it in.
+3. **Include one concrete example.** "Updates don't work" or "a mod won't
+   apply" is hard to chase; "mod X (Nexus page link), version Y, shows error Z"
+   is actionable. Name the specific mod, link its Nexus page, and say exactly
+   what goes wrong.
+
+Before filing, check the report's own TL;DR — it flags common environment
+problems (running as administrator, the game under `Program Files`, the
+`RUNASADMIN` compatibility flag) that break mod installs and aren't CDUMM bugs.
+
+## Development setup
+
+CDUMM is a Python application built on PySide6.
+
+```bash
+git clone https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager.git
+cd CrimsonDesert-UltimateModsManager
+python -m venv .venv
+# Windows:  .venv\Scripts\activate
+# Linux/macOS:  source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Run the app from source (the entry point is `src/cdumm/main.py`):
+
+```bash
+python src/cdumm/main.py
+```
+
+## Tests and linting
+
+Please run the test suite and the linter before opening a PR:
+
+```bash
+python -m pytest        # test suite (tests/)
+ruff check .            # lint (line length 100, target py310)
+```
+
+Notes:
+
+- Windows is the primary platform and the CI (`windows-tests`) runs the suite
+  there. Linux/macOS have their own platform tests.
+- A few full-table apply tests are heavy and marked `slow`; the fast suite runs
+  with `-m "not slow"`.
+- New fixes should come with a **regression test** that fails before the change
+  and passes after. The `tests/` directory has many small, focused examples to
+  mirror.
+
+## Pull requests
+
+1. Fork the repo and create a branch off `master`
+   (e.g. `fix/short-description` or `feat/short-description`).
+2. Keep changes surgical and on-topic — one logical change per PR. Match the
+   surrounding code style rather than reformatting unrelated code.
+3. Describe **what** broke and **why** your change fixes it. Link the issue it
+   addresses (`Fixes #123`) and include the verification you ran.
+4. Make sure `pytest` and `ruff` pass.
+
+## Code layout
+
+- `src/cdumm/engine/` — import, apply, delta, and format handlers (the core).
+- `src/cdumm/archive/` — PAZ/PAMT/PAPGT archive and overlay handling.
+- `src/cdumm/gui/` — the PySide6 / Fluent-Widgets interface.
+- `src/cdumm/storage/` — database, config, game discovery.
+- `tests/` — pytest suite.
+- `src/cdumm/_vendor/` — vendored third-party code (keeps its own license; see
+  the `LICENSE_MPL2` files there). Don't relicense vendored code.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the same
+license as the project. See [`LICENSE`](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 faisalkindi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+Thanks for helping keep CDUMM and its users safe.
+
+## Supported versions
+
+CDUMM ships frequent releases and updates itself in place, so security fixes
+land in the **latest release only**. Always update to the newest
+[release](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/releases/latest)
+before reporting — older builds are not patched separately.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | ✅ |
+| Anything older | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.** Public issues are
+visible to everyone and can expose users before a fix is out.
+
+Instead, use GitHub's private reporting:
+
+1. Go to the repository's **Security** tab → **Report a vulnerability**
+   ([Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)).
+2. Describe the issue with enough detail to reproduce it (see below).
+
+If private reporting is not enabled, open a minimal issue that says only *"I'd
+like to report a security issue privately"* — without details — and wait for a
+private channel. Don't post the specifics publicly.
+
+### What to include
+
+- The CDUMM version and your OS.
+- A clear description of the vulnerability and its impact.
+- Step-by-step reproduction (and a proof-of-concept if you have one).
+- Any relevant logs, with secrets such as your Nexus API key redacted.
+
+### What to expect
+
+CDUMM is maintained by a small team. Reports are handled on a best-effort
+basis — expect an initial acknowledgement within a few days, and please allow
+reasonable time for a fix to ship before any public disclosure.
+
+## Scope
+
+CDUMM is a desktop application that, by design, touches several sensitive
+areas. Reports in these areas are in scope:
+
+- **Self-updater** — the download-and-swap flow that replaces the running
+  executable (e.g. tampering, downgrade, or unsigned-payload concerns).
+- **ASI loader injection** — the proxy DLL CDUMM installs into the game's
+  `bin64` directory.
+- **Mod import / apply** — handling of untrusted mod archives (`.zip`, `.7z`,
+  `.rar`) and crafted game-table payloads (path traversal, zip-slip, archive
+  bombs, memory-safety issues in parsers).
+- **Nexus integration** — storage and handling of the Nexus API key and the
+  `nxm://` download handler.
+- **Local data** — the CDUMM database, snapshots, and backups under the game
+  directory.
+
+### Out of scope
+
+- The Crimson Desert game itself, its anti-cheat, or any publisher service.
+- Third-party mods and their content. CDUMM applies mods; it does not vouch
+  for them.
+- Nexus Mods, Steam, Epic, Xbox, or other external platforms.
+- Issues that require an already-compromised machine or physical access.
+
+## A note for users
+
+CDUMM modifies local game files through an overlay and installs an ASI loader.
+Only download CDUMM from the official
+[Releases](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/releases)
+page, and only install mods from sources you trust.


### PR DESCRIPTION
## What

The repo currently has no LICENSE, security policy, contributing guide, code of conduct, or issue/PR templates — just the README and CI workflows. This adds a standard community-health set. The files are independent, so take or leave any of them. **No code changes — docs/meta only.**

## Files

- **`SECURITY.md`** — private vulnerability reporting via GitHub Security Advisories, a supported-versions note (latest only, since CDUMM self-updates), and scope tailored to CDUMM's actual surface: the self-updater, the ASI loader injection, untrusted mod-archive handling, and the Nexus API key.
- **`CONTRIBUTING.md`** — dev setup (`pip install -e ".[dev]"`, run `src/cdumm/main.py`), `pytest` + `ruff`, the surgical-PR + regression-test expectations, and bug-report guidance that mirrors what you keep having to ask reporters for (a concrete mod + Nexus link).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 (enforcement contact set to @faisalkindi — change as you like).
- **`.github/ISSUE_TEMPLATE/`** — a structured **bug report** form that requires the in-app report paste plus an environment checklist (admin / Program Files / RUNASADMIN), so "bug report" issues arrive actionable; plus a feature-request form and a config linking Releases + Ko-fi.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — what/why, changes, verification checklist.

## ⚠️ The LICENSE is a proposal — your call

The repo has no license, which legally means "all rights reserved." I included an **MIT `LICENSE` as a suggestion only** — the license is entirely your decision as the author:

- Swap MIT for whatever you prefer, or drop the file.
- The copyright line reads `2026 faisalkindi` — change it to your name/handle and the right year.
- The vendored `src/cdumm/_vendor/*` code keeps its own MPL-2.0 license; MIT on the project is compatible (MPL-2.0 is per-file copyleft).

Happy to split the LICENSE into its own PR if you'd rather review it separately.