### PR TITLE
ci: queue concurrent runs instead of cancelling them

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -37,6 +37,12 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Queue a duplicate build for the same tag/ref behind the one already running
+# instead of cancelling it; different tags still build in parallel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write # needed to create / update GitHub Releases
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -18,6 +18,14 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+# Queue a new run behind one already running for the same branch/PR instead of
+# cancelling it. `cancel-in-progress: false` is what makes a fresh push wait its
+# turn rather than kill the run in progress. The group is keyed per ref, so
+# different branches and PRs still run in parallel — only same-ref runs serialize.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: fast tests


### PR DESCRIPTION
﻿## What

Adds a `concurrency` group to both workflows so a new run **queues behind** the one already running for the same branch/PR, instead of cancelling it.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false
```

## Why

The workflows had no `concurrency` config, so there was no explicit policy for overlapping runs — superseded "Windows tests" runs ended up cancelled (branch deletes / force-pushes during PR work). This makes the intent explicit: **queue, don''t cancel.**

- `cancel-in-progress: false` → a fresh trigger for the same ref waits its turn rather than killing the in-progress run.
- Group keyed by `${{ github.workflow }}-${{ github.ref }}` → only *same-ref* runs serialize; different branches and PRs still run in parallel, so one PR never blocks another.
- On `release-macos.yml`, different tags keep building in parallel (the tag is part of `github.ref`); only a duplicate run of the *same* tag queues.

Trade-off: rapid pushes to one branch now run every queued run in series (more minutes) rather than cancelling superseded ones — which is the requested behavior.

No job logic changed; only the top-level concurrency policy.
