### PR TITLE
Log skipped byte-patches so bug reports record them (#222)

### DIFF
--- a/src/cdumm/engine/apply_engine.py
+++ b/src/cdumm/engine/apply_engine.py
@@ -93,6 +93,50 @@ def persist_skip_summary(
     db_connection.commit()
 
 
+def log_patch_skips(
+    patch_skips: list[dict], limit: int = 15,
+) -> tuple[list[str], int]:
+    """Format skipped byte-patches, log them at WARNING, and return
+    ``(lines, overflow)`` so the caller can reuse the same lines for the
+    post-apply InfoBar.
+
+    ``lines`` holds at most ``limit`` ``"  - <label> (expected <hex>,
+    got <hex>, <reason>)"`` strings; ``overflow`` is the count beyond it.
+    Hex fields are truncated to 32 chars (+ a byte count) so whole-table
+    changes — whose expected/actual can be multiple MB of hex — don't
+    blow up the message (falobos76, #191 retest).
+
+    Issue #222 (falobos76): the skip detail previously reached only the
+    transient InfoBar, so a saved bug report — which tails cdumm.log —
+    had no record of WHICH patches were skipped and couldn't be
+    diagnosed without the user's screenshot. Logging the same lines the
+    InfoBar shows closes that gap and keeps the two sinks in lock-step.
+    """
+    def _short_hex(h: str) -> str:
+        h = h or ""
+        if len(h) <= 32:
+            return h
+        return f"{h[:32]}... ({len(h) // 2:,} bytes)"
+
+    lines = [
+        f"  - {s.get('label') or '(unnamed)'}"
+        f" (expected {_short_hex(s.get('expected'))}, "
+        f"got {_short_hex(s.get('actual'))}, "
+        f"{s.get('reason')})"
+        for s in patch_skips[:limit]
+    ]
+    overflow = max(0, len(patch_skips) - limit)
+    logger.warning(
+        "%d JSON patch(es) skipped (expected bytes don't match the "
+        "current game; mod likely built for an older version):",
+        len(patch_skips))
+    for ln in lines:
+        logger.warning("%s", ln.strip())
+    if overflow:
+        logger.warning("  ... and %d more", overflow)
+    return lines, overflow
+
+
 def invalidate_apply_fingerprint(
     game_dir: Path,
     config: "Config | None" = None,
@@ -1948,19 +1992,10 @@ class ApplyWorker(QObject):
                         # them raw turned the post-apply warning into
                         # an unreadable hex wall (falobos76, #191
                         # retest). Show a short prefix + total size.
-                        def _short_hex(h: str) -> str:
-                            h = h or ""
-                            if len(h) <= 32:
-                                return h
-                            return f"{h[:32]}... ({len(h) // 2:,} bytes)"
-                        skip_lines = [
-                            f"  - {s.get('label') or '(unnamed)'}"
-                            f" (expected {_short_hex(s.get('expected'))}, "
-                            f"got {_short_hex(s.get('actual'))}, "
-                            f"{s.get('reason')})"
-                            for s in patch_skips[:15]
-                        ]
-                        more = max(0, len(patch_skips) - 15)
+                        # Shared formatter also writes these lines to the
+                        # log at WARNING so a saved bug report records them
+                        # (issue #222) — not just the transient InfoBar.
+                        skip_lines, more = log_patch_skips(patch_skips)
                         suffix = (f"\n  ... and {more} more"
                                   if more else "")
                         msg = (

--- a/tests/test_patch_skip_logging.py
+++ b/tests/test_patch_skip_logging.py
@@ -1,0 +1,74 @@
+"""Issue #222 (falobos76): when CDUMM skips byte-patches whose original
+bytes don't match the current game (version drift), the skip detail must
+be written to the log — not only the transient post-apply InfoBar — so a
+saved bug report (which tails cdumm.log) records WHICH patches were
+skipped and can be diagnosed without the user's screenshot.
+
+Pins the contract of ``apply_engine.log_patch_skips``: it logs every
+(hex-truncated) skip line at WARNING and returns the same lines the
+InfoBar reuses, so the pop-up and the report can't drift apart.
+"""
+from __future__ import annotations
+
+import logging
+
+from cdumm.engine.apply_engine import log_patch_skips
+
+_LOGGER = "cdumm.engine.apply_engine"
+
+
+def _skip(label, expected="1F1C0000", actual="74830000",
+          reason="byte mismatch at offset 36720"):
+    return {"label": label, "expected": expected, "actual": actual,
+            "reason": reason}
+
+
+def test_skips_are_logged_at_warning(caplog):
+    skips = [_skip("[KLIFF TELEPORT] starting animations"),
+             _skip("[KLIFF TELEPORT] ending animations")]
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        lines, overflow = log_patch_skips(skips)
+
+    assert overflow == 0
+    assert len(lines) == 2
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    # the per-patch detail the pop-up shows must now be in the log
+    assert "[KLIFF TELEPORT] starting animations" in text
+    assert "[KLIFF TELEPORT] ending animations" in text
+    assert "expected 1F1C0000" in text
+    assert "2 JSON patch(es) skipped" in text
+
+
+def test_returned_lines_match_logged_lines(caplog):
+    """The InfoBar reuses the returned lines; they must be exactly what
+    was logged so the pop-up and the bug report can't drift apart."""
+    skips = [_skip(f"patch {i}") for i in range(3)]
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        lines, _ = log_patch_skips(skips)
+    logged = [r.getMessage() for r in caplog.records]
+    for ln in lines:
+        assert ln.strip() in logged
+
+
+def test_whole_table_hex_is_truncated(caplog):
+    """Whole-table changes carry multi-MB expected/actual hex; the log
+    line must truncate it, not dump the whole blob (falobos76, #191)."""
+    big = "AB" * 5000  # stands in for a whole-table expected/actual blob
+    skips = [_skip("iteminfo whole-table", expected=big, actual=big,
+                   reason="whole-table mismatch")]
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        lines, _ = log_patch_skips(skips)
+    assert big not in lines[0]
+    assert "..." in lines[0] and "bytes)" in lines[0]
+    # the full blob must not appear in any log record either
+    assert all(big not in r.getMessage() for r in caplog.records)
+
+
+def test_overflow_beyond_limit(caplog):
+    skips = [_skip(f"patch {i}") for i in range(20)]
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        lines, overflow = log_patch_skips(skips, limit=15)
+    assert len(lines) == 15
+    assert overflow == 5
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "... and 5 more" in text


### PR DESCRIPTION
﻿## What

When CDUMM skips byte-patches whose `original` bytes don't match the current game (a mod built for an older game version), the per-patch skip detail (`label`, `expected`, `actual`, `reason`) only reached the transient post-apply InfoBar. It was **not** written to `cdumm.log` or the activity log, so a saved bug report — which tails `cdumm.log` — had no record of *which* patches were skipped. A report alone couldn't be diagnosed without the user's screenshot.

Surfaced in #222 (falobos76). Note the install behavior itself is correct: skipping a patch whose expected bytes aren't present is the intended file-protection (writing them would corrupt the sequence). This PR only closes the **diagnosability** gap.

## How

- Extract the skip-line formatting (already built for the InfoBar) into a module-level `log_patch_skips()` in `apply_engine.py`.
- It writes the same hex-truncated lines to the log at `WARNING` **and** returns them, so the post-apply InfoBar reuses the exact same lines — pop-up and bug report can no longer drift apart.
- Hex fields stay truncated to 32 chars (+ a byte count) so whole-table (multi-MB) changes don't flood the log — the same guard the InfoBar already used (#191 retest).

## Tests

`tests/test_patch_skip_logging.py` (4 cases): skips are logged at WARNING with the per-patch detail; the returned lines match the logged lines (lock-step contract); whole-table hex is truncated, not dumped; overflow beyond the line limit is summarized.

Refs #222
