### PR TITLE
feat: game-data index engine (cdumm.engine.game_index)

### DIFF
--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -1,0 +1,228 @@
+"""Game-data index engine.
+
+Turns a Crimson Desert install into a searchable SQLite catalog of every
+archive asset (path / category / type / location / size) plus the keyed
+"game data" tables (iteminfo, characterinfo, questinfo, skill, ...).
+
+This is a pure library — no GUI, no argparse — so it can back an in-app
+"Game Data" page and be unit-tested headless. The heavy enumeration reuses
+the same PAMT parser CDUMM uses everywhere else
+(``cdumm.archive.paz_parse.parse_pamt``); it is injected in ``build_index`` so
+the DB-building and query helpers can be exercised without a real install.
+
+Nothing here extracts or stores asset bytes — only metadata (paths, sizes,
+IDs, and where the bytes live).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from typing import Any, Callable, Iterable
+
+# Data-table blob (.pabgb) + schema/header (.pabgh) extensions.
+TABLE_EXTS = (".pabgb", ".pabgh")
+
+
+def category_of(path: str) -> str:
+    """First path segment, e.g. 'gamedata' for 'gamedata/iteminfo.pabgb'."""
+    return path.split("/", 1)[0] if "/" in path else "(root)"
+
+
+def ext_of(path: str) -> str:
+    """Lower-cased extension, or '(none)' when the path has none."""
+    return (os.path.splitext(path)[1] or "(none)").lower()
+
+
+def archive_dirs(game_dir: str) -> list[str]:
+    """NNNN subdirs of an install that carry a 0.pamt index."""
+    out = []
+    for name in sorted(os.listdir(game_dir)):
+        d = os.path.join(game_dir, name)
+        if os.path.isdir(d) and os.path.exists(os.path.join(d, "0.pamt")):
+            out.append(name)
+    return out
+
+
+# ── schema / build ───────────────────────────────────────────────────
+
+def create_schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        DROP TABLE IF EXISTS assets;
+        DROP TABLE IF EXISTS data_tables;
+        DROP TABLE IF EXISTS stats;
+        CREATE TABLE assets (
+            path       TEXT NOT NULL,
+            archive    TEXT NOT NULL,
+            category   TEXT NOT NULL,
+            ext        TEXT NOT NULL,
+            paz_file   TEXT NOT NULL,
+            offset     INTEGER NOT NULL,
+            comp_size  INTEGER NOT NULL,
+            orig_size  INTEGER NOT NULL,
+            compressed INTEGER NOT NULL,
+            encrypted  INTEGER NOT NULL
+        );
+        CREATE TABLE data_tables (
+            name      TEXT NOT NULL,
+            path      TEXT NOT NULL,
+            archive   TEXT NOT NULL,
+            orig_size INTEGER NOT NULL
+        );
+        CREATE TABLE stats (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        """
+    )
+
+
+def insert_archive(con: sqlite3.Connection, archive: str,
+                   entries: Iterable[Any]) -> int:
+    """Insert one archive's entries.
+
+    ``entries`` is any iterable of objects exposing ``path``, ``paz_file``,
+    ``offset``, ``comp_size``, ``orig_size``, ``compressed`` and ``encrypted``
+    (i.e. ``cdumm.archive.paz_parse.PazEntry``). Returns the number inserted.
+    """
+    rows = []
+    trows = []
+    n = 0
+    for e in entries:
+        ext = ext_of(e.path)
+        rows.append((e.path, archive, category_of(e.path), ext, e.paz_file,
+                     e.offset, e.comp_size, e.orig_size,
+                     int(bool(e.compressed)), int(bool(e.encrypted))))
+        if ext in TABLE_EXTS:
+            trows.append((os.path.basename(e.path), e.path, archive,
+                          e.orig_size))
+        n += 1
+    con.executemany(
+        "INSERT INTO assets(path,archive,category,ext,paz_file,offset,"
+        "comp_size,orig_size,compressed,encrypted) VALUES(?,?,?,?,?,?,?,?,?,?)",
+        rows)
+    if trows:
+        con.executemany(
+            "INSERT INTO data_tables(name,path,archive,orig_size) "
+            "VALUES(?,?,?,?)", trows)
+    return n
+
+
+def finalize(con: sqlite3.Connection) -> None:
+    """Add lookup indexes. Call once after all archives are inserted."""
+    con.executescript(
+        """
+        CREATE INDEX IF NOT EXISTS ix_assets_path ON assets(path);
+        CREATE INDEX IF NOT EXISTS ix_assets_ext ON assets(ext);
+        CREATE INDEX IF NOT EXISTS ix_assets_cat ON assets(category);
+        CREATE INDEX IF NOT EXISTS ix_assets_archive ON assets(archive);
+        CREATE INDEX IF NOT EXISTS ix_tables_name ON data_tables(name);
+        """
+    )
+
+
+def write_stats(con: sqlite3.Connection, **extra: Any) -> dict:
+    """Compute + persist summary stats; return them as a dict."""
+    total = con.execute("SELECT COUNT(*) FROM assets").fetchone()[0]
+    archives = con.execute(
+        "SELECT COUNT(DISTINCT archive) FROM assets").fetchone()[0]
+    distinct = con.execute(
+        "SELECT COUNT(DISTINCT name) FROM data_tables").fetchone()[0]
+    stats: dict[str, Any] = {
+        "assets_total": total,
+        "archives": archives,
+        "data_table_distinct": distinct,
+        "generated_epoch": int(time.time()),
+    }
+    stats.update(extra)
+    con.execute("DELETE FROM stats")
+    con.executemany("INSERT INTO stats(key,value) VALUES(?,?)",
+                    [(k, str(v)) for k, v in stats.items()])
+    con.commit()
+    return stats
+
+
+# ── query helpers (for the GUI page / callers) ───────────────────────
+
+def _dicts(cur) -> list[dict]:
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def search_assets(con: sqlite3.Connection, query: str = "", *,
+                  ext: str | None = None, category: str | None = None,
+                  archive: str | None = None, limit: int = 200) -> list[dict]:
+    """Search assets by path substring, optionally filtered by ext/category/
+    archive. Returns up to ``limit`` rows as dicts, path-ordered."""
+    where = []
+    args: list[Any] = []
+    if query:
+        where.append("path LIKE ? ESCAPE '\\'")
+        esc = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        args.append(f"%{esc}%")
+    if ext:
+        where.append("ext = ?"); args.append(ext.lower())
+    if category:
+        where.append("category = ?"); args.append(category)
+    if archive:
+        where.append("archive = ?"); args.append(archive)
+    sql = "SELECT path,archive,category,ext,paz_file,offset,orig_size FROM assets"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY path LIMIT ?"
+    args.append(int(limit))
+    return _dicts(con.execute(sql, args))
+
+
+def list_data_tables(con: sqlite3.Connection) -> list[dict]:
+    """The keyed game-data tables, largest first, de-duplicated by name."""
+    return _dicts(con.execute(
+        "SELECT name, archive, MAX(orig_size) AS orig_size "
+        "FROM data_tables GROUP BY name ORDER BY orig_size DESC"))
+
+
+def category_counts(con: sqlite3.Connection) -> list[dict]:
+    return _dicts(con.execute(
+        "SELECT category, COUNT(*) AS n FROM assets "
+        "GROUP BY category ORDER BY n DESC"))
+
+
+def get_stats(con: sqlite3.Connection) -> dict:
+    return {k: v for k, v in con.execute("SELECT key,value FROM stats")}
+
+
+# ── full build (integration entry point) ─────────────────────────────
+
+def build_index(game_dir: str, out_path: str, *,
+                parse_pamt: Callable[..., Iterable[Any]] | None = None,
+                progress: Callable[[str, int], None] | None = None) -> dict:
+    """Build the full catalog for ``game_dir`` into the SQLite at ``out_path``.
+
+    ``parse_pamt`` defaults to CDUMM's real parser but can be injected for
+    testing. ``progress(archive, count)`` is called after each archive.
+    Returns the stats dict.
+    """
+    if parse_pamt is None:
+        from cdumm.archive.paz_parse import parse_pamt as parse_pamt  # noqa
+
+    dirs = archive_dirs(game_dir)
+    if not dirs:
+        raise ValueError(f"No NNNN/0.pamt archives under {game_dir}")
+
+    if os.path.exists(out_path):
+        os.remove(out_path)
+    con = sqlite3.connect(out_path)
+    try:
+        con.execute("PRAGMA journal_mode=OFF")
+        con.execute("PRAGMA synchronous=OFF")
+        create_schema(con)
+        for d in dirs:
+            base = os.path.join(game_dir, d)
+            entries = parse_pamt(os.path.join(base, "0.pamt"), paz_dir=base)
+            n = insert_archive(con, d, entries)
+            if progress is not None:
+                progress(d, n)
+        finalize(con)
+        stats = write_stats(con)
+    finally:
+        con.commit()
+        con.close()
+    return stats

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -1,0 +1,149 @@
+"""Headless tests for the game-data index engine (cdumm.engine.game_index).
+
+Exercises the schema, per-archive insert, query helpers, and the full
+build_index path with an injected fake parser + fake install dir — no real
+Crimson Desert install or archive bytes required.
+"""
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from cdumm.engine import game_index as gi
+
+
+def _entry(path, paz_file="0008/0.paz", offset=0, comp=10, orig=10, enc=False):
+    return SimpleNamespace(
+        path=path, paz_file=paz_file, offset=offset,
+        comp_size=comp, orig_size=orig,
+        compressed=(comp != orig), encrypted=enc)
+
+
+def _db(entries_by_archive):
+    con = sqlite3.connect(":memory:")
+    gi.create_schema(con)
+    for arch, ents in entries_by_archive.items():
+        gi.insert_archive(con, arch, ents)
+    gi.finalize(con)
+    gi.write_stats(con)
+    return con
+
+
+def test_category_and_ext_derivation():
+    assert gi.category_of("gamedata/iteminfo.pabgb") == "gamedata"
+    assert gi.category_of("sequencer/x.paseq") == "sequencer"
+    assert gi.category_of("root.txt") == "(root)"
+    assert gi.ext_of("a/b.PASEQ") == ".paseq"       # lower-cased
+    assert gi.ext_of("gamedata/iteminfo.pabgb") == ".pabgb"
+    assert gi.ext_of("noext") == "(none)"
+
+
+def test_schema_counts_and_flags():
+    con = _db({
+        "0008": [_entry("gamedata/iteminfo.pabgb", comp=100, orig=200),  # compressed
+                 _entry("gamedata/iteminfo.pabgh"),
+                 _entry("sequencer/x.paseq")],
+        "0014": [_entry("ui/y.xml", enc=True)],
+    })
+    st = gi.get_stats(con)
+    assert st["assets_total"] == "4"
+    assert st["archives"] == "2"
+    # flags persisted as 0/1
+    comp = con.execute(
+        "SELECT compressed FROM assets WHERE path='gamedata/iteminfo.pabgb'"
+    ).fetchone()[0]
+    enc = con.execute(
+        "SELECT encrypted FROM assets WHERE path='ui/y.xml'").fetchone()[0]
+    assert comp == 1 and enc == 1
+
+
+def test_search_by_substring_ext_category_archive():
+    con = _db({"0008": [
+        _entry("gamedata/iteminfo.pabgb"),
+        _entry("sequencer/loading.paseq"),
+        _entry("character/hero.paa"),
+    ], "0014": [_entry("sequencer/other.paseq")]})
+
+    r = gi.search_assets(con, query="iteminfo")
+    assert [x["path"] for x in r] == ["gamedata/iteminfo.pabgb"]
+
+    r = gi.search_assets(con, ext=".paseq")
+    assert {x["path"] for x in r} == {
+        "sequencer/loading.paseq", "sequencer/other.paseq"}
+
+    r = gi.search_assets(con, category="character")
+    assert [x["path"] for x in r] == ["character/hero.paa"]
+
+    r = gi.search_assets(con, ext=".paseq", archive="0014")
+    assert [x["path"] for x in r] == ["sequencer/other.paseq"]
+
+
+def test_search_limit_and_like_wildcards_are_literal():
+    con = _db({"0008": [_entry(f"gamedata/item{i}.pabgb") for i in range(10)]})
+    assert len(gi.search_assets(con, query="item", limit=3)) == 3
+    # a query containing % must match literally, not as a wildcard
+    con.execute("INSERT INTO assets VALUES('gamedata/50%off.txt','0008',"
+                "'gamedata','.txt','0008/0.paz',0,1,1,0,0)")
+    r = gi.search_assets(con, query="50%off")
+    assert [x["path"] for x in r] == ["gamedata/50%off.txt"]
+
+
+def test_data_tables_catalog_dedup_and_order():
+    con = _db({"0008": [
+        _entry("gamedata/iteminfo.pabgb", orig=555),
+        _entry("gamedata/stringinfo.pabgb", orig=999),
+        _entry("gamedata/iteminfo.pabgb", orig=555),   # dup name
+        _entry("character/hero.paa"),                  # not a table
+    ]})
+    tables = gi.list_data_tables(con)
+    assert [t["name"] for t in tables] == [
+        "stringinfo.pabgb", "iteminfo.pabgb"]          # largest first, deduped
+
+
+def test_category_counts():
+    con = _db({"0008": [
+        _entry("character/a.paa"), _entry("character/b.paa"),
+        _entry("sound/c.wem")]})
+    counts = {c["category"]: c["n"] for c in gi.category_counts(con)}
+    assert counts == {"character": 2, "sound": 1}
+
+
+def test_build_index_end_to_end(tmp_path):
+    """Full build_index path with a fake install + injected parser."""
+    game = tmp_path / "game"
+    for d in ("0008", "0014"):
+        (game / d).mkdir(parents=True)
+        (game / d / "0.pamt").write_bytes(b"")   # presence is all archive_dirs needs
+
+    fake = {
+        "0008": [_entry("gamedata/iteminfo.pabgb", orig=500),
+                 _entry("gamedata/iteminfo.pabgh", orig=20),
+                 _entry("character/hero.paa")],
+        "0014": [_entry("sequencer/loading.paseq")],
+    }
+
+    def fake_parse(pamt_path, paz_dir=None):
+        arch = pamt_path.replace("\\", "/").split("/")[-2]
+        return fake[arch]
+
+    seen = []
+    out = tmp_path / "idx.sqlite"
+    stats = gi.build_index(str(game), str(out),
+                           parse_pamt=fake_parse,
+                           progress=lambda a, n: seen.append((a, n)))
+
+    assert stats["assets_total"] == 4
+    assert stats["archives"] == 2
+    assert stats["data_table_distinct"] == 2      # iteminfo.pabgb + .pabgh
+    assert sorted(seen) == [("0008", 3), ("0014", 1)]
+
+    con = sqlite3.connect(str(out))
+    assert gi.search_assets(con, query="iteminfo")[0]["archive"] == "0008"
+    con.close()
+
+
+def test_build_index_no_archives_raises(tmp_path):
+    import pytest
+    with pytest.raises(ValueError):
+        gi.build_index(str(tmp_path), str(tmp_path / "x.sqlite"),
+                       parse_pamt=lambda *a, **k: [])


### PR DESCRIPTION
﻿## What

Adds `cdumm/engine/game_index.py` — a small, **headless, importable engine** that turns a Crimson Desert install into a searchable SQLite catalog of:

- every archive asset (path, category, type, which archive, offset, sizes, compression/encryption) — **~1.66M** entries, and
- the **266 keyed game-data tables** (iteminfo, characterinfo, questinfo, skill, dropsetinfo, stringinfo, …).

This is the reusable core intended to back an in-app **"Game Data" page** (GUI tab to follow in a separate PR). It has no GUI and no argparse, so it drops cleanly behind a worker thread and is unit-testable.

## How it works

It reuses CDUMM's own `cdumm.archive.paz_parse.parse_pamt` to read each `NNNN/0.pamt` index, then:

- `create_schema` / `insert_archive` / `finalize` — build the `assets` + `data_tables` + `stats` tables and lookup indexes.
- `search_assets(query, ext=, category=, archive=, limit=)` — path search with literal (escaped) `LIKE`.
- `list_data_tables()` / `category_counts()` / `get_stats()` — browse/summary helpers.
- `build_index(game_dir, out_path, parse_pamt=…, progress=…)` — the full build; `parse_pamt` is injectable so it runs without a real install.

Metadata only — it never extracts or stores asset bytes.

## Tests

`tests/test_game_index.py` — 8 headless tests: category/ext derivation, schema + counts + flags, search by substring/ext/category/archive, literal-`%` handling, data-table dedup/order, category counts, and the full `build_index` path via an injected fake parser + fake install dir. **All green.**

## Verification

- Unit tests: `8 passed`.
- Real integration run against a 1.12.02 install via the engine's default parser: **1,660,550 assets / 33 archives / 266 tables in ~18s**, and `search_assets`/`list_data_tables` return the expected rows.

Complements the standalone CLI in #239; this is the library form the GUI tab will use.
