### PR TITLE
feat: Game Data tab (in-app game-index browser)

### DIFF
--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -409,5 +409,13 @@
     "_callMercenaryCoolTime": {"type": "u64"},
     "_callMercenarySpawnDuration": {"type": "u64"},
     "_mercenaryCoolTimeType": {"type": "u8"}
+  },
+  "WantedInfo": {
+    "_meta_note": "Verified-only pass 2026-07-03. Only _increasePrice is validated: read as u64 at payload offset 0 (the default entry header consumes exactly key(2)+name_len(4, always 0)+null(1) = 7 bytes on every record, landing on the price). Values track the wanted tier — 30/50/100/500/1500 gold, consistent across all 5 key groups. _isBlocked/_useTargetPrice are all-zero in shipped data except one toggling flag byte whose name mapping can't be proven from the files alone (the field defs live only in the exe), so they are listed but gated as unverified rather than guessed. _stringKey (untyped in the base schema) stays dropped.",
+    "_ordered_fields": ["_increasePrice", "_isBlocked", "_useTargetPrice"],
+    "_verified_fields": ["_increasePrice"],
+    "_increasePrice": {"type": "u64"},
+    "_isBlocked": {"type": "u8"},
+    "_useTargetPrice": {"type": "u8"}
   }
 }

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -17,8 +17,10 @@ it; ``decode_text`` / ``hexdump`` turn those bytes into something viewable.
 """
 from __future__ import annotations
 
+import math
 import os
 import sqlite3
+import struct
 import time
 from typing import Any, Callable, Iterable
 
@@ -303,6 +305,44 @@ def hexdump(data: bytes, limit: int = 4096) -> str:
     if len(data) > limit:
         out.append(f"… ({len(data):,} bytes total, showing first {limit:,})")
     return "\n".join(out)
+
+
+def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
+    """Interpret a small, string-free binary as a table of 32-bit words.
+
+    The game stores fixed-layout structs with no embedded field names for
+    per-record attribute blocks (``.paatt``) and table key indexes
+    (``.pabgh``). There's no schema to name the fields, but showing each
+    4-byte word as uint32 / int32 / float32 is far more legible than a raw
+    hex wall: record keys (1,000,000+n), byte offsets, flags and float
+    attributes all become readable. Returns ``None`` when there aren't at
+    least two whole words to show — nothing a struct view adds over hex.
+
+    Each row is ``(offset, hex, uint32, int32, float, ascii, is_key)``; the
+    float cell is blank when the bit-pattern isn't a sane finite number
+    (i.e. it's really an int/flag), and ``is_key`` flags values in the
+    1,000,000–9,999,999 game-data record-key range.
+    """
+    nwords = len(data) // 4
+    if nwords < 2:
+        return None
+    shown = min(nwords, max_words)
+    rows: list = []
+    for k in range(shown):
+        off = k * 4
+        chunk = data[off:off + 4]
+        u = int.from_bytes(chunk, "little")
+        i = u - 0x1_0000_0000 if u & 0x8000_0000 else u
+        f = struct.unpack_from("<f", data, off)[0]
+        if f == 0.0 or (math.isfinite(f) and 1e-4 <= abs(f) < 1e9):
+            fstr = f"{f:.4g}"
+        else:  # an int/flag reinterpreted as float is just noise
+            fstr = ""
+        ascii_ = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        rows.append((f"{off:04X}", chunk.hex(), str(u), str(i), fstr,
+                     ascii_, 1_000_000 <= u <= 9_999_999))
+    return {"rows": rows, "total_words": nwords, "shown": shown,
+            "trailing": len(data) - nwords * 4}
 
 
 def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -17,7 +17,6 @@ it; ``decode_text`` / ``hexdump`` turn those bytes into something viewable.
 """
 from __future__ import annotations
 
-import math
 import os
 import sqlite3
 import struct
@@ -318,9 +317,9 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
     attributes all become readable. Returns ``None`` when there aren't at
     least two whole words to show — nothing a struct view adds over hex.
 
-    Each row is ``(offset, hex, uint32, int32, float, ascii, is_key)``; the
-    float cell is blank when the bit-pattern isn't a sane finite number
-    (i.e. it's really an int/flag), and ``is_key`` flags values in the
+    Each row is ``(offset, hex, uint32, int32, float, ascii, is_key)`` and
+    every column is always populated; the float is the exact IEEE-754 reading
+    of the same 4 bytes, and ``is_key`` flags values in the
     1,000,000–9,999,999 game-data record-key range.
     """
     nwords = len(data) // 4
@@ -334,12 +333,11 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
         u = int.from_bytes(chunk, "little")
         i = u - 0x1_0000_0000 if u & 0x8000_0000 else u
         f = struct.unpack_from("<f", data, off)[0]
-        if f == 0.0 or (math.isfinite(f) and 1e-4 <= abs(f) < 1e9):
-            fstr = f"{f:.4g}"
-        else:  # an int/flag reinterpreted as float is just noise
-            fstr = ""
+        # Every column is always populated: the float is the exact IEEE-754
+        # reading of the same 4 bytes (a word that's really an int just reads
+        # as a tiny/denormal number) — no blank cells.
         ascii_ = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
-        rows.append((f"{off:04X}", chunk.hex(), str(u), str(i), fstr,
+        rows.append((f"{off:04X}", chunk.hex(), str(u), str(i), f"{f:.6g}",
                      ascii_, 1_000_000 <= u <= 9_999_999))
     return {"rows": rows, "total_words": nwords, "shown": shown,
             "trailing": len(data) - nwords * 4}

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -204,6 +204,24 @@ def get_asset(con: sqlite3.Connection, path: str) -> dict | None:
 
 # ── on-demand extraction + preview (read one asset's real bytes) ──────
 
+def _dds_split_decompress(raw: bytes, orig: int) -> bytes | None:
+    """Recover a 'DDS-split' texture: a plaintext DDS header + one LZ4 block
+    for the pixel body. Returns header + decompressed body, or None if this
+    isn't a single-block DDS-split. The header is 128 bytes, or 148 for DX10
+    (the extra 20-byte DXGI header)."""
+    if raw[:4] != b"DDS " or len(raw) < 128:
+        return None
+    hdr = 148 if raw[84:88] == b"DX10" else 128
+    if orig <= hdr:
+        return None
+    from cdumm.archive import paz_crypto
+    try:
+        body = paz_crypto.lz4_decompress(raw[hdr:], orig - hdr)
+    except Exception:  # noqa: BLE001 — chunked / unsupported codec
+        return None
+    return raw[:hdr] + body
+
+
 def extract_asset(con: sqlite3.Connection, path: str, game_dir: str) -> bytes:
     """Read one asset's real bytes back out of its PAZ.
 
@@ -240,8 +258,13 @@ def extract_asset(con: sqlite3.Connection, path: str, game_dir: str) -> bytes:
     if comp != orig and orig > 0:
         try:
             raw = paz_crypto.lz4_decompress(raw, orig)
-        except Exception:  # noqa: BLE001 — DDS-split / type 3-4: show raw
-            pass
+        except Exception:  # noqa: BLE001
+            # Whole-buffer LZ4 failed — try DDS-split (plaintext header + one
+            # LZ4 body). If that's not it either (chunked / type 3-4), keep
+            # the raw bytes so the caller can still show a hex view.
+            split = _dds_split_decompress(raw, orig)
+            if split is not None:
+                raw = split
     return raw
 
 

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -10,8 +10,10 @@ the same PAMT parser CDUMM uses everywhere else
 (``cdumm.archive.paz_parse.parse_pamt``); it is injected in ``build_index`` so
 the DB-building and query helpers can be exercised without a real install.
 
-Nothing here extracts or stores asset bytes — only metadata (paths, sizes,
-IDs, and where the bytes live).
+Building the index stores only metadata (paths, sizes, IDs, and where the
+bytes live) — never asset bytes. ``extract_asset`` can then read one asset's
+real bytes back on demand (decrypt + LZ4-decompress) so a caller can preview
+it; ``decode_text`` / ``hexdump`` turn those bytes into something viewable.
 """
 from __future__ import annotations
 
@@ -187,6 +189,97 @@ def category_counts(con: sqlite3.Connection) -> list[dict]:
 
 def get_stats(con: sqlite3.Connection) -> dict:
     return {k: v for k, v in con.execute("SELECT key,value FROM stats")}
+
+
+def get_asset(con: sqlite3.Connection, path: str) -> dict | None:
+    """Full stored row for one asset path (or None). Includes the fields
+    ``extract_asset`` needs that ``search_assets`` omits (comp_size,
+    compressed, encrypted)."""
+    rows = _dicts(con.execute(
+        "SELECT path,archive,category,ext,paz_file,offset,comp_size,"
+        "orig_size,compressed,encrypted FROM assets WHERE path=? LIMIT 1",
+        (path,)))
+    return rows[0] if rows else None
+
+
+# ── on-demand extraction + preview (read one asset's real bytes) ──────
+
+def extract_asset(con: sqlite3.Connection, path: str, game_dir: str) -> bytes:
+    """Read one asset's real bytes back out of its PAZ.
+
+    Reverses the repack pipeline (plaintext -> LZ4 -> ChaCha20): read the
+    stored slice, decrypt if the entry is an encrypted text format, then
+    LZ4-decompress if it was compressed. The ``.paz`` is re-resolved under
+    ``game_dir`` so an index built before the install moved still works.
+
+    Raises KeyError if the path isn't indexed, FileNotFoundError if the
+    archive is gone. A decompress failure (e.g. DDS-split / unsupported
+    codec) falls back to the raw stored bytes rather than raising, so the
+    caller can still show a hex view.
+    """
+    row = get_asset(con, path)
+    if row is None:
+        raise KeyError(path)
+
+    paz = row["paz_file"]
+    if not os.path.exists(paz):
+        # Index may have been built on another machine / before a move.
+        paz = os.path.join(game_dir, row["archive"], os.path.basename(paz))
+    if not os.path.exists(paz):
+        raise FileNotFoundError(paz)
+
+    with open(paz, "rb") as f:
+        f.seek(int(row["offset"]))
+        raw = f.read(int(row["comp_size"]))
+
+    from cdumm.archive import paz_crypto
+    if row["encrypted"]:
+        raw = paz_crypto.decrypt(raw, os.path.basename(path))
+
+    comp, orig = int(row["comp_size"]), int(row["orig_size"])
+    if comp != orig and orig > 0:
+        try:
+            raw = paz_crypto.lz4_decompress(raw, orig)
+        except Exception:  # noqa: BLE001 — DDS-split / type 3-4: show raw
+            pass
+    return raw
+
+
+def decode_text(data: bytes, limit: int = 200_000) -> str | None:
+    """Return decoded text if the bytes look like a text file, else None.
+
+    Tries UTF-8 then UTF-16-LE over a leading sample and only accepts the
+    result when it's overwhelmingly printable — so XML/CSS/JSON/JS assets
+    render as text while binary blobs fall through to a hex view.
+    """
+    sample = data[:limit]
+    if not sample:
+        return ""
+    for enc in ("utf-8", "utf-16-le"):
+        try:
+            s = sample.decode(enc)
+        except (UnicodeDecodeError, ValueError):
+            continue
+        if not s:
+            continue
+        printable = sum((c.isprintable() or c in "\r\n\t") for c in s)
+        if printable / len(s) >= 0.90:
+            return s
+    return None
+
+
+def hexdump(data: bytes, limit: int = 4096) -> str:
+    """Classic ``offset  hex  ascii`` dump of the first ``limit`` bytes."""
+    out = []
+    chunk = data[:limit]
+    for i in range(0, len(chunk), 16):
+        row = chunk[i:i + 16]
+        hexs = " ".join(f"{b:02X}" for b in row)
+        ascii_ = "".join(chr(b) if 32 <= b < 127 else "." for b in row)
+        out.append(f"{i:08X}  {hexs:<47}  {ascii_}")
+    if len(data) > limit:
+        out.append(f"… ({len(data):,} bytes total, showing first {limit:,})")
+    return "\n".join(out)
 
 
 # ── full build (integration entry point) ─────────────────────────────

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -357,6 +357,55 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
             "format": _identify_binary_format(data)}
 
 
+# Per-table record payload offset holding a world (X, Y, Z) float triplet,
+# VALIDATED individually before being added here (factionnodespawninfo's nodes
+# cluster correctly by region at +4). Never guess an offset — it differs per
+# table (the +4 that fits factionnodespawninfo yields nothing on
+# actionpointinfo / gimmick / sequencer tables). Extend as tables are RE'd.
+_TABLE_POSITION_OFFSET = {"factionnodespawninfo": 4}
+
+
+def decode_table_positions(table: str, body: bytes, header: bytes) -> dict:
+    """Best-effort per-record world position (X, Y, Z) for the tables whose
+    position offset has been reverse-engineered and validated (see
+    ``_TABLE_POSITION_OFFSET``). Returns ``{record_key: (x, y, z)}`` for records
+    that have a plausible triplet there, or ``{}`` for tables with no known
+    offset. Candidate data for map-makers — accurate for listed tables, absent
+    (never guessed) for the rest."""
+    import math
+    off = _TABLE_POSITION_OFFSET.get(table)
+    if off is None:
+        return {}
+    from cdumm.semantic import parser as sem
+    try:
+        key_size, offsets = sem.parse_pabgh_index(header, table)
+    except Exception:  # noqa: BLE001
+        return {}
+    if not offsets:
+        return {}
+    ordered = sorted(offsets.items(), key=lambda kv: kv[1])
+    out: dict = {}
+    n = len(body)
+    for i, (key, start) in enumerate(ordered):
+        end = ordered[i + 1][1] if i + 1 < len(ordered) else n
+        if start >= n:
+            continue
+        rec = body[start:end]
+        try:
+            _eid, _name, pstart = sem._parse_entry_header(rec, 0, key_size)
+        except Exception:  # noqa: BLE001
+            pstart = key_size
+        payload = rec[pstart:]
+        if len(payload) < off + 12:
+            continue
+        x, y, z = struct.unpack_from("<fff", payload, off)
+        if (all(math.isfinite(v) for v in (x, y, z))
+                and any(0.5 < abs(v) < 1_000_000 for v in (x, y, z))
+                and not (abs(abs(x) - 1) < 1e-2 and abs(abs(z) - 1) < 1e-2)):
+            out[key] = (round(x, 1), round(y, 1), round(z, 1))
+    return out
+
+
 # ── Wwise audio (.wem / .bnk) ─────────────────────────────────────────
 # The game ships ALL sound through Wwise: .wem are the encoded media streams
 # (almost always Wwise Vorbis) and .bnk are SoundBanks. Windows can't play a

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -18,6 +18,7 @@ it; ``decode_text`` / ``hexdump`` turn those bytes into something viewable.
 from __future__ import annotations
 
 import os
+import re
 import sqlite3
 import struct
 import time
@@ -563,6 +564,73 @@ def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
         if s not in seen:
             out.append(s)
     return out
+
+
+_REFLECT_ID = re.compile(r"[A-Za-z][A-Za-z0-9]*$")   # class / type identifier
+
+
+def _raw_ascii_runs(data: bytes, min_len: int = 4, cap: int = 12000) -> list:
+    """Ordered ASCII runs WITHOUT de-duplication (unlike ``extract_strings``),
+    so the field→type alternation of reflection binaries is preserved."""
+    out: list = []
+    cur = bytearray()
+    for b in data:
+        if 32 <= b < 127:
+            cur.append(b)
+        else:
+            if len(cur) >= min_len:
+                out.append(cur.decode("ascii"))
+                if len(out) >= cap:
+                    return out
+            cur = bytearray()
+    if len(cur) >= min_len and len(out) < cap:
+        out.append(cur.decode("ascii"))
+    return out
+
+
+def decode_reflection(data: bytes, limit: int = 4000) -> dict | None:
+    """Parse a verbose reflection-serialized binary (.pae / .paseq / .prefab /
+    .meshinfo / .paproj / …) into the schema it embeds: the object/class names
+    and their ``(field, type)`` pairs, plus any asset references.
+
+    These formats store their own reflection metadata inline as an alternating
+    stream — a class name, then ``_field`` followed by its type, repeating, with
+    nested objects starting a new class section. Returns ``None`` when it isn't
+    one (fewer than 3 field/type pairs), so callers can fall back to the plain
+    string outline / hex. Everything here is the engine's OWN names, read
+    straight from the file — nothing inferred.
+    """
+    ss = _raw_ascii_runs(data, 4, cap=limit * 3)
+    fields: list = []
+    objects: list = []
+    refs: list = []
+    cur = ""
+    i, n = 0, len(ss)
+    while i < n and len(fields) < limit:
+        s = ss[i]
+        if s.startswith("_"):
+            fields.append((cur, s, ss[i + 1] if i + 1 < n else ""))
+            i += 2
+        else:
+            nxt = ss[i + 1] if i + 1 < n else ""
+            if nxt.startswith("_") and _REFLECT_ID.match(s):
+                cur = s
+                objects.append(s)
+                i += 1
+            else:
+                if "/" in s:                  # a real asset-path reference
+                    refs.append(s)
+                i += 1
+    if len(fields) < 3:
+        return None
+    seen: set = set()
+    urefs: list = []
+    for r in refs:
+        if r not in seen:
+            seen.add(r)
+            urefs.append(r)
+    return {"objects": objects, "fields": fields,
+            "refs": urefs[:400], "nfields": len(fields)}
 
 
 def _lz4_stream_decode(src: bytes, pos: int, want: int) -> bytes:

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -343,6 +343,109 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
             "trailing": len(data) - nwords * 4}
 
 
+# ── Wwise audio (.wem / .bnk) ─────────────────────────────────────────
+# The game ships ALL sound through Wwise: .wem are the encoded media streams
+# (almost always Wwise Vorbis) and .bnk are SoundBanks. Windows can't play a
+# raw .wem, and Wwise Vorbis can't be decoded in pure Python — so this is a
+# header parse for metadata, paired with vgmstream for actual WAV playback.
+WWISE_EXTS = (".wem", ".bnk")
+_WEM_CODECS = {0x0001: "PCM", 0x0002: "ADPCM", 0x0011: "IMA ADPCM",
+               0x0069: "Wwise IMA", 0x0166: "XMA2",
+               0xFFFE: "WAVE extensible", 0xFFFF: "Wwise Vorbis"}
+
+
+def _parse_wem_header(data: bytes) -> dict | None:
+    if data[:4] not in (b"RIFF", b"RIFX") or data[8:12] != b"WAVE":
+        return None
+    end = ">" if data[:4] == b"RIFX" else "<"
+    pos, chunks = 12, []
+    codec = channels = sample_rate = bits = data_bytes = None
+    while pos + 8 <= len(data):
+        cid = data[pos:pos + 4]
+        csz = struct.unpack_from(end + "I", data, pos + 4)[0]
+        chunks.append(cid.decode("ascii", "replace").strip())
+        if cid == b"fmt " and csz >= 16 and pos + 8 + 16 <= len(data):
+            tag, channels, sample_rate, _br, _ba, bits = \
+                struct.unpack_from(end + "HHIIHH", data, pos + 8)
+            codec = _WEM_CODECS.get(tag, f"0x{tag:04X}")
+        elif cid == b"data":
+            data_bytes = csz
+        pos += 8 + csz + (csz & 1)
+    dur = None
+    if codec == "PCM" and channels and sample_rate and bits and data_bytes:
+        dur = data_bytes / (channels * (bits // 8) * sample_rate)
+    return {"kind": "wem", "codec": codec, "channels": channels,
+            "sample_rate": sample_rate, "bits": bits or None,
+            "data_bytes": data_bytes, "chunks": chunks,
+            "endian": "big" if end == ">" else "little", "duration": dur}
+
+
+def _parse_bnk_header(data: bytes) -> dict | None:
+    if data[:4] != b"BKHD":
+        return None
+    version = struct.unpack_from("<I", data, 8)[0] if len(data) >= 12 else None
+    pos, sections, n_streams = 0, [], 0
+    while pos + 8 <= len(data):
+        sid = data[pos:pos + 4]
+        ssz = struct.unpack_from("<I", data, pos + 4)[0]
+        if not (sid.isalpha() and sid.isupper()):
+            break
+        sections.append(sid.decode("ascii", "replace"))
+        if sid == b"DIDX":            # data index: 12 bytes per embedded stream
+            n_streams = ssz // 12
+        pos += 8 + ssz
+    return {"kind": "bnk", "bank_version": version, "sections": sections,
+            "embedded_streams": n_streams}
+
+
+def decode_audio(data: bytes, path: str = "") -> dict | None:
+    """Parse a Wwise audio container header into readable metadata, or None if
+    it isn't one. Header parse only — the encoded audio needs vgmstream (see
+    ``find_vgmstream`` / ``convert_to_wav``) to become a playable WAV."""
+    if data[:4] in (b"RIFF", b"RIFX"):
+        return _parse_wem_header(data)
+    if data[:4] == b"BKHD":
+        return _parse_bnk_header(data)
+    return None
+
+
+def find_vgmstream() -> str | None:
+    """Locate the vgmstream CLI used to decode Wwise audio to WAV: the copy
+    bundled under ``cdumm/tools/vgmstream/`` first, then anything on PATH."""
+    import shutil
+    pkg = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # …/cdumm
+    for name in ("vgmstream-cli.exe", "vgmstream-cli", "test.exe"):
+        cand = os.path.join(pkg, "tools", "vgmstream", name)
+        if os.path.exists(cand):
+            return cand
+    return shutil.which("vgmstream-cli") or shutil.which("vgmstream_cli")
+
+
+def convert_to_wav(data: bytes, out_wav: str) -> bool:
+    """Decode Wwise ``.wem`` bytes to a standard WAV at ``out_wav`` via
+    vgmstream. Returns True on success, False if vgmstream is unavailable or
+    the decode fails."""
+    exe = find_vgmstream()
+    if not exe:
+        return False
+    import subprocess
+    import tempfile
+    tmp = tempfile.NamedTemporaryFile(suffix=".wem", delete=False)
+    try:
+        tmp.write(data)
+        tmp.close()
+        subprocess.run([exe, "-o", out_wav, tmp.name],
+                       capture_output=True, timeout=60, check=False)
+        return os.path.exists(out_wav) and os.path.getsize(out_wav) > 44
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
 def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
     """Printable-ASCII runs of at least ``min_len`` chars — the embedded
     field / type / object names in the game's reflection-serialized binaries

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -307,6 +307,18 @@ def hexdump(data: bytes, limit: int = 4096) -> str:
     return "\n".join(out)
 
 
+def _identify_binary_format(data: bytes) -> str | None:
+    """Best-effort identification of a packed binary from its magic — the one
+    thing that IS verifiable in these schema-less formats. Returns a human
+    label or None. Does NOT name individual fields (those aren't in the file).
+    """
+    if data[:4] == b"PAR ":            # constant across all .paa in the corpus
+        return "Pearl Abyss animation (PAR container)"
+    if data[:2] == b"\xff\xff" and b"AnimationMetaData" in data[:64]:
+        return "Animation metadata (AnimationMetaData)"
+    return None
+
+
 def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
     """Interpret a small, string-free binary as a table of 32-bit words.
 
@@ -316,7 +328,7 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
     4-byte word as uint32 / int32 / float32 is far more legible than a raw
     hex wall: record keys (1,000,000+n), byte offsets, flags and float
     attributes all become readable. Returns ``None`` when there aren't at
-    least two whole words to show — nothing a struct view adds over hex.
+    least one whole 4-byte word to show — nothing a struct view adds over hex.
 
     Each row is ``(offset, hex, uint32, int32, float, ascii, is_key)`` and
     every column is always populated; the float is the exact IEEE-754 reading
@@ -324,7 +336,7 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
     1,000,000–9,999,999 game-data record-key range.
     """
     nwords = len(data) // 4
-    if nwords < 2:
+    if nwords < 1:                    # need at least one whole 4-byte word
         return None
     shown = min(nwords, max_words)
     rows: list = []
@@ -341,7 +353,8 @@ def decode_struct(data: bytes, max_words: int = 512) -> dict | None:
         rows.append((f"{off:04X}", chunk.hex(), str(u), str(i), f"{f:.6g}",
                      ascii_, 1_000_000 <= u <= 9_999_999))
     return {"rows": rows, "total_words": nwords, "shown": shown,
-            "trailing": len(data) - nwords * 4}
+            "trailing": len(data) - nwords * 4,
+            "format": _identify_binary_format(data)}
 
 
 # ── Wwise audio (.wem / .bnk) ─────────────────────────────────────────

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -305,6 +305,33 @@ def hexdump(data: bytes, limit: int = 4096) -> str:
     return "\n".join(out)
 
 
+def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
+    """Printable-ASCII runs of at least ``min_len`` chars — the embedded
+    field / type / object names in the game's reflection-serialized binaries
+    (.paseq, .prefab, .meshinfo, ...). De-duplicated in encounter order and
+    capped to ``limit`` — a readable structure outline instead of raw hex."""
+    out: list = []
+    seen: set = set()
+    cur = bytearray()
+    for b in data:
+        if 32 <= b < 127:
+            cur.append(b)
+        else:
+            if len(cur) >= min_len:
+                s = cur.decode("ascii")
+                if s not in seen:
+                    seen.add(s)
+                    out.append(s)
+                    if len(out) >= limit:
+                        return out
+            cur = bytearray()
+    if len(cur) >= min_len and len(out) < limit:
+        s = cur.decode("ascii")
+        if s not in seen:
+            out.append(s)
+    return out
+
+
 def _lz4_stream_decode(src: bytes, pos: int, want: int) -> bytes:
     """Decode a continuous LZ4-block byte stream from ``src[pos:]`` until
     ``want`` output bytes are produced. Raises on malformed / truncated

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -1,0 +1,228 @@
+"""Game-data index engine.
+
+Turns a Crimson Desert install into a searchable SQLite catalog of every
+archive asset (path / category / type / location / size) plus the keyed
+"game data" tables (iteminfo, characterinfo, questinfo, skill, ...).
+
+This is a pure library — no GUI, no argparse — so it can back an in-app
+"Game Data" page and be unit-tested headless. The heavy enumeration reuses
+the same PAMT parser CDUMM uses everywhere else
+(``cdumm.archive.paz_parse.parse_pamt``); it is injected in ``build_index`` so
+the DB-building and query helpers can be exercised without a real install.
+
+Nothing here extracts or stores asset bytes — only metadata (paths, sizes,
+IDs, and where the bytes live).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from typing import Any, Callable, Iterable
+
+# Data-table blob (.pabgb) + schema/header (.pabgh) extensions.
+TABLE_EXTS = (".pabgb", ".pabgh")
+
+
+def category_of(path: str) -> str:
+    """First path segment, e.g. 'gamedata' for 'gamedata/iteminfo.pabgb'."""
+    return path.split("/", 1)[0] if "/" in path else "(root)"
+
+
+def ext_of(path: str) -> str:
+    """Lower-cased extension, or '(none)' when the path has none."""
+    return (os.path.splitext(path)[1] or "(none)").lower()
+
+
+def archive_dirs(game_dir: str) -> list[str]:
+    """NNNN subdirs of an install that carry a 0.pamt index."""
+    out = []
+    for name in sorted(os.listdir(game_dir)):
+        d = os.path.join(game_dir, name)
+        if os.path.isdir(d) and os.path.exists(os.path.join(d, "0.pamt")):
+            out.append(name)
+    return out
+
+
+# ── schema / build ───────────────────────────────────────────────────
+
+def create_schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        DROP TABLE IF EXISTS assets;
+        DROP TABLE IF EXISTS data_tables;
+        DROP TABLE IF EXISTS stats;
+        CREATE TABLE assets (
+            path       TEXT NOT NULL,
+            archive    TEXT NOT NULL,
+            category   TEXT NOT NULL,
+            ext        TEXT NOT NULL,
+            paz_file   TEXT NOT NULL,
+            offset     INTEGER NOT NULL,
+            comp_size  INTEGER NOT NULL,
+            orig_size  INTEGER NOT NULL,
+            compressed INTEGER NOT NULL,
+            encrypted  INTEGER NOT NULL
+        );
+        CREATE TABLE data_tables (
+            name      TEXT NOT NULL,
+            path      TEXT NOT NULL,
+            archive   TEXT NOT NULL,
+            orig_size INTEGER NOT NULL
+        );
+        CREATE TABLE stats (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        """
+    )
+
+
+def insert_archive(con: sqlite3.Connection, archive: str,
+                   entries: Iterable[Any]) -> int:
+    """Insert one archive's entries.
+
+    ``entries`` is any iterable of objects exposing ``path``, ``paz_file``,
+    ``offset``, ``comp_size``, ``orig_size``, ``compressed`` and ``encrypted``
+    (i.e. ``cdumm.archive.paz_parse.PazEntry``). Returns the number inserted.
+    """
+    rows = []
+    trows = []
+    n = 0
+    for e in entries:
+        ext = ext_of(e.path)
+        rows.append((e.path, archive, category_of(e.path), ext, e.paz_file,
+                     e.offset, e.comp_size, e.orig_size,
+                     int(bool(e.compressed)), int(bool(e.encrypted))))
+        if ext in TABLE_EXTS:
+            trows.append((os.path.basename(e.path), e.path, archive,
+                          e.orig_size))
+        n += 1
+    con.executemany(
+        "INSERT INTO assets(path,archive,category,ext,paz_file,offset,"
+        "comp_size,orig_size,compressed,encrypted) VALUES(?,?,?,?,?,?,?,?,?,?)",
+        rows)
+    if trows:
+        con.executemany(
+            "INSERT INTO data_tables(name,path,archive,orig_size) "
+            "VALUES(?,?,?,?)", trows)
+    return n
+
+
+def finalize(con: sqlite3.Connection) -> None:
+    """Add lookup indexes. Call once after all archives are inserted."""
+    con.executescript(
+        """
+        CREATE INDEX IF NOT EXISTS ix_assets_path ON assets(path);
+        CREATE INDEX IF NOT EXISTS ix_assets_ext ON assets(ext);
+        CREATE INDEX IF NOT EXISTS ix_assets_cat ON assets(category);
+        CREATE INDEX IF NOT EXISTS ix_assets_archive ON assets(archive);
+        CREATE INDEX IF NOT EXISTS ix_tables_name ON data_tables(name);
+        """
+    )
+
+
+def write_stats(con: sqlite3.Connection, **extra: Any) -> dict:
+    """Compute + persist summary stats; return them as a dict."""
+    total = con.execute("SELECT COUNT(*) FROM assets").fetchone()[0]
+    archives = con.execute(
+        "SELECT COUNT(DISTINCT archive) FROM assets").fetchone()[0]
+    distinct = con.execute(
+        "SELECT COUNT(DISTINCT name) FROM data_tables").fetchone()[0]
+    stats: dict[str, Any] = {
+        "assets_total": total,
+        "archives": archives,
+        "data_table_distinct": distinct,
+        "generated_epoch": int(time.time()),
+    }
+    stats.update(extra)
+    con.execute("DELETE FROM stats")
+    con.executemany("INSERT INTO stats(key,value) VALUES(?,?)",
+                    [(k, str(v)) for k, v in stats.items()])
+    con.commit()
+    return stats
+
+
+# ── query helpers (for the GUI page / callers) ───────────────────────
+
+def _dicts(cur) -> list[dict]:
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def search_assets(con: sqlite3.Connection, query: str = "", *,
+                  ext: str | None = None, category: str | None = None,
+                  archive: str | None = None, limit: int = 200) -> list[dict]:
+    """Search assets by path substring, optionally filtered by ext/category/
+    archive. Returns up to ``limit`` rows as dicts, path-ordered."""
+    where = []
+    args: list[Any] = []
+    if query:
+        where.append("path LIKE ? ESCAPE '\\'")
+        esc = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        args.append(f"%{esc}%")
+    if ext:
+        where.append("ext = ?"); args.append(ext.lower())
+    if category:
+        where.append("category = ?"); args.append(category)
+    if archive:
+        where.append("archive = ?"); args.append(archive)
+    sql = "SELECT path,archive,category,ext,paz_file,offset,orig_size FROM assets"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY path LIMIT ?"
+    args.append(int(limit))
+    return _dicts(con.execute(sql, args))
+
+
+def list_data_tables(con: sqlite3.Connection) -> list[dict]:
+    """The keyed game-data tables, largest first, de-duplicated by name."""
+    return _dicts(con.execute(
+        "SELECT name, archive, MAX(orig_size) AS orig_size "
+        "FROM data_tables GROUP BY name ORDER BY orig_size DESC"))
+
+
+def category_counts(con: sqlite3.Connection) -> list[dict]:
+    return _dicts(con.execute(
+        "SELECT category, COUNT(*) AS n FROM assets "
+        "GROUP BY category ORDER BY n DESC"))
+
+
+def get_stats(con: sqlite3.Connection) -> dict:
+    return {k: v for k, v in con.execute("SELECT key,value FROM stats")}
+
+
+# ── full build (integration entry point) ─────────────────────────────
+
+def build_index(game_dir: str, out_path: str, *,
+                parse_pamt: Callable[..., Iterable[Any]] | None = None,
+                progress: Callable[[str, int], None] | None = None) -> dict:
+    """Build the full catalog for ``game_dir`` into the SQLite at ``out_path``.
+
+    ``parse_pamt`` defaults to CDUMM's real parser but can be injected for
+    testing. ``progress(archive, count)`` is called after each archive.
+    Returns the stats dict.
+    """
+    if parse_pamt is None:
+        from cdumm.archive.paz_parse import parse_pamt as parse_pamt  # noqa
+
+    dirs = archive_dirs(game_dir)
+    if not dirs:
+        raise ValueError(f"No NNNN/0.pamt archives under {game_dir}")
+
+    if os.path.exists(out_path):
+        os.remove(out_path)
+    con = sqlite3.connect(out_path)
+    try:
+        con.execute("PRAGMA journal_mode=OFF")
+        con.execute("PRAGMA synchronous=OFF")
+        create_schema(con)
+        for d in dirs:
+            base = os.path.join(game_dir, d)
+            entries = parse_pamt(os.path.join(base, "0.pamt"), paz_dir=base)
+            n = insert_archive(con, d, entries)
+            if progress is not None:
+                progress(d, n)
+        finalize(con)
+        stats = write_stats(con)
+    finally:
+        con.commit()
+        con.close()
+    return stats

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -282,6 +282,47 @@ def hexdump(data: bytes, limit: int = 4096) -> str:
     return "\n".join(out)
 
 
+_IMAGE_EXTS = (".dds", ".png", ".jpg", ".jpeg", ".bmp", ".tga")
+
+
+def decode_image(data: bytes, path: str = "", max_dim: int = 1024):
+    """Decode an image asset (chiefly the game's standard DDS textures) to a
+    small PNG for previewing.
+
+    Returns ``{png, width, height, orig_w, orig_h, mode}`` or None when the
+    bytes aren't a decodable image (not an image, an unsupported DDS codec
+    such as BC7, or Pillow missing). The output is downscaled so its long
+    edge is at most ``max_dim`` — a cheap PNG the GUI can show. Pillow does
+    the decode and is called off the UI thread by the preview worker.
+    """
+    if not (data[:4] == b"DDS " or path.lower().endswith(_IMAGE_EXTS)):
+        return None
+    try:
+        from PIL import Image
+    except Exception:  # noqa: BLE001 — Pillow is optional
+        return None
+    import io
+    try:
+        im = Image.open(io.BytesIO(data))
+        im.load()
+    except Exception:  # noqa: BLE001 — unsupported codec / not an image
+        return None
+    ow, oh = im.size
+    if im.mode not in ("RGB", "RGBA", "L", "LA"):
+        try:
+            im = im.convert("RGBA")
+        except Exception:  # noqa: BLE001
+            return None
+    w, h = im.size
+    if w and h and max(w, h) > max_dim:
+        scale = max_dim / max(w, h)
+        im = im.resize((max(1, int(w * scale)), max(1, int(h * scale))))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return {"png": buf.getvalue(), "width": im.size[0], "height": im.size[1],
+            "orig_w": ow, "orig_h": oh, "mode": im.mode}
+
+
 # ── full build (integration entry point) ─────────────────────────────
 
 def build_index(game_dir: str, out_path: str, *,

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -128,8 +128,11 @@ def write_stats(con: sqlite3.Connection, **extra: Any) -> dict:
     total = con.execute("SELECT COUNT(*) FROM assets").fetchone()[0]
     archives = con.execute(
         "SELECT COUNT(DISTINCT archive) FROM assets").fetchone()[0]
+    # One data table == one .pabgb blob (+ its .pabgh key index). Count the
+    # blobs only, so the paired header file isn't tallied as a second table.
     distinct = con.execute(
-        "SELECT COUNT(DISTINCT name) FROM data_tables").fetchone()[0]
+        "SELECT COUNT(DISTINCT name) FROM data_tables "
+        "WHERE name LIKE '%.pabgb'").fetchone()[0]
     stats: dict[str, Any] = {
         "assets_total": total,
         "archives": archives,

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -411,14 +411,106 @@ def decode_audio(data: bytes, path: str = "") -> dict | None:
 
 def find_vgmstream() -> str | None:
     """Locate the vgmstream CLI used to decode Wwise audio to WAV: the copy
-    bundled under ``cdumm/tools/vgmstream/`` first, then anything on PATH."""
+    under ``cdumm/tools/vgmstream/`` (searched recursively, since release
+    archives may nest it in a subfolder), then anything on PATH."""
     import shutil
+    names = ("vgmstream-cli.exe", "vgmstream-cli", "test.exe")
     pkg = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # …/cdumm
-    for name in ("vgmstream-cli.exe", "vgmstream-cli", "test.exe"):
-        cand = os.path.join(pkg, "tools", "vgmstream", name)
+    base = os.path.join(pkg, "tools", "vgmstream")
+    for name in names:
+        cand = os.path.join(base, name)
         if os.path.exists(cand):
             return cand
+    if os.path.isdir(base):
+        for root, _dirs, files in os.walk(base):
+            for name in names:
+                if name in files:
+                    return os.path.join(root, name)
     return shutil.which("vgmstream-cli") or shutil.which("vgmstream_cli")
+
+
+VGMSTREAM_RELEASES_API = \
+    "https://api.github.com/repos/vgmstream/vgmstream/releases/latest"
+
+
+def _pick_vgmstream_asset(assets: list, system: str,
+                          machine: str = "") -> dict | None:
+    """Pick the right release archive for this OS from a GitHub 'assets' list
+    (each a dict with 'name' / 'browser_download_url'). Pure and testable."""
+    system = (system or "").lower()
+    pairs = [(a, str(a.get("name", "")).lower()) for a in assets]
+
+    def find(*must):
+        for a, n in pairs:
+            if (n.endswith((".zip", ".tar.gz", ".tgz"))
+                    and all(m in n for m in must)):
+                return a
+        return None
+    if system.startswith("win"):
+        return find("win64") or find("win")
+    if system == "linux":
+        return find("linux", "cli") or find("linux")
+    if system in ("darwin", "mac"):
+        return find("mac", "cli") or find("mac")
+    return None
+
+
+def download_vgmstream(dest_dir: str, *, timeout: int = 90) -> tuple:
+    """Download the latest vgmstream CLI for this OS from the OFFICIAL
+    vgmstream GitHub releases and extract it into ``dest_dir``. Returns
+    ``(ok, message)`` — message is the version tag on success, else an error.
+    Network + archive extraction only; nothing is executed here."""
+    import io
+    import json
+    import platform
+    import tarfile
+    import urllib.request
+    import zipfile
+    os.makedirs(dest_dir, exist_ok=True)
+
+    def _get(url, as_json=False):
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "CDUMM",
+                          "Accept": "application/vnd.github+json"})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r) if as_json else r.read()
+
+    try:
+        rel = _get(VGMSTREAM_RELEASES_API, as_json=True)
+    except Exception as ex:  # noqa: BLE001
+        return False, f"Could not reach GitHub: {ex}"
+    asset = _pick_vgmstream_asset(
+        rel.get("assets", []), platform.system(), platform.machine())
+    if not asset:
+        return False, f"No vgmstream build published for {platform.system()}."
+    url = str(asset.get("browser_download_url", ""))
+    if "github.com/vgmstream/vgmstream" not in url:
+        return False, "Refusing a non-official download URL."
+    try:
+        blob = _get(url)
+    except Exception as ex:  # noqa: BLE001
+        return False, f"Download failed: {ex}"
+    name = str(asset.get("name", "")).lower()
+    try:
+        if name.endswith(".zip"):
+            with zipfile.ZipFile(io.BytesIO(blob)) as z:
+                z.extractall(dest_dir)
+        elif name.endswith((".tar.gz", ".tgz")):
+            with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as t:
+                t.extractall(dest_dir, filter="data")
+        else:
+            return False, f"Unknown archive type: {asset.get('name')}"
+    except Exception as ex:  # noqa: BLE001
+        return False, f"Extract failed: {ex}"
+    exe = find_vgmstream()
+    if not exe:
+        return False, "Extracted, but vgmstream-cli wasn't in the archive."
+    if not exe.endswith(".exe"):
+        try:
+            os.chmod(exe, 0o755)
+        except OSError:
+            pass
+    return True, str(rel.get("tag_name", "latest"))
 
 
 def convert_to_wav(data: bytes, out_wav: str) -> bool:

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -305,6 +305,57 @@ def hexdump(data: bytes, limit: int = 4096) -> str:
     return "\n".join(out)
 
 
+def _lz4_stream_decode(src: bytes, pos: int, want: int) -> bytes:
+    """Decode a continuous LZ4-block byte stream from ``src[pos:]`` until
+    ``want`` output bytes are produced. Raises on malformed / truncated
+    input. Used to recover the top mip of a compressed multi-mip DDS."""
+    out = bytearray()
+    while len(out) < want:
+        tok = src[pos]; pos += 1
+        lit = tok >> 4
+        if lit == 15:
+            while True:
+                bb = src[pos]; pos += 1; lit += bb
+                if bb != 255:
+                    break
+        out += src[pos:pos + lit]; pos += lit
+        if len(out) >= want:
+            break
+        off = src[pos] | (src[pos + 1] << 8); pos += 2
+        ml = tok & 15
+        if ml == 15:
+            while True:
+                bb = src[pos]; pos += 1; ml += bb
+                if bb != 255:
+                    break
+        ml += 4
+        st = len(out) - off
+        for i in range(ml):
+            out.append(out[st + i])
+    return bytes(out[:want])
+
+
+def _dds_top_mip_dds(data: bytes) -> bytes | None:
+    """Recover a previewable DDS from a compressed multi-mip texture whose
+    body is a continuous LZ4 stream (the game's type-1 layout that whole-
+    buffer / single-block LZ4 can't open). Decodes just the top mip
+    (``dwPitchOrLinearSize`` bytes) and returns a single-mip DDS a standard
+    decoder opens, or None if it doesn't apply / decode."""
+    if data[:4] != b"DDS " or len(data) < 128:
+        return None
+    hdr_size = 148 if data[84:88] == b"DX10" else 128
+    linear = int.from_bytes(data[20:24], "little")   # mip-0 size in bytes
+    if linear <= 0 or linear > 64 * 1024 * 1024:
+        return None
+    try:
+        mip0 = _lz4_stream_decode(data, hdr_size, linear)
+    except Exception:  # noqa: BLE001 — not a continuous-LZ4 body
+        return None
+    hdr = bytearray(data[:hdr_size])
+    hdr[28:32] = (1).to_bytes(4, "little")           # dwMipMapCount = 1
+    return bytes(hdr) + mip0
+
+
 _IMAGE_EXTS = (".dds", ".png", ".jpg", ".jpeg", ".bmp", ".tga")
 
 
@@ -325,11 +376,24 @@ def decode_image(data: bytes, path: str = "", max_dim: int = 1024):
     except Exception:  # noqa: BLE001 — Pillow is optional
         return None
     import io
+    im = None
     try:
         im = Image.open(io.BytesIO(data))
         im.load()
     except Exception:  # noqa: BLE001 — unsupported codec / not an image
-        return None
+        im = None
+    if im is None:
+        # Compressed multi-mip DDS: the body is a continuous LZ4 stream a
+        # standard decoder can't open. Recover just the top mip (full-res)
+        # and retry — all a preview needs.
+        rebuilt = _dds_top_mip_dds(data)
+        if rebuilt is None:
+            return None
+        try:
+            im = Image.open(io.BytesIO(rebuilt))
+            im.load()
+        except Exception:  # noqa: BLE001
+            return None
     ow, oh = im.size
     if im.mode not in ("RGB", "RGBA", "L", "LA"):
         try:

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -887,6 +887,7 @@ from cdumm.gui.pages.tool_page import (  # noqa: E402
     InspectModPage, FixEverythingPage, RescanPage,
 )
 from cdumm.gui.pages.reshade_page import ReshadePage  # noqa: E402
+from cdumm.gui.pages.game_data_page import GameDataPage  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -1216,6 +1217,9 @@ class CdummWindow(FluentWindow):
         self.rescan_page.set_managers(**tool_kwargs)
         self.rescan_page.rescan_requested.connect(self._on_refresh_snapshot)
 
+        self.game_data_page = GameDataPage(self)
+        self.game_data_page.set_managers(**tool_kwargs)
+
         self.reshade_page = ReshadePage(self)
         self.reshade_page.set_managers(db=self._db, game_dir=self._game_dir)
 
@@ -1290,6 +1294,10 @@ class CdummWindow(FluentWindow):
         )
         self.addSubInterface(
             self.rescan_page, FluentIcon.SYNC, tr("nav.rescan"),
+            position=NavigationItemPosition.SCROLL,
+        )
+        self.addSubInterface(
+            self.game_data_page, FluentIcon.ZOOM_IN, "Game Data",
             position=NavigationItemPosition.SCROLL,
         )
         self.addSubInterface(
@@ -6783,7 +6791,8 @@ class CdummWindow(FluentWindow):
             activity_log=self._activity_log if hasattr(self, '_activity_log') else None,
         )
         for page_name in ('verify_state_page', 'check_mods_page', 'find_culprit_page',
-                          'inspect_mod_page', 'fix_everything_page', 'rescan_page'):
+                          'inspect_mod_page', 'fix_everything_page', 'rescan_page',
+                          'game_data_page'):
             page = getattr(self, page_name, None)
             if page:
                 page.set_managers(**tool_kwargs)

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -1218,7 +1218,8 @@ class CdummWindow(FluentWindow):
         self.rescan_page.rescan_requested.connect(self._on_refresh_snapshot)
 
         self.game_data_page = GameDataPage(self)
-        self.game_data_page.set_managers(**tool_kwargs)
+        self.game_data_page.set_managers(
+            **tool_kwargs, app_data_dir=getattr(self, "_app_data_dir", None))
 
         self.reshade_page = ReshadePage(self)
         self.reshade_page.set_managers(db=self._db, game_dir=self._game_dir)

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -904,6 +904,15 @@ class CdummWindow(FluentWindow):
     ) -> None:
         super().__init__()
 
+        # Disable the Windows 11 Mica backdrop. Mica tints the window from the
+        # desktop wallpaper and — because Windows dims inactive windows — makes
+        # the whole background visibly change every time the app gains or loses
+        # focus. Turning it off gives one steady, focus-independent background.
+        try:
+            self.setMicaEffectEnabled(False)
+        except Exception:  # noqa: BLE001 — older qfluentwidgets / non-Windows
+            pass
+
         # ── Window chrome ─────────────────────────────────────────────
         self.setWindowTitle(tr("app.name_short") + " v" + __version__)
         self.setMinimumSize(1000, 700)

--- a/src/cdumm/gui/pages/activity_page.py
+++ b/src/cdumm/gui/pages/activity_page.py
@@ -296,12 +296,18 @@ class ActivityPage(SmoothScrollArea):
 
     # Per-category chip colors: (light_text, dark_text, light_border, dark_border)
     _CHIP_CATEGORY_COLORS = {
-        "apply":    ("#2E7D32", "#81C784", "#A5D6A7", "#2E7D32"),
-        "revert":   ("#E65100", "#FFB74D", "#FFCC80", "#E65100"),
-        "import":   ("#1565C0", "#64B5F6", "#90CAF9", "#1565C0"),
-        "remove":   ("#C62828", "#EF5350", "#EF9A9A", "#C62828"),
-        "verify":   ("#00796B", "#4DB6AC", "#80CBC4", "#00796B"),
-        "error":    ("#C62828", "#EF5350", "#EF9A9A", "#C62828"),
+        "apply":     ("#2E7D32", "#81C784", "#A5D6A7", "#2E7D32"),
+        "revert":    ("#E65100", "#FFB74D", "#FFCC80", "#E65100"),
+        "import":    ("#1565C0", "#64B5F6", "#90CAF9", "#1565C0"),
+        "remove":    ("#C62828", "#EF5350", "#EF9A9A", "#C62828"),
+        "snapshot":  ("#3949AB", "#7986CB", "#9FA8DA", "#3949AB"),
+        "verify":    ("#00796B", "#4DB6AC", "#80CBC4", "#00796B"),
+        "cleanup":   ("#7B1FA2", "#BA68C8", "#CE93D8", "#7B1FA2"),
+        "warning":   ("#F9A825", "#FFD54F", "#FFE082", "#F9A825"),
+        "error":     ("#C62828", "#EF5350", "#EF9A9A", "#C62828"),
+        "health":    ("#00838F", "#4DD0E1", "#80DEEA", "#00838F"),
+        "fix":       ("#4527A0", "#7E57C2", "#B39DDB", "#4527A0"),
+        "uninstall": ("#455A64", "#90A4AE", "#B0BEC5", "#455A64"),
     }
     # Fallback for categories not in the map above
     _CHIP_DEFAULT_COLORS = ("#4A5568", "#A0AEC0", "#E2E8F0", "#4A5568")
@@ -310,35 +316,41 @@ class ActivityPage(SmoothScrollArea):
     def _apply_chip_style(btn: PushButton, color: str, active: bool,
                           category: str | None = None) -> None:
         from qfluentwidgets import setCustomStyleSheet
+        # Look up the category's palette (fall back to grey). Prefer the
+        # explicit English category key over the (now-localized) button text.
+        cat_key = (category or btn.text()).lower()
+        lt, dt, lb, db = ActivityPage._CHIP_CATEGORY_COLORS.get(
+            cat_key, ActivityPage._CHIP_DEFAULT_COLORS)
+
+        def _tint(hexc: str, aa: str) -> str:
+            # Qt QSS 8-digit hex is #AARRGGBB (alpha FIRST) — build the
+            # translucent fill by PREFIXING the alpha, not suffixing it.
+            return f"#{aa}{hexc.lstrip('#')}"
+
         if active:
+            # Solid fill in the category's saturated colour, white text.
             light = (
-                f"PushButton {{ background: {color}; color: white; "
+                f"PushButton {{ background: {lt}; color: white; "
                 "border: none; border-radius: 15px; padding: 0 16px; padding-bottom: 6px; }"
-                f"PushButton:hover {{ background: {color}; opacity: 0.85; }}"
+                f"PushButton:hover {{ background: {db}; }}"
             )
             dark = (
-                f"PushButton {{ background: {color}; color: white; "
+                f"PushButton {{ background: {db}; color: white; "
                 "border: none; border-radius: 15px; padding: 0 16px; padding-bottom: 6px; }"
-                f"PushButton:hover {{ background: {color}; opacity: 0.85; }}"
+                f"PushButton:hover {{ background: {lt}; }}"
             )
-            setCustomStyleSheet(btn, light, dark)
         else:
-            # Look up per-category color, fall back to grey. Prefer the explicit
-            # English category key over the (now-localized) button text.
-            cat_key = (category or btn.text()).lower()
-            lt, dt, lb, db = ActivityPage._CHIP_CATEGORY_COLORS.get(
-                cat_key, ActivityPage._CHIP_DEFAULT_COLORS)
             light = (
-                f"PushButton {{ background: {lt}14; color: {lt}; "
+                f"PushButton {{ background: {_tint(lt, '14')}; color: {lt}; "
                 f"border: 1px solid {lb}; border-radius: 15px; padding: 0 16px; padding-bottom: 6px; }}"
-                f"PushButton:hover {{ background: {lt}28; }}"
+                f"PushButton:hover {{ background: {_tint(lt, '28')}; }}"
             )
             dark = (
-                f"PushButton {{ background: {dt}14; color: {dt}; "
+                f"PushButton {{ background: {_tint(dt, '14')}; color: {dt}; "
                 f"border: 1px solid {db}; border-radius: 15px; padding: 0 16px; padding-bottom: 6px; }}"
-                f"PushButton:hover {{ background: {dt}28; }}"
+                f"PushButton:hover {{ background: {_tint(dt, '28')}; }}"
             )
-            setCustomStyleSheet(btn, light, dark)
+        setCustomStyleSheet(btn, light, dark)
 
     def _populate_cards(self, entries: list[dict], search_query: str = "") -> None:
         """Build cards from a list of log entries."""

--- a/src/cdumm/gui/pages/activity_page.py
+++ b/src/cdumm/gui/pages/activity_page.py
@@ -51,7 +51,7 @@ class _ActivityEntryCard(CardWidget):
         badge.setFixedWidth(80)
         badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
         badge.setStyleSheet(
-            f"background: {color}{alpha}; color: {color}; "
+            f"background: #{alpha}{color.lstrip('#')}; color: {color}; "
             f"border-radius: 6px; padding: 4px 8px; font-weight: 700; font-size: 12px;"
         )
         layout.addWidget(badge)
@@ -107,7 +107,7 @@ class _ActivityEntryCard(CardWidget):
             c = category_color(self._category, dark=dark)
             alpha = "33" if dark else "20"
             self._badge.setStyleSheet(
-                f"background: {c}{alpha}; color: {c}; "
+                f"background: #{alpha}{c.lstrip('#')}; color: {c}; "
                 f"border-radius: 6px; padding: 4px 8px; font-weight: 700; font-size: 12px;"
             )
 

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -15,8 +15,9 @@ import sqlite3
 import subprocess
 import tempfile
 
-from PySide6.QtCore import QObject, QThread, Signal
-from PySide6.QtWidgets import QFileDialog, QHBoxLayout, QTableWidgetItem
+from PySide6.QtCore import QObject, Qt, QThread, Signal
+from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QSplitter,
+                               QTableWidgetItem, QVBoxLayout, QWidget)
 
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
@@ -62,8 +63,9 @@ class GameDataPage(ToolPageBase):
             description=(
                 "Build a searchable catalog of this Crimson Desert install — "
                 "every asset the game ships plus the keyed game-data tables "
-                "(items, NPCs, quests, skills, drops, ...). Metadata only; no "
-                "asset files are extracted."),
+                "(items, NPCs, quests, skills, drops, ...). Click any result "
+                "to preview it on the right — text formats show as text, "
+                "everything else as hex + metadata — or extract it to disk."),
             run_label="Build / refresh game-data index",
             parent=parent,
         )
@@ -82,7 +84,8 @@ class GameDataPage(ToolPageBase):
     # ── extra controls (persistent — not wiped by _clear_results) ────
     def _build_controls(self) -> None:
         from qfluentwidgets import (BodyLabel, CaptionLabel, LineEdit,
-                                     PushButton, TableWidget)
+                                     PlainTextEdit, PushButton,
+                                     StrongBodyLabel, TableWidget)
         root = self._container.layout()
 
         # Save-location row: path label + Change + Open folder
@@ -119,13 +122,20 @@ class GameDataPage(ToolPageBase):
         self._hits.setFont(_hitf)
         root.insertWidget(root.count() - 1, self._hits)
 
-        self._table = TableWidget(self._container)
+        # Results table (left) + live preview pane (right), in a draggable
+        # splitter so the user can trade list width for preview width.
+        split = QSplitter(Qt.Horizontal, self._container)
+        split.setChildrenCollapsible(False)
+        split.setMinimumHeight(420)
+
+        self._table = TableWidget(split)
         self._table.setColumnCount(4)
         self._table.setHorizontalHeaderLabels(
             ["Path", "Archive", "Type", "Size (bytes)"])
         self._table.verticalHeader().hide()
-        self._table.setMinimumHeight(380)
         self._table.setEditTriggers(self._table.EditTrigger.NoEditTriggers)
+        self._table.setSelectionBehavior(
+            self._table.SelectionBehavior.SelectRows)
         # Larger, more readable text + roomier rows.
         _tf = self._table.font()
         _tf.setPixelSize(15)
@@ -135,10 +145,50 @@ class GameDataPage(ToolPageBase):
         self._table.horizontalHeader().setFont(_hf)
         self._table.verticalHeader().setDefaultSectionSize(36)
         try:
-            self._table.setColumnWidth(0, 620)
+            self._table.setColumnWidth(0, 360)
         except Exception:  # noqa: BLE001
             pass
-        root.insertWidget(root.count() - 1, self._table)
+        self._table.itemSelectionChanged.connect(self._on_asset_selected)
+        split.addWidget(self._table)
+
+        # Preview pane: title + metadata + monospace text/hex view + extract.
+        pane = QWidget(split)
+        pv = QVBoxLayout(pane)
+        pv.setContentsMargins(10, 0, 0, 0)
+        pv.setSpacing(6)
+        self._pv_title = StrongBodyLabel("Select an asset to preview", pane)
+        _ptf = self._pv_title.font()
+        _ptf.setPixelSize(16)
+        self._pv_title.setFont(_ptf)
+        pv.addWidget(self._pv_title)
+        self._pv_meta = CaptionLabel("", pane)
+        self._pv_meta.setWordWrap(True)
+        pv.addWidget(self._pv_meta)
+        self._pv_text = PlainTextEdit(pane)
+        self._pv_text.setReadOnly(True)
+        self._pv_text.setLineWrapMode(PlainTextEdit.LineWrapMode.NoWrap)
+        _mf = self._pv_text.font()
+        _mf.setFamily("Consolas")
+        _mf.setStyleHint(_mf.StyleHint.Monospace)
+        _mf.setPixelSize(13)
+        self._pv_text.setFont(_mf)
+        self._pv_text.setPlaceholderText(
+            "Click any row on the left to view that asset.\n\nText formats "
+            "(XML, JSON, JS, CSS) show as text; everything else shows a hex "
+            "+ metadata view. Textures, audio and models need format "
+            "converters, which are a later addition.")
+        pv.addWidget(self._pv_text, 1)
+        self._pv_extract = PushButton("Extract raw file…", pane)
+        self._pv_extract.setEnabled(False)
+        self._pv_extract.clicked.connect(self._extract_raw)
+        pv.addWidget(self._pv_extract)
+        split.addWidget(pane)
+
+        split.setStretchFactor(0, 3)
+        split.setStretchFactor(1, 2)
+        self._preview_bytes: bytes | None = None
+        self._preview_name: str | None = None
+        root.insertWidget(root.count() - 1, split)
 
     # ── engine wiring ────────────────────────────────────────────────
     def set_managers(self, **kwargs) -> None:
@@ -297,3 +347,121 @@ class GameDataPage(ToolPageBase):
             self._table.setItem(i, 2, QTableWidgetItem(str(r["ext"])))
             self._table.setItem(
                 i, 3, QTableWidgetItem(f"{int(r['orig_size']):,}"))
+
+    # ── preview pane ─────────────────────────────────────────────────
+    _PREVIEW_TEXT_CAP = 200_000            # chars shown for text assets
+    _PREVIEW_HEX_CAP = 4096               # bytes shown for the hex view
+    _PREVIEW_SIZE_LIMIT = 32 * 1024 * 1024  # don't inline-decode above this
+
+    def _selected_path(self) -> str | None:
+        items = self._table.selectedItems()
+        if not items:
+            return None
+        cell = self._table.item(items[0].row(), 0)
+        return cell.text() if cell else None
+
+    def _on_asset_selected(self) -> None:
+        """Read + preview the clicked asset (metadata always; text or hex
+        when the bytes are reachable and within the inline size limit)."""
+        path = self._selected_path()
+        if not path:
+            return
+        self._preview_bytes = None
+        self._preview_name = os.path.basename(path)
+        self._pv_extract.setEnabled(False)
+        self._pv_title.setText(self._preview_name)
+
+        row = data = err = None
+        try:
+            con = sqlite3.connect(self._index_path)
+            try:
+                row = game_index.get_asset(con, path)
+                if (row and self._game_dir
+                        and int(row["orig_size"]) <= self._PREVIEW_SIZE_LIMIT):
+                    data = game_index.extract_asset(
+                        con, path, str(self._game_dir))
+            finally:
+                con.close()
+        except Exception as ex:  # noqa: BLE001 — surface to the pane
+            err = str(ex)
+
+        if row is None:
+            self._pv_meta.setText(
+                f"Could not read: {err}" if err else "Asset not in index.")
+            self._pv_text.setPlainText("")
+            return
+
+        flags = []
+        if row["compressed"]:
+            flags.append("LZ4")
+        if row["encrypted"]:
+            flags.append("encrypted")
+        self._pv_meta.setText(
+            f"{row['ext']}  ·  {int(row['orig_size']):,} bytes  ·  archive "
+            f"{row['archive']}  ·  {', '.join(flags) or 'stored raw'}\n{path}")
+
+        if not self._game_dir:
+            self._pv_text.setPlainText(
+                "No game folder configured — can't read asset bytes.")
+            return
+        if int(row["orig_size"]) > self._PREVIEW_SIZE_LIMIT:
+            self._pv_text.setPlainText(
+                f"Asset is {int(row['orig_size']):,} bytes — too large to "
+                "preview inline.\nUse “Extract raw file…” to save it to disk.")
+            self._pv_extract.setEnabled(True)
+            return
+        if err is not None:
+            self._pv_text.setPlainText(f"Could not read asset bytes:\n{err}")
+            return
+        if data is None:
+            self._pv_text.setPlainText("(no data)")
+            return
+
+        self._preview_bytes = data
+        self._pv_extract.setEnabled(True)
+        text = game_index.decode_text(data, limit=self._PREVIEW_TEXT_CAP)
+        if text is not None:
+            if len(text) >= self._PREVIEW_TEXT_CAP:
+                text += ("\n\n… (truncated preview — use Extract raw for the "
+                         "full file)")
+            self._pv_text.setLineWrapMode(
+                self._pv_text.LineWrapMode.WidgetWidth)
+            self._pv_text.setPlainText(text)
+        else:
+            self._pv_text.setLineWrapMode(self._pv_text.LineWrapMode.NoWrap)
+            self._pv_text.setPlainText(
+                "Binary asset — no visual decoder for this format yet "
+                "(textures, audio and models need converters). Hex view of "
+                "the first bytes:\n\n"
+                + game_index.hexdump(data, limit=self._PREVIEW_HEX_CAP))
+
+    def _extract_raw(self) -> None:
+        """Save the selected asset's real (decoded) bytes to a file."""
+        path = self._selected_path()
+        if not path:
+            return
+        data = self._preview_bytes
+        if data is None:                       # large asset — extract on demand
+            try:
+                con = sqlite3.connect(self._index_path)
+                try:
+                    data = game_index.extract_asset(
+                        con, path, str(self._game_dir))
+                finally:
+                    con.close()
+            except Exception as ex:  # noqa: BLE001
+                self._set_status(f"Extract failed: {ex}", "#BF616A")
+                return
+        default = os.path.join(
+            os.path.expanduser("~"),
+            self._preview_name or os.path.basename(path))
+        out, _ = QFileDialog.getSaveFileName(
+            self, "Save extracted asset", default, "All files (*.*)")
+        if not out:
+            return
+        try:
+            with open(out, "wb") as f:
+                f.write(data)
+            self._set_status(f"Saved {len(data):,} bytes to {out}.", "#2E7D32")
+        except Exception as ex:  # noqa: BLE001
+            self._set_status(f"Save failed: {ex}", "#BF616A")

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -16,9 +16,10 @@ import subprocess
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
-from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QHeaderView,
-                               QSizePolicy, QSplitter, QTableWidgetItem,
-                               QVBoxLayout, QWidget)
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QHeaderView, QLabel,
+                               QScrollArea, QSizePolicy, QSplitter,
+                               QTableWidgetItem, QVBoxLayout, QWidget)
 
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
@@ -109,7 +110,7 @@ class _PreviewWorker(QObject):
     ready = Signal(dict)
 
     def __init__(self, index_path, game_dir, path, gen,
-                 byte_limit, table_limit, text_cap, hex_cap):
+                 byte_limit, table_limit, image_limit, text_cap, hex_cap):
         super().__init__()
         self._index_path = index_path
         self._game_dir = game_dir
@@ -117,6 +118,7 @@ class _PreviewWorker(QObject):
         self._gen = gen
         self._byte_limit = byte_limit
         self._table_limit = table_limit
+        self._image_limit = image_limit
         self._text_cap = text_cap
         self._hex_cap = hex_cap
 
@@ -171,11 +173,26 @@ class _PreviewWorker(QObject):
         if not gd:
             res.update(kind="meta")
             return
-        # 3) too big for an inline byte preview
+
+        # 3) image asset (chiefly DDS textures) → rendered PNG for the pane
+        if self._path.lower().endswith(game_index._IMAGE_EXTS):
+            if orig > self._image_limit:
+                res.update(kind="toobig")
+                return
+            data = game_index.extract_asset(con, self._path, gd)
+            img = game_index.decode_image(data, self._path)
+            if img:
+                res.update(kind="image", img=img)
+            else:  # unsupported codec (e.g. BC7) → show the header bytes
+                res.update(kind="hex",
+                           text=game_index.hexdump(data, limit=self._hex_cap))
+            return
+
+        # 4) too big for an inline byte preview
         if orig > self._byte_limit:
             res.update(kind="toobig")
             return
-        # 4) text or hex
+        # 5) text or hex
         data = game_index.extract_asset(con, self._path, gd)
         text = game_index.decode_text(data, limit=self._text_cap)
         if text is not None:
@@ -327,9 +344,9 @@ class GameDataPage(ToolPageBase):
         self._pv_text.setPlaceholderText(
             "Click any row on the left to view that asset.\n\nKeyed data "
             "tables (items, NPCs, quests, skills, drops …) open as a grid of "
-            "records. Text formats (XML, JSON, JS, CSS) show as text; "
-            "everything else shows a hex + metadata view. Textures, audio and "
-            "models need format converters, which are a later addition.")
+            "records, DDS textures render as images, and text formats "
+            "(XML, JSON, JS, CSS) show as text; everything else shows a "
+            "hex + metadata view.")
         pv.addWidget(self._pv_text, 1)
 
         # Grid view for keyed game-data tables (.pabgb), parsed via CDUMM's
@@ -343,6 +360,16 @@ class GameDataPage(ToolPageBase):
         self._pv_grid.verticalHeader().setDefaultSectionSize(30)
         self._pv_grid.setVisible(False)
         pv.addWidget(self._pv_grid, 1)
+
+        # Image view for textures (DDS decoded to PNG). Hidden until selected.
+        self._pv_image = QLabel(pane)
+        self._pv_image.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._pv_img_scroll = QScrollArea(pane)
+        self._pv_img_scroll.setWidget(self._pv_image)
+        self._pv_img_scroll.setWidgetResizable(True)
+        self._pv_img_scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._pv_img_scroll.setVisible(False)
+        pv.addWidget(self._pv_img_scroll, 1)
 
         self._pv_extract = PushButton("Extract raw file…", pane)
         self._pv_extract.setEnabled(False)
@@ -523,6 +550,7 @@ class GameDataPage(ToolPageBase):
     _PREVIEW_HEX_CAP = 4096               # bytes shown for the hex view
     _PREVIEW_SIZE_LIMIT = 4 * 1024 * 1024   # inline byte-preview ceiling
     _TABLE_SIZE_LIMIT = 8 * 1024 * 1024     # parse .pabgb data tables up to here
+    _IMAGE_SIZE_LIMIT = 64 * 1024 * 1024    # decode DDS textures up to here
     #   Reading / decoding / parsing all run on a background worker, so these
     #   caps just bound memory + latency — they no longer gate the UI thread.
 
@@ -553,8 +581,8 @@ class GameDataPage(ToolPageBase):
             self._index_path,
             str(self._game_dir) if self._game_dir else "",
             path, self._pv_gen, self._PREVIEW_SIZE_LIMIT,
-            self._TABLE_SIZE_LIMIT, self._PREVIEW_TEXT_CAP,
-            self._PREVIEW_HEX_CAP)
+            self._TABLE_SIZE_LIMIT, self._IMAGE_SIZE_LIMIT,
+            self._PREVIEW_TEXT_CAP, self._PREVIEW_HEX_CAP)
         w.moveToThread(th)
         th.started.connect(w.run)
         w.ready.connect(self._on_preview_ready)
@@ -600,6 +628,17 @@ class GameDataPage(ToolPageBase):
             self._pv_extract.setEnabled(True)
             return
 
+        if kind == "image":
+            img = res.get("img", {})
+            self._pv_meta.setText(
+                f"texture  ·  {img.get('orig_w', '?')}×"
+                f"{img.get('orig_h', '?')}  ·  {img.get('mode', '')}"
+                + (f"  ·  {meta}" if meta else "")
+                + f"\n{res.get('path', '')}")
+            self._show_image(img.get("png", b""))
+            self._pv_extract.setEnabled(True)
+            return
+
         self._pv_meta.setText(f"{meta}\n{res.get('path', '')}" if meta
                               else res.get("path", ""))
         if kind == "text":
@@ -630,14 +669,31 @@ class GameDataPage(ToolPageBase):
 
     def _show_text(self, text: str, *, wrap: bool) -> None:
         self._pv_grid.setVisible(False)
+        self._pv_img_scroll.setVisible(False)
         self._pv_text.setVisible(True)
         self._pv_text.setLineWrapMode(
             self._pv_text.LineWrapMode.WidgetWidth if wrap
             else self._pv_text.LineWrapMode.NoWrap)
         self._pv_text.setPlainText(text)
 
+    def _show_image(self, png: bytes) -> None:
+        self._pv_text.setVisible(False)
+        self._pv_grid.setVisible(False)
+        self._pv_img_scroll.setVisible(True)
+        pm = QPixmap()
+        if png:
+            pm.loadFromData(png, "PNG")
+        # Fit to the pane width (preserve aspect); the scroll area handles
+        # anything taller than the viewport.
+        avail = self._pv_img_scroll.viewport().width() or 600
+        if not pm.isNull() and pm.width() > avail:
+            pm = pm.scaledToWidth(
+                avail, Qt.TransformationMode.SmoothTransformation)
+        self._pv_image.setPixmap(pm)
+
     def _show_grid(self, cols: list, rows: list) -> None:
         self._pv_text.setVisible(False)
+        self._pv_img_scroll.setVisible(False)
         self._pv_grid.setVisible(True)
         self._pv_grid.clear()
         self._pv_grid.setColumnCount(len(cols))

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -54,6 +54,115 @@ class _GameIndexWorker(QObject):
             self.error.emit(str(ex))
 
 
+_GRID_ROW_CAP = 500          # max records rendered in the table-preview grid
+
+
+def _cell(v) -> str:
+    """Stringify one field value for a grid cell (bounded)."""
+    if v is None:
+        return ""
+    s = str(v)
+    return s if len(s) <= 200 else s[:200] + "…"
+
+
+def _shape_records(records: dict, schema) -> tuple[list, list, int]:
+    """Turn parse_records output into (columns, rows, total) for the grid.
+
+    Columns are ``_key`` + ``_name`` + the schema's field names in order;
+    rows are stringified and capped to the first ``_GRID_ROW_CAP`` by key.
+    """
+    field_names = [f.name for f in schema.fields] if schema else []
+    cols = ["_key", "_name"] + field_names
+    rows = [[_cell(records[k].get(c)) for c in cols]
+            for k in sorted(records)[:_GRID_ROW_CAP]]
+    return cols, rows, len(records)
+
+
+class _PreviewWorker(QObject):
+    """Reads + decodes one asset off the UI thread so a large table or
+    texture can never freeze the app. Emits exactly one ``ready`` dict
+    carrying its generation id (stale results are ignored by the page)."""
+
+    ready = Signal(dict)
+
+    def __init__(self, index_path, game_dir, path, gen,
+                 byte_limit, table_limit, text_cap, hex_cap):
+        super().__init__()
+        self._index_path = index_path
+        self._game_dir = game_dir
+        self._path = path
+        self._gen = gen
+        self._byte_limit = byte_limit
+        self._table_limit = table_limit
+        self._text_cap = text_cap
+        self._hex_cap = hex_cap
+
+    def run(self) -> None:
+        res = {"gen": self._gen, "path": self._path}
+        try:
+            con = sqlite3.connect(self._index_path)
+            try:
+                self._work(con, res)
+            finally:
+                con.close()
+        except Exception as ex:  # noqa: BLE001 — surface to the pane
+            res.update(kind="error", error=str(ex))
+        self.ready.emit(res)
+
+    def _work(self, con, res: dict) -> None:
+        row = game_index.get_asset(con, self._path)
+        if row is None:
+            res.update(kind="error", error="asset not in index")
+            return
+        res["row"] = {k: row[k] for k in
+                      ("ext", "orig_size", "archive", "compressed", "encrypted")}
+        orig = int(row["orig_size"])
+        gd = self._game_dir
+
+        # 1) keyed game-data table → parsed grid (CDUMM's semantic schemas)
+        if gd and self._path.endswith(".pabgb"):
+            try:
+                from cdumm.semantic import parser as sem
+                table = sem.identify_table_from_path(self._path)
+            except Exception:  # noqa: BLE001
+                table = None
+            if table:
+                if orig > self._table_limit:
+                    res.update(kind="toobig")
+                    return
+                try:
+                    body = game_index.extract_asset(con, self._path, gd)
+                    header = game_index.extract_asset(
+                        con, self._path[:-6] + ".pabgh", gd)
+                    recs = sem.parse_records(table, body, header)
+                except Exception:  # noqa: BLE001 — fall back to a raw view
+                    recs = {}
+                if recs:
+                    cols, rows, total = _shape_records(
+                        recs, sem.get_schema(table))
+                    res.update(kind="table", table=table,
+                               cols=cols, rows=rows, total=total)
+                    return
+
+        # 2) no game folder → metadata only
+        if not gd:
+            res.update(kind="meta")
+            return
+        # 3) too big for an inline byte preview
+        if orig > self._byte_limit:
+            res.update(kind="toobig")
+            return
+        # 4) text or hex
+        data = game_index.extract_asset(con, self._path, gd)
+        text = game_index.decode_text(data, limit=self._text_cap)
+        if text is not None:
+            res.update(kind="text", text=text[:self._text_cap],
+                       truncated=len(text) >= self._text_cap)
+        else:
+            res.update(kind="hex",
+                       text=game_index.hexdump(data, limit=self._hex_cap))
+
+
 class GameDataPage(ToolPageBase):
     """Build, locate, and search an index of the installed game's data."""
 
@@ -193,11 +302,25 @@ class GameDataPage(ToolPageBase):
         _mf.setPixelSize(13)
         self._pv_text.setFont(_mf)
         self._pv_text.setPlaceholderText(
-            "Click any row on the left to view that asset.\n\nText formats "
-            "(XML, JSON, JS, CSS) show as text; everything else shows a hex "
-            "+ metadata view. Textures, audio and models need format "
-            "converters, which are a later addition.")
+            "Click any row on the left to view that asset.\n\nKeyed data "
+            "tables (items, NPCs, quests, skills, drops …) open as a grid of "
+            "records. Text formats (XML, JSON, JS, CSS) show as text; "
+            "everything else shows a hex + metadata view. Textures, audio and "
+            "models need format converters, which are a later addition.")
         pv.addWidget(self._pv_text, 1)
+
+        # Grid view for keyed game-data tables (.pabgb), parsed via CDUMM's
+        # semantic schemas. Hidden until a table is selected.
+        self._pv_grid = TableWidget(pane)
+        self._pv_grid.verticalHeader().hide()
+        self._pv_grid.setEditTriggers(self._pv_grid.EditTrigger.NoEditTriggers)
+        _gf = self._pv_grid.font()
+        _gf.setPixelSize(13)
+        self._pv_grid.setFont(_gf)
+        self._pv_grid.verticalHeader().setDefaultSectionSize(30)
+        self._pv_grid.setVisible(False)
+        pv.addWidget(self._pv_grid, 1)
+
         self._pv_extract = PushButton("Extract raw file…", pane)
         self._pv_extract.setEnabled(False)
         self._pv_extract.clicked.connect(self._extract_raw)
@@ -208,6 +331,8 @@ class GameDataPage(ToolPageBase):
         split.setStretchFactor(1, 2)
         self._preview_bytes: bytes | None = None
         self._preview_name: str | None = None
+        self._pv_gen = 0                 # bumped per selection; ignore stale
+        self._pv_jobs: list = []         # live (thread, worker) — keep refs
         # stretch=1 makes this row absorb the page's spare vertical space
         # (the base layout's trailing addStretch() has factor 0, so it yields).
         root.insertWidget(root.count() - 1, split, 1)
@@ -373,9 +498,10 @@ class GameDataPage(ToolPageBase):
     # ── preview pane ─────────────────────────────────────────────────
     _PREVIEW_TEXT_CAP = 200_000            # chars shown for text assets
     _PREVIEW_HEX_CAP = 4096               # bytes shown for the hex view
-    _PREVIEW_SIZE_LIMIT = 4 * 1024 * 1024   # keep inline decode cheap: a 4 MB
-    #   read+LZ4+decode is ~tens of ms; a multi-MB table/texture would freeze
-    #   the UI thread (AppHang). Bigger assets show metadata + Extract raw only.
+    _PREVIEW_SIZE_LIMIT = 4 * 1024 * 1024   # inline byte-preview ceiling
+    _TABLE_SIZE_LIMIT = 8 * 1024 * 1024     # parse .pabgb data tables up to here
+    #   Reading / decoding / parsing all run on a background worker, so these
+    #   caps just bound memory + latency — they no longer gate the UI thread.
 
     def _selected_path(self) -> str | None:
         items = self._table.selectedItems()
@@ -385,79 +511,122 @@ class GameDataPage(ToolPageBase):
         return cell.text() if cell else None
 
     def _on_asset_selected(self) -> None:
-        """Read + preview the clicked asset (metadata always; text or hex
-        when the bytes are reachable and within the inline size limit)."""
+        """Kick off a background read of the clicked asset. The heavy work
+        (extract / decompress / decode / parse) runs on a worker thread;
+        results land in _on_preview_ready, so the UI can never freeze."""
         path = self._selected_path()
         if not path:
             return
+        self._pv_gen += 1
         self._preview_bytes = None
         self._preview_name = os.path.basename(path)
         self._pv_extract.setEnabled(False)
         self._pv_title.setText(self._preview_name)
+        self._pv_meta.setText("")
+        self._show_text("Reading…", wrap=True)
 
-        row = data = err = None
-        try:
-            con = sqlite3.connect(self._index_path)
-            try:
-                row = game_index.get_asset(con, path)
-                if (row and self._game_dir
-                        and int(row["orig_size"]) <= self._PREVIEW_SIZE_LIMIT):
-                    data = game_index.extract_asset(
-                        con, path, str(self._game_dir))
-            finally:
-                con.close()
-        except Exception as ex:  # noqa: BLE001 — surface to the pane
-            err = str(ex)
+        th = QThread(self)
+        w = _PreviewWorker(
+            self._index_path,
+            str(self._game_dir) if self._game_dir else "",
+            path, self._pv_gen, self._PREVIEW_SIZE_LIMIT,
+            self._TABLE_SIZE_LIMIT, self._PREVIEW_TEXT_CAP,
+            self._PREVIEW_HEX_CAP)
+        w.moveToThread(th)
+        th.started.connect(w.run)
+        w.ready.connect(self._on_preview_ready)
+        w.ready.connect(th.quit)
+        w.ready.connect(w.deleteLater)
+        th.finished.connect(th.deleteLater)
+        job = (th, w)
+        self._pv_jobs.append(job)
+        th.finished.connect(
+            lambda job=job: job in self._pv_jobs and self._pv_jobs.remove(job))
+        th.start()
 
-        if row is None:
+    def _on_preview_ready(self, res: dict) -> None:
+        if res.get("gen") != self._pv_gen:
+            return   # a newer selection superseded this result
+        row = res.get("row")
+        meta = ""
+        if row:
+            flags = []
+            if row["compressed"]:
+                flags.append("LZ4")
+            if row["encrypted"]:
+                flags.append("encrypted")
+            meta = (f"{row['ext']}  ·  {int(row['orig_size']):,} bytes  ·  "
+                    f"archive {row['archive']}  ·  "
+                    f"{', '.join(flags) or 'stored raw'}")
+        kind = res.get("kind")
+
+        if kind == "table":
+            total = res.get("total", 0)
+            shown = len(res.get("rows", []))
+            more = f" (showing first {shown:,})" if shown < total else ""
             self._pv_meta.setText(
-                f"Could not read: {err}" if err else "Asset not in index.")
-            self._pv_text.setPlainText("")
-            return
-
-        flags = []
-        if row["compressed"]:
-            flags.append("LZ4")
-        if row["encrypted"]:
-            flags.append("encrypted")
-        self._pv_meta.setText(
-            f"{row['ext']}  ·  {int(row['orig_size']):,} bytes  ·  archive "
-            f"{row['archive']}  ·  {', '.join(flags) or 'stored raw'}\n{path}")
-
-        if not self._game_dir:
-            self._pv_text.setPlainText(
-                "No game folder configured — can't read asset bytes.")
-            return
-        if int(row["orig_size"]) > self._PREVIEW_SIZE_LIMIT:
-            self._pv_text.setPlainText(
-                f"Asset is {int(row['orig_size']):,} bytes — too large to "
-                "preview inline.\nUse “Extract raw file…” to save it to disk.")
+                f"data table “{res.get('table', '')}”  ·  {total:,} records"
+                f"{more}\n{res.get('path', '')}")
+            self._show_grid(res.get("cols", []), res.get("rows", []))
             self._pv_extract.setEnabled(True)
             return
-        if err is not None:
-            self._pv_text.setPlainText(f"Could not read asset bytes:\n{err}")
-            return
-        if data is None:
-            self._pv_text.setPlainText("(no data)")
-            return
 
-        self._preview_bytes = data
-        self._pv_extract.setEnabled(True)
-        text = game_index.decode_text(data, limit=self._PREVIEW_TEXT_CAP)
-        if text is not None:
-            if len(text) >= self._PREVIEW_TEXT_CAP:
-                text += ("\n\n… (truncated preview — use Extract raw for the "
+        self._pv_meta.setText(f"{meta}\n{res.get('path', '')}" if meta
+                              else res.get("path", ""))
+        if kind == "text":
+            body = res.get("text", "")
+            if res.get("truncated"):
+                body += ("\n\n… (truncated preview — use Extract raw for the "
                          "full file)")
-            self._pv_text.setLineWrapMode(
-                self._pv_text.LineWrapMode.WidgetWidth)
-            self._pv_text.setPlainText(text)
-        else:
-            self._pv_text.setLineWrapMode(self._pv_text.LineWrapMode.NoWrap)
-            self._pv_text.setPlainText(
+            self._show_text(body, wrap=True)
+            self._pv_extract.setEnabled(True)
+        elif kind == "hex":
+            self._show_text(
                 "Binary asset — no visual decoder for this format yet "
                 "(textures, audio and models need converters). Hex view of "
-                "the first bytes:\n\n"
-                + game_index.hexdump(data, limit=self._PREVIEW_HEX_CAP))
+                "the first bytes:\n\n" + res.get("text", ""), wrap=False)
+            self._pv_extract.setEnabled(True)
+        elif kind == "toobig":
+            self._show_text(
+                "Asset is too large to preview inline.\nUse “Extract raw "
+                "file…” to save it to disk.", wrap=True)
+            self._pv_extract.setEnabled(True)
+        elif kind == "meta":
+            self._show_text(
+                "No game folder configured — can't read asset bytes.",
+                wrap=True)
+        else:  # error
+            self._show_text(
+                f"Could not read asset:\n{res.get('error', '')}", wrap=True)
+
+    def _show_text(self, text: str, *, wrap: bool) -> None:
+        self._pv_grid.setVisible(False)
+        self._pv_text.setVisible(True)
+        self._pv_text.setLineWrapMode(
+            self._pv_text.LineWrapMode.WidgetWidth if wrap
+            else self._pv_text.LineWrapMode.NoWrap)
+        self._pv_text.setPlainText(text)
+
+    def _show_grid(self, cols: list, rows: list) -> None:
+        self._pv_text.setVisible(False)
+        self._pv_grid.setVisible(True)
+        self._pv_grid.clear()
+        self._pv_grid.setColumnCount(len(cols))
+        self._pv_grid.setHorizontalHeaderLabels([str(c) for c in cols])
+        self._pv_grid.setRowCount(len(rows))
+        for r, rowvals in enumerate(rows):
+            for c, v in enumerate(rowvals):
+                self._pv_grid.setItem(r, c, QTableWidgetItem(v))
+        # Auto-size only for narrow tables; wide ones (e.g. iteminfo's 113
+        # fields) keep a default width and scroll, so sizing stays instant.
+        if len(cols) <= 25:
+            try:
+                self._pv_grid.resizeColumnsToContents()
+            except Exception:  # noqa: BLE001
+                pass
+        else:
+            for c in range(len(cols)):
+                self._pv_grid.setColumnWidth(c, 130)
 
     def _extract_raw(self) -> None:
         """Save the selected asset's real (decoded) bytes to a file."""

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -742,9 +742,9 @@ class GameDataPage(ToolPageBase):
         self._pv_3d_btn.clicked.connect(self._on_view_3d)
         pv.addWidget(self._pv_3d_btn)
 
-        # Save the decoded texture as a normal image (JPEG, or PNG to keep
-        # transparency) — only shown for image previews.
-        self._pv_saveimg_btn = PushButton("Save as JPEG…", pane)
+        # Save the decoded texture as a normal image — PNG keeps the
+        # transparent background, JPEG flattens it. Only shown for images.
+        self._pv_saveimg_btn = PushButton("Save as PNG / JPEG…", pane)
         self._pv_saveimg_btn.setVisible(False)
         self._pv_saveimg_btn.clicked.connect(self._on_save_image)
         pv.addWidget(self._pv_saveimg_btn)
@@ -1326,17 +1326,18 @@ class GameDataPage(ToolPageBase):
     def _on_save_image(self) -> None:
         """Save the decoded texture as a standard image the OS can open.
 
-        JPEG by default (small, universally viewable); PNG is offered too for
-        anyone who needs the alpha channel kept.
+        PNG by default — it keeps the transparent background exactly as shown
+        in the preview. JPEG is offered too (smaller, but no transparency, so
+        transparent areas are flattened onto white).
         """
         img = self._pv_qimage
         if img is None or img.isNull():
             return
         base = os.path.splitext(self._preview_name or "texture")[0]
-        start = os.path.join(os.path.expanduser("~"), base + ".jpg")
+        start = os.path.join(os.path.expanduser("~"), base + ".png")
         path, _sel = QFileDialog.getSaveFileName(
             self, "Save texture as image", start,
-            "JPEG image (*.jpg *.jpeg);;PNG image (*.png)")
+            "PNG image — keeps transparency (*.png);;JPEG image (*.jpg *.jpeg)")
         if not path:
             return
         ext = os.path.splitext(path)[1].lower()

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -378,7 +378,7 @@ class GameDataPage(ToolPageBase):
 
     # ── extra controls (persistent — not wiped by _clear_results) ────
     def _build_controls(self) -> None:
-        from qfluentwidgets import (BodyLabel, CaptionLabel, LineEdit,
+        from qfluentwidgets import (BodyLabel, CaptionLabel, ComboBox, LineEdit,
                                      PlainTextEdit, PushButton,
                                      StrongBodyLabel, TableWidget)
         root = self._container.layout()
@@ -389,13 +389,15 @@ class GameDataPage(ToolPageBase):
         self._path_label = CaptionLabel(
             f"Save location:  {self._index_path}", self._container)
         self._path_label.setWordWrap(True)
-        loc_row.addWidget(self._path_label, 1)
+        loc_row.addWidget(self._path_label)
+        loc_row.addSpacing(12)
         self._change_btn = PushButton("Change…", self._container)
         self._change_btn.clicked.connect(self._choose_location)
         loc_row.addWidget(self._change_btn)
         self._open_btn = PushButton("Open folder", self._container)
         self._open_btn.clicked.connect(self._open_location)
         loc_row.addWidget(self._open_btn)
+        loc_row.addStretch(1)   # keep the buttons grouped by the path, not far right
         root.insertLayout(root.count() - 1, loc_row)
         root.insertSpacing(root.count() - 1, 16)
 
@@ -414,6 +416,17 @@ class GameDataPage(ToolPageBase):
         self._search.setFont(_sf)
         self._search.textChanged.connect(self._on_search)
         search_row.addWidget(self._search)
+        _show_lbl = CaptionLabel("Show", self._container)
+        _show_lbl.setContentsMargins(14, 0, 6, 0)
+        search_row.addWidget(_show_lbl)
+        self._limit_combo = ComboBox(self._container)
+        self._limit_combo.addItems([f"{n:,}" for n in self._LIMIT_OPTIONS])
+        self._limit_combo.setCurrentIndex(1)          # default 300 (unchanged)
+        self._limit_combo.setFixedHeight(38)
+        self._limit_combo.setMinimumWidth(104)
+        self._limit_combo.currentIndexChanged.connect(
+            lambda _i: self._on_search(self._search.text()))
+        search_row.addWidget(self._limit_combo)
         search_row.addStretch(1)
         root.insertLayout(root.count() - 1, search_row)
 
@@ -659,7 +672,9 @@ class GameDataPage(ToolPageBase):
                 for t in tables)
         except Exception as ex:  # noqa: BLE001
             detail = f"(could not read tables: {ex})"
-        self._add_result_card("Largest keyed game-data tables", detail)
+        card = self._add_result_card("Largest keyed game-data tables", detail)
+        card.setMaximumWidth(600)   # hug the content instead of spanning the page
+        self._results_layout.setAlignment(card, Qt.AlignLeft)
         # refresh the viewer if a search is active
         self._on_search(self._search.text())
 
@@ -669,6 +684,19 @@ class GameDataPage(ToolPageBase):
         self._add_result_card("Error", msg, "#BF616A")
 
     # ── search / viewer ──────────────────────────────────────────────
+    # Result-count choices for the "Show" selector. Capped at 20,000: a broad
+    # 2-char substring can match >1,000,000 paths and the results table renders
+    # on the UI thread, so an unbounded "All" would freeze the app — 20,000
+    # already covers every realistic per-type query (e.g. .pae is 6,638).
+    _LIMIT_OPTIONS = (100, 300, 1_000, 5_000, 20_000)
+
+    def _result_limit(self) -> int:
+        combo = getattr(self, "_limit_combo", None)
+        idx = combo.currentIndex() if combo is not None else 1
+        if 0 <= idx < len(self._LIMIT_OPTIONS):
+            return self._LIMIT_OPTIONS[idx]
+        return 300
+
     def _on_search(self, text: str) -> None:
         text = (text or "").strip()
         if not os.path.exists(self._index_path):
@@ -679,18 +707,21 @@ class GameDataPage(ToolPageBase):
             self._hits.setText("Type at least 2 characters to search.")
             self._table.setRowCount(0)
             return
+        limit = self._result_limit()
         try:
             con = sqlite3.connect(self._index_path)
             try:
-                rows = game_index.search_assets(con, query=text, limit=300)
+                rows = game_index.search_assets(con, query=text, limit=limit)
             finally:
                 con.close()
         except Exception as ex:  # noqa: BLE001
             self._hits.setText(f"Search failed: {ex}")
             return
+        capped = len(rows) >= limit
         self._hits.setText(
-            f"{len(rows)} match(es)" + (" (showing first 300)"
-                                        if len(rows) == 300 else ""))
+            f"{len(rows):,} match(es)"
+            + (f" (showing first {limit:,} — narrow the search for more)"
+               if capped else ""))
         self._table.setRowCount(len(rows))
         for i, r in enumerate(rows):
             self._table.setItem(i, 0, QTableWidgetItem(str(r["path"])))

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -795,6 +795,15 @@ class GameDataPage(ToolPageBase):
         self._set_status("Index built.", "#2E7D32")
         self._open_btn.setEnabled(os.path.exists(self._index_path))
 
+        # Record the build in the Activity Log, the same way the other pages
+        # log their actions (shows up as a "snapshot" entry).
+        self._log_activity(
+            "snapshot",
+            f"Game data index built: "
+            f"{int(stats.get('assets_total', 0)):,} assets indexed",
+            f"{stats.get('archives', '?')} archives · "
+            f"{stats.get('data_table_distinct', '?')} data tables")
+
         detail = ""
         try:
             con = sqlite3.connect(self._index_path)

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -233,7 +233,10 @@ class _PreviewWorker(QObject):
                     body = game_index.extract_asset(con, self._path, gd)
                     header = game_index.extract_asset(
                         con, self._path[:-6] + ".pabgh", gd)
-                    recs = sem.parse_records(table, body, header)
+                    # Display-only decoder: honors override flags + walks
+                    # variable-length fields so richly-schema'd tables
+                    # (iteminfo, regioninfo, ...) show their real columns.
+                    recs = sem.parse_records_display(table, body, header)
                 except Exception:  # noqa: BLE001 — fall back to a raw view
                     recs = {}
                 if recs:

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -65,17 +65,40 @@ def _cell(v) -> str:
     return s if len(s) <= 200 else s[:200] + "…"
 
 
-def _shape_records(records: dict, schema) -> tuple[list, list, int]:
-    """Turn parse_records output into (columns, rows, total) for the grid.
+def _shape_records(records: dict, schema) -> tuple[list, list, int, float]:
+    """Turn parse_records output into (columns, rows, total, health).
 
     Columns are ``_key`` + ``_name`` + the schema's field names in order;
     rows are stringified and capped to the first ``_GRID_ROW_CAP`` by key.
+    ``health`` is the fraction of schema-field columns whose sampled values
+    look unusable — constant, all-zero/None, or simply mirroring the key —
+    i.e. a signal that CDUMM's patch-oriented parser mis-read this table's
+    fields (its job is diffing, not a clean human dump).
     """
     field_names = [f.name for f in schema.fields] if schema else []
     cols = ["_key", "_name"] + field_names
-    rows = [[_cell(records[k].get(c)) for c in cols]
-            for k in sorted(records)[:_GRID_ROW_CAP]]
-    return cols, rows, len(records)
+    keys = sorted(records)[:_GRID_ROW_CAP]
+    rows = [[_cell(records[k].get(c)) for c in cols] for k in keys]
+
+    suspect = 0
+    sample = keys[:60]
+    for fn in field_names:
+        vals = [records[k].get(fn) for k in sample]
+        sv = [str(v) for v in vals]
+        const = len(set(sv)) == 1
+        zero = all(s in ("", "None") or set(s) <= set("0") for s in sv)
+        seq = False
+        try:
+            iv = [int(v) for v in vals]
+            seq = len(iv) > 2 and all(
+                (iv[i] - iv[0]) == (sample[i] - sample[0])
+                for i in range(len(iv)))
+        except (TypeError, ValueError):
+            pass
+        if const or zero or seq:
+            suspect += 1
+    health = (suspect / len(field_names)) if field_names else 0.0
+    return cols, rows, len(records), health
 
 
 class _PreviewWorker(QObject):
@@ -138,10 +161,10 @@ class _PreviewWorker(QObject):
                 except Exception:  # noqa: BLE001 — fall back to a raw view
                     recs = {}
                 if recs:
-                    cols, rows, total = _shape_records(
+                    cols, rows, total, health = _shape_records(
                         recs, sem.get_schema(table))
-                    res.update(kind="table", table=table,
-                               cols=cols, rows=rows, total=total)
+                    res.update(kind="table", table=table, cols=cols,
+                               rows=rows, total=total, health=health)
                     return
 
         # 2) no game folder → metadata only
@@ -564,9 +587,15 @@ class GameDataPage(ToolPageBase):
             total = res.get("total", 0)
             shown = len(res.get("rows", []))
             more = f" (showing first {shown:,})" if shown < total else ""
+            if res.get("health", 0.0) >= 0.9:
+                note = ("\n⚠ field columns didn't parse cleanly for this "
+                        "table on this build — trust _key and _name only")
+            else:
+                note = ("\nfield columns are experimental (from CDUMM's patch "
+                        "parser); _key and _name are authoritative")
             self._pv_meta.setText(
                 f"data table “{res.get('table', '')}”  ·  {total:,} records"
-                f"{more}\n{res.get('path', '')}")
+                f"{more}{note}\n{res.get('path', '')}")
             self._show_grid(res.get("cols", []), res.get("rows", []))
             self._pv_extract.setEnabled(True)
             return

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -110,7 +110,8 @@ _FILE_TYPE_GUIDE = """A quick guide to Crimson Desert's file types — what you'
 Tip: a name ending in "info" is almost always a game-data table you can edit."""
 
 
-def _shape_records(records: dict, schema) -> tuple[list, list, int, float]:
+def _shape_records(records: dict, schema, positions: dict | None = None
+                   ) -> tuple[list, list, int, float]:
     """Turn parse_records output into (columns, rows, total, health).
 
     Columns are ``_key`` + ``_name`` + the schema's field names in order;
@@ -125,9 +126,21 @@ def _shape_records(records: dict, schema) -> tuple[list, list, int, float]:
     # (e.g. sequencerspawninfo) also list _key/_name among their schema
     # fields, which would render a redundant duplicate column — drop those.
     field_names = [f for f in field_names if f not in ("_key", "_name")]
-    cols = ["_key", "_name"] + field_names
+    pos_col = "world pos (X, Y, Z)"
+    cols = ["_key", "_name"] + ([pos_col] if positions else []) + field_names
     keys = sorted(records)[:_GRID_ROW_CAP]
-    rows = [[_cell(records[k].get(c)) for c in cols] for k in keys]
+
+    def _posval(k):
+        p = positions.get(k) if positions else None
+        return f"{p[0]:.1f}, {p[1]:.1f}, {p[2]:.1f}" if p else ""
+
+    rows = []
+    for k in keys:
+        row = [_cell(records[k].get("_key")), _cell(records[k].get("_name"))]
+        if positions:
+            row.append(_posval(k))
+        row += [_cell(records[k].get(c)) for c in field_names]
+        rows.append(row)
 
     suspect = 0
     sample = keys[:60]
@@ -211,10 +224,13 @@ class _PreviewWorker(QObject):
                 except Exception:  # noqa: BLE001 — fall back to a raw view
                     recs = {}
                 if recs:
+                    positions = game_index.decode_table_positions(
+                        table, body, header)
                     cols, rows, total, health = _shape_records(
-                        recs, sem.get_schema(table))
+                        recs, sem.get_schema(table), positions)
                     res.update(kind="table", table=table, cols=cols,
-                               rows=rows, total=total, health=health)
+                               rows=rows, total=total, health=health,
+                               has_pos=bool(positions))
                     return
 
         # 2) no game folder → metadata only
@@ -925,6 +941,9 @@ class GameDataPage(ToolPageBase):
             else:
                 note = ("\nfield columns are experimental (from CDUMM's patch "
                         "parser); _key and _name are authoritative")
+            if res.get("has_pos"):
+                note += ("\nworld pos (X, Y, Z) = decoded, region-validated "
+                         "map coordinates for mod-makers")
             self._pv_meta.setText(
                 f"data table “{res.get('table', '')}”  ·  {total:,} records"
                 f"{more}{note}\n{res.get('path', '')}")

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -945,8 +945,11 @@ class GameDataPage(ToolPageBase):
         trailing = res.get("trailing", 0)
         more = f" · first {shown:,} of {total:,}" if shown < total else ""
         tail = f" · +{trailing} trailing byte(s)" if trailing else ""
+        fmt = res.get("format")
+        fmt_line = f"Format: {fmt}.  " if fmt else ""
         self._pv_meta.setText(
-            "Struct view — this format has no embedded field names, so each "
+            fmt_line
+            + "Struct view — this format has no embedded field names, so each "
             "32-bit word is shown as unsigned / signed / float. Values in the "
             "1,000,000+ range are flagged as likely record keys."
             f"  ({total:,} words{more}{tail})\n"

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -589,6 +589,20 @@ class GameDataPage(ToolPageBase):
         self._search.setFont(_sf)
         self._search.textChanged.connect(self._on_search)
         search_row.addWidget(self._search)
+        # File-type filter — narrow results to one extension (e.g. .dds). The
+        # list is curated until the index is built, then repopulated from the
+        # actual extensions present (with counts) in _populate_type_filter().
+        _type_lbl = CaptionLabel("Type", self._container)
+        _type_lbl.setContentsMargins(14, 0, 6, 0)
+        search_row.addWidget(_type_lbl)
+        self._type_combo = ComboBox(self._container)
+        self._type_combo.setFixedHeight(38)
+        self._type_combo.setMinimumWidth(150)
+        self._type_exts: list[str | None] = []
+        self._set_type_items(self._DEFAULT_TYPE_FILTERS)
+        self._type_combo.currentIndexChanged.connect(
+            lambda _i: self._on_search(self._search.text()))
+        search_row.addWidget(self._type_combo)
         _show_lbl = CaptionLabel("Show", self._container)
         _show_lbl.setContentsMargins(14, 0, 6, 0)
         search_row.addWidget(_show_lbl)
@@ -885,6 +899,7 @@ class GameDataPage(ToolPageBase):
         try:
             con = sqlite3.connect(self._index_path)
             try:
+                self._populate_type_filter(con)   # real extensions + counts
                 tables = game_index.list_data_tables(con)[:12]
             finally:
                 con.close()
@@ -918,13 +933,63 @@ class GameDataPage(ToolPageBase):
             return self._LIMIT_OPTIONS[idx]
         return 300
 
+    # Curated file-type filter shown before the index is built (and as a
+    # fallback). Once built, _populate_type_filter() replaces this with the
+    # extensions actually present, each with its count.
+    _DEFAULT_TYPE_FILTERS = (
+        ("All types", None), (".pabgb", ".pabgb"), (".dds", ".dds"),
+        (".wem", ".wem"), (".bnk", ".bnk"), (".paa", ".paa"),
+        (".pae", ".pae"), (".paseq", ".paseq"), (".prefab", ".prefab"),
+        (".meshinfo", ".meshinfo"), (".hkx", ".hkx"), (".xml", ".xml"),
+    )
+
+    def _set_type_items(self, items) -> None:
+        """Rebuild the Type dropdown from ``items`` (list of (label, ext)),
+        keeping the current selection by extension when it still exists."""
+        prev = self._type_filter() if getattr(self, "_type_exts", None) else None
+        self._type_combo.blockSignals(True)
+        self._type_combo.clear()
+        self._type_exts = [ext for _lbl, ext in items]
+        self._type_combo.addItems([lbl for lbl, _ext in items])
+        if prev in self._type_exts:
+            self._type_combo.setCurrentIndex(self._type_exts.index(prev))
+        self._type_combo.blockSignals(False)
+
+    def _type_filter(self) -> str | None:
+        """The currently selected extension filter, or None for 'All types'."""
+        exts = getattr(self, "_type_exts", None)
+        if not exts:
+            return None
+        idx = self._type_combo.currentIndex()
+        return exts[idx] if 0 <= idx < len(exts) else None
+
+    def _populate_type_filter(self, con) -> None:
+        """Fill the Type dropdown from the extensions actually indexed, most
+        common first, each labelled with its file count."""
+        try:
+            rows = con.execute(
+                "SELECT ext, COUNT(*) c FROM assets GROUP BY ext "
+                "ORDER BY c DESC").fetchall()
+        except Exception:  # noqa: BLE001
+            return
+        items = [("All types", None)]
+        for ext, c in rows[:40]:
+            if ext and ext != "(none)":
+                items.append((f"{ext}  ({c:,})", ext))
+        if len(items) > 1:
+            self._set_type_items(items)
+
     def _on_search(self, text: str) -> None:
         text = (text or "").strip()
+        ext = self._type_filter()
         if not os.path.exists(self._index_path):
             self._hits.setText("Build the index first to search.")
             self._table.setRowCount(0)
             return
-        if len(text) < 2:
+        # A type filter lets you browse every file of that type with no search
+        # text; without one, require 2+ chars so a bare query can't scan all
+        # 1.6M paths.
+        if ext is None and len(text) < 2:
             self._hits.setText("Type at least 2 characters to search.")
             self._table.setRowCount(0)
             return
@@ -932,7 +997,8 @@ class GameDataPage(ToolPageBase):
         try:
             con = sqlite3.connect(self._index_path)
             try:
-                rows = game_index.search_assets(con, query=text, limit=limit)
+                rows = game_index.search_assets(
+                    con, query=text, ext=ext, limit=limit)
             finally:
                 con.close()
         except Exception as ex:  # noqa: BLE001

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -192,6 +192,18 @@ class _PreviewWorker(QObject):
                            text=game_index.hexdump(data, limit=self._hex_cap))
             return
 
+        # 3.5) Wwise audio (.wem streams / .bnk soundbanks) → metadata + play
+        if self._path.lower().endswith(game_index.WWISE_EXTS):
+            if orig > self._image_limit:
+                res.update(kind="toobig")
+                return
+            data = game_index.extract_asset(con, self._path, gd)
+            audio = game_index.decode_audio(data, self._path)
+            if audio:
+                res.update(kind="audio", audio=audio,
+                           vgmstream=bool(game_index.find_vgmstream()))
+                return
+
         # 4) too big for an inline byte preview
         if orig > self._byte_limit:
             res.update(kind="toobig")
@@ -536,6 +548,18 @@ class GameDataPage(ToolPageBase):
         self._pv_3d_btn.clicked.connect(self._on_view_3d)
         pv.addWidget(self._pv_3d_btn)
 
+        # Wwise audio controls — only shown for .wem/.bnk previews. Play/Export
+        # need the bundled vgmstream; they stay disabled (with a note) if it
+        # isn't present, but raw extract always works.
+        self._pv_play_btn = PushButton("▶  Play", pane)
+        self._pv_play_btn.setVisible(False)
+        self._pv_play_btn.clicked.connect(self._on_play_audio)
+        pv.addWidget(self._pv_play_btn)
+        self._pv_export_btn = PushButton("Export as WAV…", pane)
+        self._pv_export_btn.setVisible(False)
+        self._pv_export_btn.clicked.connect(self._on_export_wav)
+        pv.addWidget(self._pv_export_btn)
+
         self._pv_extract = PushButton("Extract raw file…", pane)
         self._pv_extract.setEnabled(False)
         self._pv_extract.clicked.connect(self._extract_raw)
@@ -845,6 +869,9 @@ class GameDataPage(ToolPageBase):
         elif kind == "struct":
             self._show_struct(res)
             self._pv_extract.setEnabled(True)
+        elif kind == "audio":
+            self._show_audio(res)
+            self._pv_extract.setEnabled(True)
         elif kind == "hex":
             self._show_text(
                 "Binary asset — no visual decoder for this format yet "
@@ -868,6 +895,8 @@ class GameDataPage(ToolPageBase):
         self._pv_grid.setVisible(False)
         self._pv_img_scroll.setVisible(False)
         self._pv_3d_btn.setVisible(False)
+        self._pv_play_btn.setVisible(False)
+        self._pv_export_btn.setVisible(False)
         self._pv_text.setVisible(True)
         self._pv_text.setLineWrapMode(
             self._pv_text.LineWrapMode.WidgetWidth if wrap
@@ -891,9 +920,46 @@ class GameDataPage(ToolPageBase):
                 for r in res.get("rows", [])]
         self._show_grid(cols, rows)
 
+    def _show_audio(self, res: dict) -> None:
+        a = res.get("audio", {})
+        has_vgm = res.get("vgmstream", False)
+        if a.get("kind") == "wem":
+            dur = a.get("duration")
+            durs = f"{dur:.2f} s" if dur else "(shown after decode)"
+            body = ("Wwise audio stream (.wem)\n\n"
+                    f"Codec         {a.get('codec')}\n"
+                    f"Channels      {a.get('channels')}\n"
+                    f"Sample rate   {a.get('sample_rate', 0):,} Hz\n"
+                    f"Audio bytes   {a.get('data_bytes', 0):,}\n"
+                    f"Duration      {durs}\n"
+                    f"Chunks        {', '.join(a.get('chunks', []))}\n")
+            playable = has_vgm
+        else:  # .bnk SoundBank
+            body = ("Wwise SoundBank (.bnk)\n\n"
+                    f"Bank version       {a.get('bank_version')}\n"
+                    f"Sections           {', '.join(a.get('sections', []))}\n"
+                    f"Embedded streams   {a.get('embedded_streams', 0)}\n")
+            playable = False   # banks hold many subsongs — extract, don't play
+        note = ("\nThe game ships all sound through Wwise: .wem are the encoded "
+                "streams (Wwise Vorbis) and .bnk are SoundBanks — Windows can't "
+                "play these directly.\n")
+        if has_vgm:
+            note += ("Use ▶ Play to hear it or Export as WAV for a playable "
+                     "copy; Extract raw file saves the original .wem/.bnk.")
+        else:
+            note += ("Playback needs vgmstream — drop vgmstream-cli.exe into the "
+                     "app's tools/vgmstream folder. Extract raw file works now.")
+        self._show_text(body + note, wrap=True)
+        self._pv_play_btn.setVisible(True)
+        self._pv_play_btn.setEnabled(playable)
+        self._pv_export_btn.setVisible(True)
+        self._pv_export_btn.setEnabled(playable)
+
     def _show_image(self, png: bytes) -> None:
         self._pv_text.setVisible(False)
         self._pv_grid.setVisible(False)
+        self._pv_play_btn.setVisible(False)
+        self._pv_export_btn.setVisible(False)
         self._pv_img_scroll.setVisible(True)
         self._pv_qimage = QImage.fromData(png, "PNG") if png else None
         self._pv_3d_btn.setVisible(
@@ -913,6 +979,8 @@ class GameDataPage(ToolPageBase):
         self._pv_text.setVisible(False)
         self._pv_img_scroll.setVisible(False)
         self._pv_3d_btn.setVisible(False)
+        self._pv_play_btn.setVisible(False)
+        self._pv_export_btn.setVisible(False)
         self._pv_grid.setVisible(True)
         self._pv_grid.clear()
         self._pv_grid.setColumnCount(len(cols))
@@ -975,3 +1043,72 @@ class GameDataPage(ToolPageBase):
             self._set_status(f"Saved {len(data):,} bytes to {out}.", "#2E7D32")
         except Exception as ex:  # noqa: BLE001
             self._set_status(f"Save failed: {ex}", "#BF616A")
+
+    # ── Wwise audio playback / export (via bundled vgmstream) ─────────
+    def _audio_wav(self, path: str) -> str | None:
+        """Decode the selected .wem to a temp WAV via vgmstream. Returns the
+        temp path or None (with a status message) on failure."""
+        data = self._preview_bytes
+        if data is None:                       # large asset — read on demand
+            try:
+                con = sqlite3.connect(self._index_path)
+                try:
+                    data = game_index.extract_asset(
+                        con, path, str(self._game_dir))
+                finally:
+                    con.close()
+            except Exception as ex:  # noqa: BLE001
+                self._set_status(f"Read failed: {ex}", "#BF616A")
+                return None
+        import tempfile
+        fd, wav = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        if not game_index.convert_to_wav(data, wav):
+            self._set_status(
+                "Could not decode audio — is vgmstream installed?", "#BF616A")
+            try:
+                os.unlink(wav)
+            except OSError:
+                pass
+            return None
+        return wav
+
+    def _on_play_audio(self) -> None:
+        path = self._selected_path()
+        if not path:
+            return
+        wav = self._audio_wav(path)
+        if not wav:
+            return
+        try:                                   # winsound is Windows-only
+            import winsound
+            winsound.PlaySound(wav, winsound.SND_FILENAME | winsound.SND_ASYNC)
+            self._set_status("Playing…", "#2E7D32")
+        except Exception as ex:  # noqa: BLE001
+            self._set_status(f"Playback failed: {ex}", "#BF616A")
+        # temp WAV is left for the async player; the OS reclaims %TEMP%.
+
+    def _on_export_wav(self) -> None:
+        path = self._selected_path()
+        if not path:
+            return
+        wav = self._audio_wav(path)
+        if not wav:
+            return
+        base = os.path.splitext(
+            self._preview_name or os.path.basename(path))[0]
+        default = os.path.join(os.path.expanduser("~"), base + ".wav")
+        out, _ = QFileDialog.getSaveFileName(
+            self, "Save WAV", default, "WAV audio (*.wav)")
+        try:
+            if out:
+                import shutil
+                shutil.copyfile(wav, out)
+                self._set_status(f"Saved WAV to {out}.", "#2E7D32")
+        except Exception as ex:  # noqa: BLE001
+            self._set_status(f"Save failed: {ex}", "#BF616A")
+        finally:
+            try:
+                os.unlink(wav)
+            except OSError:
+                pass

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -1,24 +1,26 @@
-"""Game Data page — build a searchable catalog of the installed game.
+"""Game Data page — build + browse a searchable catalog of the installed game.
 
-A thin tool page over ``cdumm.engine.game_index``: one button builds (or
-refreshes) a SQLite index of every archive asset + the keyed game-data tables,
-on a background thread, then shows a summary. Search/browse UI is a planned
-follow-up; this first version reuses only ToolPageBase's built-in widgets
-(button, progress, stat cards, result cards) to keep it low-risk.
+A tool page over ``cdumm.engine.game_index``: one button builds (or refreshes)
+a SQLite index of every archive asset + the keyed game-data tables, on a
+background thread. You can choose where the index file is saved, open its
+folder, and search the indexed assets in a table right in the app.
 
-Strings are intentionally literal (not tr() keys) for this first version, so it
-adds no new localization keys; localization is a follow-up.
+Strings are literal (not tr() keys) for this first version, so it adds no new
+localization keys; localization is a follow-up.
 """
 from __future__ import annotations
 
 import os
 import sqlite3
+import subprocess
 import tempfile
 
 from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtWidgets import QFileDialog, QHBoxLayout, QTableWidgetItem
 
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
+from cdumm.platform import IS_MACOS, IS_WINDOWS
 
 
 class _GameIndexWorker(QObject):
@@ -51,7 +53,7 @@ class _GameIndexWorker(QObject):
 
 
 class GameDataPage(ToolPageBase):
-    """Build + summarize a searchable index of the installed game's data."""
+    """Build, locate, and search an index of the installed game's data."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(
@@ -65,8 +67,7 @@ class GameDataPage(ToolPageBase):
             run_label="Build / refresh game-data index",
             parent=parent,
         )
-        # Persisted next to the OS temp dir for this first version; a future
-        # revision can move it under CDMods and add a search UI over it.
+        self._app_data_dir = None
         self._index_path = os.path.join(
             tempfile.gettempdir(), "cdumm_game_index.sqlite")
         self._thread: QThread | None = None
@@ -75,6 +76,117 @@ class GameDataPage(ToolPageBase):
         self._stat_assets = self._add_stat_card("--", "Assets", "#2878D0")
         self._stat_archives = self._add_stat_card("--", "Archives", "#8B5CF6")
         self._stat_tables = self._add_stat_card("--", "Data tables", "#0EA5E9")
+
+        self._build_controls()
+
+    # ── extra controls (persistent — not wiped by _clear_results) ────
+    def _build_controls(self) -> None:
+        from qfluentwidgets import (BodyLabel, CaptionLabel, LineEdit,
+                                     PushButton, TableWidget)
+        root = self._container.layout()
+
+        # Save-location row: path label + Change + Open folder
+        loc_row = QHBoxLayout()
+        loc_row.setSpacing(8)
+        self._path_label = CaptionLabel(
+            f"Save location:  {self._index_path}", self._container)
+        self._path_label.setWordWrap(True)
+        loc_row.addWidget(self._path_label, 1)
+        self._change_btn = PushButton("Change…", self._container)
+        self._change_btn.clicked.connect(self._choose_location)
+        loc_row.addWidget(self._change_btn)
+        self._open_btn = PushButton("Open folder", self._container)
+        self._open_btn.clicked.connect(self._open_location)
+        loc_row.addWidget(self._open_btn)
+        root.insertLayout(root.count() - 1, loc_row)
+
+        # Search + results table
+        self._search = LineEdit(self._container)
+        self._search.setPlaceholderText(
+            "Search assets by path (build the index first)…")
+        self._search.setClearButtonEnabled(True)
+        self._search.textChanged.connect(self._on_search)
+        root.insertWidget(root.count() - 1, self._search)
+
+        self._hits = BodyLabel("", self._container)
+        self._hits.setContentsMargins(2, 4, 0, 0)
+        root.insertWidget(root.count() - 1, self._hits)
+
+        self._table = TableWidget(self._container)
+        self._table.setColumnCount(4)
+        self._table.setHorizontalHeaderLabels(
+            ["Path", "Archive", "Type", "Size (bytes)"])
+        self._table.verticalHeader().hide()
+        self._table.setMinimumHeight(320)
+        self._table.setEditTriggers(self._table.EditTrigger.NoEditTriggers)
+        try:
+            self._table.setColumnWidth(0, 620)
+        except Exception:  # noqa: BLE001
+            pass
+        root.insertWidget(root.count() - 1, self._table)
+
+    # ── engine wiring ────────────────────────────────────────────────
+    def set_managers(self, **kwargs) -> None:
+        super().set_managers(**kwargs)
+        # Preserve across re-wire calls that don't pass app_data_dir.
+        self._app_data_dir = kwargs.get("app_data_dir") or self._app_data_dir
+        saved = self._load_pref()
+        if saved:
+            self._index_path = saved
+        elif self._app_data_dir:
+            self._index_path = os.path.join(
+                str(self._app_data_dir), "game_index.sqlite")
+        if hasattr(self, "_path_label"):
+            self._path_label.setText(f"Save location:  {self._index_path}")
+        if hasattr(self, "_open_btn"):
+            self._open_btn.setEnabled(os.path.exists(self._index_path))
+
+    def _load_pref(self):
+        try:
+            if self._db:
+                from cdumm.storage.config import Config
+                return Config(self._db).get("game_index_path") or None
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+
+    def _save_pref(self, path: str) -> None:
+        try:
+            if self._db:
+                from cdumm.storage.config import Config
+                Config(self._db).set("game_index_path", path)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ── location actions ─────────────────────────────────────────────
+    def _choose_location(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Choose where to save the game-data index",
+            self._index_path, "SQLite database (*.sqlite)")
+        if path:
+            self._index_path = path
+            self._save_pref(path)
+            self._path_label.setText(f"Save location:  {path}")
+            self._open_btn.setEnabled(os.path.exists(path))
+
+    def _open_location(self) -> None:
+        p = self._index_path
+        folder = os.path.dirname(p) or "."
+        try:
+            if IS_WINDOWS:
+                if os.path.exists(p):
+                    subprocess.Popen(["explorer", "/select,",
+                                      os.path.normpath(p)])
+                else:
+                    os.startfile(folder)  # noqa: S606
+            elif IS_MACOS:
+                args = ["open", "-R", p] if os.path.exists(p) else ["open",
+                                                                     folder]
+                subprocess.Popen(args)
+            else:
+                subprocess.Popen(["xdg-open", folder])
+        except Exception as ex:  # noqa: BLE001
+            self._set_status(f"Could not open folder: {ex}", "#BF616A")
 
     # ── run ─────────────────────────────────────────────────────────
     def _on_run_clicked(self) -> None:
@@ -94,7 +206,6 @@ class GameDataPage(ToolPageBase):
         self._worker.progress.connect(self._on_progress)
         self._worker.done.connect(self._on_done)
         self._worker.error.connect(self._on_error)
-        # Teardown: quit the loop + delete the worker once it reports back.
         self._worker.done.connect(self._thread.quit)
         self._worker.error.connect(self._thread.quit)
         self._worker.done.connect(self._worker.deleteLater)
@@ -118,6 +229,7 @@ class GameDataPage(ToolPageBase):
         except Exception:  # noqa: BLE001
             pass
         self._set_status("Index built.", "#2E7D32")
+        self._open_btn.setEnabled(os.path.exists(self._index_path))
 
         detail = ""
         try:
@@ -132,9 +244,41 @@ class GameDataPage(ToolPageBase):
         except Exception as ex:  # noqa: BLE001
             detail = f"(could not read tables: {ex})"
         self._add_result_card("Largest keyed game-data tables", detail)
-        self._add_result_card("Index file", self._index_path)
+        # refresh the viewer if a search is active
+        self._on_search(self._search.text())
 
     def _on_error(self, msg: str) -> None:
         self._set_running(False)
         self._set_status("Index failed.", "#BF616A")
         self._add_result_card("Error", msg, "#BF616A")
+
+    # ── search / viewer ──────────────────────────────────────────────
+    def _on_search(self, text: str) -> None:
+        text = (text or "").strip()
+        if not os.path.exists(self._index_path):
+            self._hits.setText("Build the index first to search.")
+            self._table.setRowCount(0)
+            return
+        if len(text) < 2:
+            self._hits.setText("Type at least 2 characters to search.")
+            self._table.setRowCount(0)
+            return
+        try:
+            con = sqlite3.connect(self._index_path)
+            try:
+                rows = game_index.search_assets(con, query=text, limit=300)
+            finally:
+                con.close()
+        except Exception as ex:  # noqa: BLE001
+            self._hits.setText(f"Search failed: {ex}")
+            return
+        self._hits.setText(
+            f"{len(rows)} match(es)" + (" (showing first 300)"
+                                        if len(rows) == 300 else ""))
+        self._table.setRowCount(len(rows))
+        for i, r in enumerate(rows):
+            self._table.setItem(i, 0, QTableWidgetItem(str(r["path"])))
+            self._table.setItem(i, 1, QTableWidgetItem(str(r["archive"])))
+            self._table.setItem(i, 2, QTableWidgetItem(str(r["ext"])))
+            self._table.setItem(
+                i, 3, QTableWidgetItem(f"{int(r['orig_size']):,}"))

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -596,6 +596,7 @@ class GameDataPage(ToolPageBase):
         self._preview_bytes: bytes | None = None
         self._preview_name: str | None = None
         self._pv_gen = 0                 # bumped per selection; ignore stale
+        self._play_token = 0             # bumped per Play; ignore stale finish
         self._pv_jobs: list = []         # live (thread, worker) — keep refs
         self._pv_qimage: QImage | None = None   # current texture, for 3D
         self._pv_3d_dlg = None                   # open 3D dialog (keep a ref)
@@ -1109,13 +1110,39 @@ class GameDataPage(ToolPageBase):
         wav = self._audio_wav(path)
         if not wav:
             return
+        name = self._preview_name or os.path.basename(path)
         try:                                   # winsound is Windows-only
             import winsound
+            winsound.PlaySound(None, winsound.SND_PURGE)      # stop any prior
             winsound.PlaySound(wav, winsound.SND_FILENAME | winsound.SND_ASYNC)
-            self._set_status("Playing…", "#2E7D32")
         except Exception as ex:  # noqa: BLE001
             self._set_status(f"Playback failed: {ex}", "#BF616A")
+            return
+        # Read the decoded WAV's real length so we can flip the status back
+        # to "finished" live when it ends (winsound gives no end callback).
+        dur = 0.0
+        try:
+            import contextlib
+            import wave
+            with contextlib.closing(wave.open(wav, "rb")) as w:
+                if w.getframerate():
+                    dur = w.getnframes() / float(w.getframerate())
+        except Exception:  # noqa: BLE001
+            pass
+        self._play_token += 1
+        token = self._play_token
+        tag = f"  ({dur:.1f}s)" if dur else ""
+        self._set_status(f"▶ Playing: {name}{tag}", "#2E7D32")
+        if dur > 0:
+            from PySide6.QtCore import QTimer
+            QTimer.singleShot(
+                int(dur * 1000) + 150,
+                lambda t=token, n=name: self._on_play_finished(t, n))
         # temp WAV is left for the async player; the OS reclaims %TEMP%.
+
+    def _on_play_finished(self, token: int, name: str) -> None:
+        if token == self._play_token:      # not superseded by a newer Play
+            self._set_status(f"Finished: {name}", "")
 
     def _on_export_wav(self) -> None:
         path = self._selected_path()

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -339,6 +339,14 @@ class _Texture3DView(QDialog):
 
         self.setWindowTitle(title)
         self.resize(760, 700)
+        # A QDialog shows only a close button; make it a normal OS window with
+        # minimize / maximize / close like any other program.
+        self.setWindowFlags(
+            Qt.WindowType.Window
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowCloseButtonHint)
+        self._mid_last = None            # middle-mouse orbit anchor
 
         # Most portable way to get a QImage into a Qt3D texture across PySide6
         # builds: a temp PNG loaded by QTextureLoader (a painted-texture
@@ -349,6 +357,7 @@ class _Texture3DView(QDialog):
 
         self._window = _E.Qt3DWindow()
         self._window.defaultFrameGraph().setClearColor(QColor("#20222E"))
+        self._window.installEventFilter(self)     # middle-mouse orbit
         container = QWidget.createWindowContainer(self._window, self)
         container.setMinimumSize(420, 420)
         container.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -363,7 +372,8 @@ class _Texture3DView(QDialog):
             btn.clicked.connect(lambda _=False, s=shape: self._set_shape(s))
             bar.addWidget(btn)
         bar.addStretch(1)
-        bar.addWidget(CaptionLabel("Drag to orbit · scroll to zoom", self))
+        bar.addWidget(CaptionLabel(
+            "Left- or middle-drag to orbit · scroll to zoom", self))
         root_layout.addLayout(bar)
         root_layout.addWidget(container, 1)
 
@@ -421,6 +431,32 @@ class _Texture3DView(QDialog):
 
         self._window.setRootEntity(self._root)
         self._set_shape("plane")
+
+    def eventFilter(self, obj, event):  # noqa: N802
+        """Middle-mouse drag orbits the camera around the asset (in addition to
+        the orbit controller's left-drag), the way 3D tools behave."""
+        from PySide6.QtCore import QEvent
+        t = event.type()
+        if (t == QEvent.Type.MouseButtonPress
+                and event.button() == Qt.MouseButton.MiddleButton):
+            self._mid_last = event.position()
+            return True
+        if t == QEvent.Type.MouseMove and self._mid_last is not None:
+            p = event.position()
+            dx = p.x() - self._mid_last.x()
+            dy = p.y() - self._mid_last.y()
+            self._mid_last = p
+            try:
+                self._cam.panAboutViewCenter(-dx * 0.35)
+                self._cam.tiltAboutViewCenter(-dy * 0.35)
+            except Exception:  # noqa: BLE001
+                pass
+            return True
+        if (t == QEvent.Type.MouseButtonRelease
+                and event.button() == Qt.MouseButton.MiddleButton):
+            self._mid_last = None
+            return True
+        return super().eventFilter(obj, event)
 
     def resizeEvent(self, event):  # noqa: N802
         super().resizeEvent(event)

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -105,11 +105,18 @@ class GameDataPage(ToolPageBase):
         self._search.setPlaceholderText(
             "Search assets by path (build the index first)…")
         self._search.setClearButtonEnabled(True)
+        self._search.setFixedHeight(38)
+        _sf = self._search.font()
+        _sf.setPixelSize(15)
+        self._search.setFont(_sf)
         self._search.textChanged.connect(self._on_search)
         root.insertWidget(root.count() - 1, self._search)
 
         self._hits = BodyLabel("", self._container)
         self._hits.setContentsMargins(2, 4, 0, 0)
+        _hitf = self._hits.font()
+        _hitf.setPixelSize(15)
+        self._hits.setFont(_hitf)
         root.insertWidget(root.count() - 1, self._hits)
 
         self._table = TableWidget(self._container)
@@ -117,8 +124,16 @@ class GameDataPage(ToolPageBase):
         self._table.setHorizontalHeaderLabels(
             ["Path", "Archive", "Type", "Size (bytes)"])
         self._table.verticalHeader().hide()
-        self._table.setMinimumHeight(320)
+        self._table.setMinimumHeight(380)
         self._table.setEditTriggers(self._table.EditTrigger.NoEditTriggers)
+        # Larger, more readable text + roomier rows.
+        _tf = self._table.font()
+        _tf.setPixelSize(15)
+        self._table.setFont(_tf)
+        _hf = self._table.horizontalHeader().font()
+        _hf.setPixelSize(15)
+        self._table.horizontalHeader().setFont(_hf)
+        self._table.verticalHeader().setDefaultSectionSize(36)
         try:
             self._table.setColumnWidth(0, 620)
         except Exception:  # noqa: BLE001

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -192,12 +192,19 @@ class _PreviewWorker(QObject):
         if orig > self._byte_limit:
             res.update(kind="toobig")
             return
-        # 5) text or hex
+        # 5) text, structure outline, or hex
         data = game_index.extract_asset(con, self._path, gd)
         text = game_index.decode_text(data, limit=self._text_cap)
         if text is not None:
             res.update(kind="text", text=text[:self._text_cap],
                        truncated=len(text) >= self._text_cap)
+            return
+        # Reflection-serialized binaries (.paseq/.prefab/.meshinfo/...) embed
+        # their field/type/object names as text — surface those as a readable
+        # outline instead of raw hex.
+        strings = game_index.extract_strings(data)
+        if len(strings) >= 6:
+            res.update(kind="outline", strings=strings, nstr=len(strings))
         else:
             res.update(kind="hex",
                        text=game_index.hexdump(data, limit=self._hex_cap))
@@ -254,12 +261,12 @@ class _Texture3DView(QDialog):
         root_layout.addWidget(container, 1)
 
         self._root = _C.QEntity()
-        cam = self._window.camera()
-        cam.lens().setPerspectiveProjection(45.0, 1.2, 0.1, 1000.0)
-        cam.setPosition(QVector3D(0, 0, 3.2))
-        cam.setViewCenter(QVector3D(0, 0, 0))
+        self._cam = self._window.camera()
+        self._cam.lens().setPerspectiveProjection(45.0, 1.2, 0.1, 1000.0)
+        self._cam.setPosition(QVector3D(0, 0, 3.2))
+        self._cam.setViewCenter(QVector3D(0, 0, 0))
         ctrl = _E.QOrbitCameraController(self._root)
-        ctrl.setCamera(cam)
+        ctrl.setCamera(self._cam)
         ctrl.setLinearSpeed(60.0)
         ctrl.setLookSpeed(180.0)
 
@@ -270,34 +277,52 @@ class _Texture3DView(QDialog):
         mat = _E.QTextureMaterial(self._root)
         mat.setTexture(tex)
 
+        # Keep Python references to every Qt3D node. PySide6 garbage-collects
+        # unparented meshes / transforms / materials otherwise, destroying the
+        # component and leaving the scene empty — the bug that made earlier
+        # attempts render nothing. Parenting each mesh to its entity + holding
+        # them in a list guarantees they survive.
+        self._keep = [ctrl, tex, mat]
         self._shapes = {}
         # Plane — a flat card (thin cuboid, visible from both sides).
         pe = _C.QEntity(self._root)
-        pmesh = _E.QCuboidMesh()
-        ptx = _C.QTransform()
+        pmesh = _E.QCuboidMesh(pe)
+        ptx = _C.QTransform(pe)
         ptx.setScale3D(QVector3D(2.0, 2.0, 0.03))
         pe.addComponent(pmesh)
         pe.addComponent(mat)
         pe.addComponent(ptx)
         self._shapes["plane"] = pe
+        self._keep += [pmesh, ptx]
         # Sphere
         se = _C.QEntity(self._root)
-        smesh = _E.QSphereMesh()
+        smesh = _E.QSphereMesh(se)
         smesh.setRadius(1.2)
         smesh.setRings(60)
         smesh.setSlices(60)
         se.addComponent(smesh)
         se.addComponent(mat)
         self._shapes["sphere"] = se
+        self._keep.append(smesh)
         # Cube
         ce = _C.QEntity(self._root)
-        cmesh = _E.QCuboidMesh()
+        cmesh = _E.QCuboidMesh(ce)
         ce.addComponent(cmesh)
         ce.addComponent(mat)
         self._shapes["cube"] = ce
+        self._keep.append(cmesh)
 
         self._window.setRootEntity(self._root)
         self._set_shape("plane")
+
+    def resizeEvent(self, event):  # noqa: N802
+        super().resizeEvent(event)
+        try:
+            w = max(1, self._window.width())
+            h = max(1, self._window.height())
+            self._cam.lens().setPerspectiveProjection(45.0, w / h, 0.1, 1000.0)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _set_shape(self, which: str) -> None:
         for name, ent in self._shapes.items():
@@ -765,6 +790,15 @@ class GameDataPage(ToolPageBase):
                 body += ("\n\n… (truncated preview — use Extract raw for the "
                          "full file)")
             self._show_text(body, wrap=True)
+            self._pv_extract.setEnabled(True)
+        elif kind == "outline":
+            strings = res.get("strings", [])
+            self._show_text(
+                "Structure outline — the field / type / object names embedded "
+                "in this reflection-serialized binary ("
+                f"{res.get('nstr', len(strings))} names). Use “Extract raw "
+                "file…” for the full bytes.\n\n" + "\n".join(strings),
+                wrap=True)
             self._pv_extract.setEnabled(True)
         elif kind == "hex":
             self._show_text(

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -77,6 +77,10 @@ def _shape_records(records: dict, schema) -> tuple[list, list, int, float]:
     fields (its job is diffing, not a clean human dump).
     """
     field_names = [f.name for f in schema.fields] if schema else []
+    # _key and _name are shown as their own leading columns; several tables
+    # (e.g. sequencerspawninfo) also list _key/_name among their schema
+    # fields, which would render a redundant duplicate column — drop those.
+    field_names = [f for f in field_names if f not in ("_key", "_name")]
     cols = ["_key", "_name"] + field_names
     keys = sorted(records)[:_GRID_ROW_CAP]
     rows = [[_cell(records[k].get(c)) for c in cols] for k in keys]
@@ -205,6 +209,13 @@ class _PreviewWorker(QObject):
         strings = game_index.extract_strings(data)
         if len(strings) >= 6:
             res.update(kind="outline", strings=strings, nstr=len(strings))
+            return
+        # No embedded names, but a word-aligned struct (.paatt attribute
+        # blocks, .pabgh key indexes) reads far better as a typed word
+        # table than a raw hex wall.
+        st = game_index.decode_struct(data)
+        if st:
+            res.update(kind="struct", **st)
         else:
             res.update(kind="hex",
                        text=game_index.hexdump(data, limit=self._hex_cap))
@@ -800,6 +811,9 @@ class GameDataPage(ToolPageBase):
                 "file…” for the full bytes.\n\n" + "\n".join(strings),
                 wrap=True)
             self._pv_extract.setEnabled(True)
+        elif kind == "struct":
+            self._show_struct(res)
+            self._pv_extract.setEnabled(True)
         elif kind == "hex":
             self._show_text(
                 "Binary asset — no visual decoder for this format yet "
@@ -828,6 +842,23 @@ class GameDataPage(ToolPageBase):
             self._pv_text.LineWrapMode.WidgetWidth if wrap
             else self._pv_text.LineWrapMode.NoWrap)
         self._pv_text.setPlainText(text)
+
+    def _show_struct(self, res: dict) -> None:
+        total = res.get("total_words", 0)
+        shown = res.get("shown", 0)
+        trailing = res.get("trailing", 0)
+        more = f" · first {shown:,} of {total:,}" if shown < total else ""
+        tail = f" · +{trailing} trailing byte(s)" if trailing else ""
+        self._pv_meta.setText(
+            "Struct view — this format has no embedded field names, so each "
+            "32-bit word is shown as unsigned / signed / float. Values in the "
+            "1,000,000+ range are flagged as likely record keys."
+            f"  ({total:,} words{more}{tail})\n"
+            + self._pv_meta.text())
+        cols = ["Offset", "Bytes", "UInt32", "Int32", "Float32", "ASCII", ""]
+        rows = [[r[0], r[1], r[2], r[3], r[4], r[5], "key" if r[6] else ""]
+                for r in res.get("rows", [])]
+        self._show_grid(cols, rows)
 
     def _show_image(self, png: bytes) -> None:
         self._pv_text.setVisible(False)

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -218,6 +218,12 @@ class _PreviewWorker(QObject):
         # Reflection-serialized binaries (.paseq/.prefab/.meshinfo/...) embed
         # their field/type/object names as text — surface those as a readable
         # outline instead of raw hex.
+        # Verbose reflection binaries (.pae/.paseq/.prefab/.meshinfo/…) embed a
+        # full field→type schema; surface it as a named table.
+        refl = game_index.decode_reflection(data)
+        if refl:
+            res.update(kind="schema", **refl)
+            return
         strings = game_index.extract_strings(data)
         if len(strings) >= 6:
             res.update(kind="outline", strings=strings, nstr=len(strings))
@@ -883,6 +889,9 @@ class GameDataPage(ToolPageBase):
                          "full file)")
             self._show_text(body, wrap=True)
             self._pv_extract.setEnabled(True)
+        elif kind == "schema":
+            self._show_schema(res)
+            self._pv_extract.setEnabled(True)
         elif kind == "outline":
             strings = res.get("strings", [])
             self._show_text(
@@ -946,6 +955,29 @@ class GameDataPage(ToolPageBase):
         rows = [[r[0], r[1], r[2], r[3], r[4], r[5], "key" if r[6] else ""]
                 for r in res.get("rows", [])]
         self._show_grid(cols, rows)
+
+    def _show_schema(self, res: dict) -> None:
+        fields = res.get("fields", [])
+        objects = res.get("objects", [])
+        refs = res.get("refs", [])
+        rows = []
+        last_obj = None
+        for obj, name, typ in fields:            # object name only on its first
+            rows.append([obj if obj != last_obj else "", name, typ])
+            last_obj = obj
+        if refs:                                 # asset references / values
+            rows.append(["", "", ""])
+            rows.append([f"references ({len(refs)})", "", ""])
+            for r in refs:
+                rows.append(["", r, ""])
+        note = (
+            f"Reflection schema — {res.get('nfields', len(fields))} fields "
+            f"across {len(objects)} object(s)"
+            + (f", {len(refs)} references" if refs else "")
+            + ". These are the engine's own field + type names, read straight "
+            "from the file (not inferred).")
+        self._pv_meta.setText(note + "\n" + self._pv_meta.text())
+        self._show_grid(["Object", "Field", "Type"], rows)
 
     def _show_audio(self, res: dict) -> None:
         a = res.get("audio", {})

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -742,6 +742,13 @@ class GameDataPage(ToolPageBase):
         self._pv_3d_btn.clicked.connect(self._on_view_3d)
         pv.addWidget(self._pv_3d_btn)
 
+        # Save the decoded texture as a normal image (JPEG, or PNG to keep
+        # transparency) — only shown for image previews.
+        self._pv_saveimg_btn = PushButton("Save as JPEG…", pane)
+        self._pv_saveimg_btn.setVisible(False)
+        self._pv_saveimg_btn.clicked.connect(self._on_save_image)
+        pv.addWidget(self._pv_saveimg_btn)
+
         # Wwise audio controls — only shown for .wem/.bnk previews. Play/Export
         # need the bundled vgmstream; they stay disabled (with a note) if it
         # isn't present, but raw extract always works.
@@ -1070,6 +1077,9 @@ class GameDataPage(ToolPageBase):
     def _on_preview_ready(self, res: dict) -> None:
         if res.get("gen") != self._pv_gen:
             return   # a newer selection superseded this result
+        # Image-only button; _show_image re-shows it, every other branch leaves
+        # it hidden.
+        self._pv_saveimg_btn.setVisible(False)
         row = res.get("row")
         meta = ""
         if row:
@@ -1260,8 +1270,9 @@ class GameDataPage(ToolPageBase):
         self._pv_getvgm_btn.setVisible(False)
         self._pv_img_scroll.setVisible(True)
         self._pv_qimage = QImage.fromData(png, "PNG") if png else None
-        self._pv_3d_btn.setVisible(
-            self._pv_qimage is not None and not self._pv_qimage.isNull())
+        _has_img = self._pv_qimage is not None and not self._pv_qimage.isNull()
+        self._pv_3d_btn.setVisible(_has_img)
+        self._pv_saveimg_btn.setVisible(_has_img)
         pm = QPixmap()
         if png:
             pm.loadFromData(png, "PNG")
@@ -1311,6 +1322,40 @@ class GameDataPage(ToolPageBase):
             return
         self._pv_3d_dlg = dlg          # keep a ref so it isn't GC'd
         dlg.show()
+
+    def _on_save_image(self) -> None:
+        """Save the decoded texture as a standard image the OS can open.
+
+        JPEG by default (small, universally viewable); PNG is offered too for
+        anyone who needs the alpha channel kept.
+        """
+        img = self._pv_qimage
+        if img is None or img.isNull():
+            return
+        base = os.path.splitext(self._preview_name or "texture")[0]
+        start = os.path.join(os.path.expanduser("~"), base + ".jpg")
+        path, _sel = QFileDialog.getSaveFileName(
+            self, "Save texture as image", start,
+            "JPEG image (*.jpg *.jpeg);;PNG image (*.png)")
+        if not path:
+            return
+        ext = os.path.splitext(path)[1].lower()
+        is_jpeg = ext in (".jpg", ".jpeg")
+        out = img
+        if is_jpeg and img.hasAlphaChannel():
+            # JPEG has no alpha — flatten onto white so transparent regions
+            # don't turn black.
+            from PySide6.QtGui import QPainter, QColor
+            out = QImage(img.size(), QImage.Format.Format_RGB32)
+            out.fill(QColor("white"))
+            p = QPainter(out)
+            p.drawImage(0, 0, img)
+            p.end()
+        ok = (out.save(path, "JPG", 92) if is_jpeg else out.save(path, "PNG"))
+        base_meta = self._pv_meta.text()
+        self._pv_meta.setText(
+            (f"Saved image → {path}" if ok
+             else f"Could not save image to {path}") + "\n" + base_meta)
 
     def _extract_raw(self) -> None:
         """Save the selected asset's real (decoded) bytes to a file."""

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -212,12 +212,22 @@ class _Texture3DView(QDialog):
 
     def __init__(self, qimage, title="Texture — 3D preview", parent=None):
         super().__init__(parent)
-        from PySide6.Qt3DExtras import (Qt3DWindow, QOrbitCameraController,
-                                        QDiffuseMapMaterial, QSphereMesh,
-                                        QCuboidMesh)
-        from PySide6.Qt3DCore import QEntity, QTransform
-        from PySide6.Qt3DRender import (QTexture2D, QPaintedTextureImage,
-                                        QPointLight)
+        # PySide6 6.10 nests the Qt3D classes under a same-named namespace
+        # (PySide6.Qt3DExtras.Qt3DExtras.Qt3DWindow, etc.), so pull them off
+        # the nested namespace rather than the top-level module.
+        from PySide6.Qt3DExtras import Qt3DExtras as _E
+        from PySide6.Qt3DCore import Qt3DCore as _C
+        from PySide6.Qt3DRender import Qt3DRender as _R
+        Qt3DWindow = _E.Qt3DWindow
+        QOrbitCameraController = _E.QOrbitCameraController
+        QDiffuseMapMaterial = _E.QDiffuseMapMaterial
+        QSphereMesh = _E.QSphereMesh
+        QCuboidMesh = _E.QCuboidMesh
+        QEntity = _C.QEntity
+        QTransform = _C.QTransform
+        QTexture2D = _R.QTexture2D
+        QPaintedTextureImage = _R.QPaintedTextureImage
+        QPointLight = _R.QPointLight
         from PySide6.QtGui import QVector3D, QColor
         from qfluentwidgets import CaptionLabel, PushButton
 

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -362,7 +362,6 @@ class _Texture3DView(QDialog):
             | Qt.WindowType.WindowMinimizeButtonHint
             | Qt.WindowType.WindowMaximizeButtonHint
             | Qt.WindowType.WindowCloseButtonHint)
-        self._mid_last = None            # middle-mouse orbit anchor
 
         # Most portable way to get a QImage into a Qt3D texture across PySide6
         # builds: a temp PNG loaded by QTextureLoader (a painted-texture
@@ -395,13 +394,18 @@ class _Texture3DView(QDialog):
 
         self._root = _C.QEntity()
         self._cam = self._window.camera()
-        self._cam.lens().setPerspectiveProjection(45.0, 1.2, 0.1, 1000.0)
-        self._cam.setPosition(QVector3D(0, 0, 3.2))
-        self._cam.setViewCenter(QVector3D(0, 0, 0))
-        ctrl = _E.QOrbitCameraController(self._root)
-        ctrl.setCamera(self._cam)
-        ctrl.setLinearSpeed(60.0)
-        ctrl.setLookSpeed(180.0)
+        self._cam.lens().setPerspectiveProjection(45.0, 1.2, 0.05, 1000.0)
+        # Unreal-style orbit: the camera revolves around a FIXED pivot at the
+        # origin (where the shape sits) at a controllable distance, so the asset
+        # stays centred and can never translate off-screen. Drag = orbit,
+        # wheel = dolly. Driven by hand — QOrbitCameraController was removed
+        # because it also pans the view centre, which let the asset fly out of
+        # frame and vanish at the window edges (the reported bug).
+        self._azimuth = 0.0        # degrees, around the vertical axis
+        self._elevation = 0.0      # degrees, up/down (kept off the poles)
+        self._distance = 3.2       # camera distance from the pivot
+        self._orbit_last = None
+        self._update_camera()
 
         # Unlit texture material — shows the texture at full brightness with
         # no lighting dependency, so the shape is always visible.
@@ -415,7 +419,7 @@ class _Texture3DView(QDialog):
         # component and leaving the scene empty — the bug that made earlier
         # attempts render nothing. Parenting each mesh to its entity + holding
         # them in a list guarantees they survive.
-        self._keep = [ctrl, tex, mat]
+        self._keep = [tex, mat]
         self._shapes = {}
         # Plane — a flat card (thin cuboid, visible from both sides).
         pe = _C.QEntity(self._root)
@@ -448,29 +452,50 @@ class _Texture3DView(QDialog):
         self._window.setRootEntity(self._root)
         self._set_shape("plane")
 
+    def _update_camera(self):
+        """Position the camera on a sphere around the origin from the current
+        azimuth / elevation / distance. The view centre is pinned to the
+        origin, so the asset is always framed no matter how you spin it."""
+        import math
+        from PySide6.QtGui import QVector3D
+        self._elevation = max(-89.0, min(89.0, self._elevation))
+        a = math.radians(self._azimuth)
+        e = math.radians(self._elevation)
+        cos_e = math.cos(e)
+        pos = QVector3D(self._distance * cos_e * math.sin(a),
+                        self._distance * math.sin(e),
+                        self._distance * cos_e * math.cos(a))
+        self._cam.setViewCenter(QVector3D(0, 0, 0))
+        self._cam.setPosition(pos)
+        self._cam.setUpVector(QVector3D(0, 1, 0))
+
     def eventFilter(self, obj, event):  # noqa: N802
-        """Middle-mouse drag orbits the camera around the asset (in addition to
-        the orbit controller's left-drag), the way 3D tools behave."""
+        """Drag (left or middle button) orbits the camera around the fixed
+        pivot; the wheel dollies in and out. Same feel as an Unreal viewport —
+        the asset stays put and you move the camera around it."""
         from PySide6.QtCore import QEvent
         t = event.type()
+        _orbit_btns = (Qt.MouseButton.LeftButton, Qt.MouseButton.MiddleButton)
         if (t == QEvent.Type.MouseButtonPress
-                and event.button() == Qt.MouseButton.MiddleButton):
-            self._mid_last = event.position()
+                and event.button() in _orbit_btns):
+            self._orbit_last = event.position()
             return True
-        if t == QEvent.Type.MouseMove and self._mid_last is not None:
+        if t == QEvent.Type.MouseMove and self._orbit_last is not None:
             p = event.position()
-            dx = p.x() - self._mid_last.x()
-            dy = p.y() - self._mid_last.y()
-            self._mid_last = p
-            try:
-                self._cam.panAboutViewCenter(-dx * 0.35)
-                self._cam.tiltAboutViewCenter(-dy * 0.35)
-            except Exception:  # noqa: BLE001
-                pass
+            self._azimuth -= (p.x() - self._orbit_last.x()) * 0.3
+            self._elevation -= (p.y() - self._orbit_last.y()) * 0.3
+            self._orbit_last = p
+            self._update_camera()
             return True
         if (t == QEvent.Type.MouseButtonRelease
-                and event.button() == Qt.MouseButton.MiddleButton):
-            self._mid_last = None
+                and event.button() in _orbit_btns):
+            self._orbit_last = None
+            return True
+        if t == QEvent.Type.Wheel:
+            # positive delta = wheel up = zoom in (smaller distance)
+            step = 0.88 if event.angleDelta().y() > 0 else 1.0 / 0.88
+            self._distance = max(1.5, min(40.0, self._distance * step))
+            self._update_camera()
             return True
         return super().eventFilter(obj, event)
 
@@ -479,7 +504,7 @@ class _Texture3DView(QDialog):
         try:
             w = max(1, self._window.width())
             h = max(1, self._window.height())
-            self._cam.lens().setPerspectiveProjection(45.0, w / h, 0.1, 1000.0)
+            self._cam.lens().setPerspectiveProjection(45.0, w / h, 0.05, 1000.0)
         except Exception:  # noqa: BLE001
             pass
 

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -1,0 +1,140 @@
+"""Game Data page — build a searchable catalog of the installed game.
+
+A thin tool page over ``cdumm.engine.game_index``: one button builds (or
+refreshes) a SQLite index of every archive asset + the keyed game-data tables,
+on a background thread, then shows a summary. Search/browse UI is a planned
+follow-up; this first version reuses only ToolPageBase's built-in widgets
+(button, progress, stat cards, result cards) to keep it low-risk.
+
+Strings are intentionally literal (not tr() keys) for this first version, so it
+adds no new localization keys; localization is a follow-up.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+from PySide6.QtCore import QObject, QThread, Signal
+
+from cdumm.engine import game_index
+from cdumm.gui.pages.tool_page import ToolPageBase
+
+
+class _GameIndexWorker(QObject):
+    """Runs game_index.build_index off the UI thread."""
+
+    progress = Signal(int, str)
+    done = Signal(dict)
+    error = Signal(str)
+
+    def __init__(self, game_dir: str, out_path: str) -> None:
+        super().__init__()
+        self._game_dir = game_dir
+        self._out = out_path
+
+    def run(self) -> None:
+        try:
+            total = max(1, len(game_index.archive_dirs(self._game_dir)))
+            state = {"i": 0}
+
+            def cb(archive: str, n: int) -> None:
+                state["i"] += 1
+                pct = min(99, int(state["i"] * 100 / total))
+                self.progress.emit(pct, f"Indexed {archive}  ({n:,} entries)")
+
+            stats = game_index.build_index(
+                self._game_dir, self._out, progress=cb)
+            self.done.emit(stats)
+        except Exception as ex:  # noqa: BLE001 — surface any failure to the UI
+            self.error.emit(str(ex))
+
+
+class GameDataPage(ToolPageBase):
+    """Build + summarize a searchable index of the installed game's data."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(
+            object_name="GameDataPage",
+            title="Game Data",
+            description=(
+                "Build a searchable catalog of this Crimson Desert install — "
+                "every asset the game ships plus the keyed game-data tables "
+                "(items, NPCs, quests, skills, drops, ...). Metadata only; no "
+                "asset files are extracted."),
+            run_label="Build / refresh game-data index",
+            parent=parent,
+        )
+        # Persisted next to the OS temp dir for this first version; a future
+        # revision can move it under CDMods and add a search UI over it.
+        self._index_path = os.path.join(
+            tempfile.gettempdir(), "cdumm_game_index.sqlite")
+        self._thread: QThread | None = None
+        self._worker: _GameIndexWorker | None = None
+
+        self._stat_assets = self._add_stat_card("--", "Assets", "#2878D0")
+        self._stat_archives = self._add_stat_card("--", "Archives", "#8B5CF6")
+        self._stat_tables = self._add_stat_card("--", "Data tables", "#0EA5E9")
+
+    # ── run ─────────────────────────────────────────────────────────
+    def _on_run_clicked(self) -> None:
+        if not self._can_run():
+            return
+        if not self._game_dir:
+            self._set_status("No game folder configured.", "#BF616A")
+            return
+
+        self._clear_results()
+        self._set_running(True)
+
+        self._thread = QThread(self)
+        self._worker = _GameIndexWorker(str(self._game_dir), self._index_path)
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.done.connect(self._on_done)
+        self._worker.error.connect(self._on_error)
+        # Teardown: quit the loop + delete the worker once it reports back.
+        self._worker.done.connect(self._thread.quit)
+        self._worker.error.connect(self._thread.quit)
+        self._worker.done.connect(self._worker.deleteLater)
+        self._worker.error.connect(self._worker.deleteLater)
+        self._thread.finished.connect(self._thread.deleteLater)
+        self._thread.finished.connect(lambda: setattr(self, "_thread", None))
+        self._thread.start()
+
+    # ── worker callbacks (main thread, via queued signals) ──────────
+    def _on_progress(self, pct: int, msg: str) -> None:
+        self._set_progress(pct, msg)
+
+    def _on_done(self, stats: dict) -> None:
+        self._set_running(False)
+        try:
+            self._stat_assets.set_value(
+                f"{int(stats.get('assets_total', 0)):,}")
+            self._stat_archives.set_value(str(stats.get("archives", "--")))
+            self._stat_tables.set_value(
+                str(stats.get("data_table_distinct", "--")))
+        except Exception:  # noqa: BLE001
+            pass
+        self._set_status("Index built.", "#2E7D32")
+
+        detail = ""
+        try:
+            con = sqlite3.connect(self._index_path)
+            try:
+                tables = game_index.list_data_tables(con)[:12]
+            finally:
+                con.close()
+            detail = "\n".join(
+                f"• {t['name']}  ({t['orig_size']:,} bytes)"
+                for t in tables)
+        except Exception as ex:  # noqa: BLE001
+            detail = f"(could not read tables: {ex})"
+        self._add_result_card("Largest keyed game-data tables", detail)
+        self._add_result_card("Index file", self._index_path)
+
+    def _on_error(self, msg: str) -> None:
+        self._set_running(False)
+        self._set_status("Index failed.", "#BF616A")
+        self._add_result_card("Error", msg, "#BF616A")

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -16,9 +16,9 @@ import subprocess
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
-from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QHeaderView, QLabel,
-                               QScrollArea, QSizePolicy, QSplitter,
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (QDialog, QFileDialog, QHBoxLayout, QHeaderView,
+                               QLabel, QScrollArea, QSizePolicy, QSplitter,
                                QTableWidgetItem, QVBoxLayout, QWidget)
 
 from cdumm.engine import game_index
@@ -203,6 +203,112 @@ class _PreviewWorker(QObject):
                        text=game_index.hexdump(data, limit=self._hex_cap))
 
 
+class _Texture3DView(QDialog):
+    """Pop-up 3D material preview: the selected texture on an orbitable
+    sphere or cube. Built with Qt3D and constructed lazily (Qt3D is only
+    imported when the user opens a 3D preview). The caller wraps
+    construction in try/except so a GPU/driver problem can't take the app
+    down — it just reports the texture can't be shown in 3D."""
+
+    def __init__(self, qimage, title="Texture — 3D preview", parent=None):
+        super().__init__(parent)
+        from PySide6.Qt3DExtras import (Qt3DWindow, QOrbitCameraController,
+                                        QDiffuseMapMaterial, QSphereMesh,
+                                        QCuboidMesh)
+        from PySide6.Qt3DCore import QEntity, QTransform
+        from PySide6.Qt3DRender import (QTexture2D, QPaintedTextureImage,
+                                        QPointLight)
+        from PySide6.QtGui import QVector3D, QColor
+        from qfluentwidgets import CaptionLabel, PushButton
+
+        class _Painted(QPaintedTextureImage):
+            def __init__(self):
+                super().__init__()
+                self._img = None
+
+            def set_image(self, img):
+                self._img = img
+                self.setSize(img.size())
+                self.update()
+
+            def paint(self, painter):
+                if self._img is not None:
+                    painter.drawImage(0, 0, self._img)
+
+        self.setWindowTitle(title)
+        self.resize(720, 660)
+
+        self._window = Qt3DWindow()
+        self._window.defaultFrameGraph().setClearColor(QColor("#20222E"))
+        container = QWidget.createWindowContainer(self._window, self)
+        container.setMinimumSize(400, 400)
+        container.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(8, 8, 8, 8)
+        root_layout.setSpacing(8)
+        bar = QHBoxLayout()
+        self._sphere_btn = PushButton("Sphere", self)
+        self._cube_btn = PushButton("Cube", self)
+        self._sphere_btn.clicked.connect(lambda: self._set_shape(True))
+        self._cube_btn.clicked.connect(lambda: self._set_shape(False))
+        hint = CaptionLabel("Drag to orbit · scroll to zoom", self)
+        bar.addWidget(self._sphere_btn)
+        bar.addWidget(self._cube_btn)
+        bar.addStretch(1)
+        bar.addWidget(hint)
+        root_layout.addLayout(bar)
+        root_layout.addWidget(container, 1)
+
+        self._root = QEntity()
+        cam = self._window.camera()
+        cam.lens().setPerspectiveProjection(45.0, 1.0, 0.1, 1000.0)
+        cam.setPosition(QVector3D(0, 0, 3.5))
+        cam.setViewCenter(QVector3D(0, 0, 0))
+        ctrl = QOrbitCameraController(self._root)
+        ctrl.setCamera(cam)
+        ctrl.setLinearSpeed(50.0)
+        ctrl.setLookSpeed(180.0)
+
+        light_ent = QEntity(self._root)
+        light = QPointLight(light_ent)
+        light.setIntensity(1.1)
+        lt = QTransform()
+        lt.setTranslation(QVector3D(0, 0, 8))
+        light_ent.addComponent(light)
+        light_ent.addComponent(lt)
+
+        self._painted = _Painted()
+        tex = QTexture2D(self._root)
+        tex.addTextureImage(self._painted)
+        mat = QDiffuseMapMaterial(self._root)
+        mat.setDiffuse(tex)
+        mat.setAmbient(QColor(80, 80, 80))
+        mat.setSpecular(QColor(28, 28, 28))
+        mat.setShininess(8.0)
+
+        self._sphere = QEntity(self._root)
+        sm = QSphereMesh()
+        sm.setRadius(1.2)
+        sm.setRings(60)
+        sm.setSlices(60)
+        self._sphere.addComponent(sm)
+        self._sphere.addComponent(mat)
+
+        self._cube = QEntity(self._root)
+        cm = QCuboidMesh()
+        self._cube.addComponent(cm)
+        self._cube.addComponent(mat)
+        self._cube.setEnabled(False)
+
+        self._window.setRootEntity(self._root)
+        self._painted.set_image(qimage)
+
+    def _set_shape(self, sphere: bool) -> None:
+        self._sphere.setEnabled(sphere)
+        self._cube.setEnabled(not sphere)
+
+
 class GameDataPage(ToolPageBase):
     """Build, locate, and search an index of the installed game's data."""
 
@@ -371,6 +477,13 @@ class GameDataPage(ToolPageBase):
         self._pv_img_scroll.setVisible(False)
         pv.addWidget(self._pv_img_scroll, 1)
 
+        # "View in 3D" — only shown for image previews; opens a pop-up with
+        # the texture on a rotatable sphere/cube (Qt3D).
+        self._pv_3d_btn = PushButton("View in 3D  ⬤", pane)
+        self._pv_3d_btn.setVisible(False)
+        self._pv_3d_btn.clicked.connect(self._on_view_3d)
+        pv.addWidget(self._pv_3d_btn)
+
         self._pv_extract = PushButton("Extract raw file…", pane)
         self._pv_extract.setEnabled(False)
         self._pv_extract.clicked.connect(self._extract_raw)
@@ -383,6 +496,8 @@ class GameDataPage(ToolPageBase):
         self._preview_name: str | None = None
         self._pv_gen = 0                 # bumped per selection; ignore stale
         self._pv_jobs: list = []         # live (thread, worker) — keep refs
+        self._pv_qimage: QImage | None = None   # current texture, for 3D
+        self._pv_3d_dlg = None                   # open 3D dialog (keep a ref)
         # stretch=1 makes this row absorb the page's spare vertical space
         # (the base layout's trailing addStretch() has factor 0, so it yields).
         root.insertWidget(root.count() - 1, split, 1)
@@ -670,6 +785,7 @@ class GameDataPage(ToolPageBase):
     def _show_text(self, text: str, *, wrap: bool) -> None:
         self._pv_grid.setVisible(False)
         self._pv_img_scroll.setVisible(False)
+        self._pv_3d_btn.setVisible(False)
         self._pv_text.setVisible(True)
         self._pv_text.setLineWrapMode(
             self._pv_text.LineWrapMode.WidgetWidth if wrap
@@ -680,6 +796,9 @@ class GameDataPage(ToolPageBase):
         self._pv_text.setVisible(False)
         self._pv_grid.setVisible(False)
         self._pv_img_scroll.setVisible(True)
+        self._pv_qimage = QImage.fromData(png, "PNG") if png else None
+        self._pv_3d_btn.setVisible(
+            self._pv_qimage is not None and not self._pv_qimage.isNull())
         pm = QPixmap()
         if png:
             pm.loadFromData(png, "PNG")
@@ -694,6 +813,7 @@ class GameDataPage(ToolPageBase):
     def _show_grid(self, cols: list, rows: list) -> None:
         self._pv_text.setVisible(False)
         self._pv_img_scroll.setVisible(False)
+        self._pv_3d_btn.setVisible(False)
         self._pv_grid.setVisible(True)
         self._pv_grid.clear()
         self._pv_grid.setColumnCount(len(cols))
@@ -712,6 +832,19 @@ class GameDataPage(ToolPageBase):
         else:
             for c in range(len(cols)):
                 self._pv_grid.setColumnWidth(c, 130)
+
+    def _on_view_3d(self) -> None:
+        """Open the current texture on a rotatable sphere/cube (pop-up)."""
+        if self._pv_qimage is None or self._pv_qimage.isNull():
+            return
+        try:
+            dlg = _Texture3DView(
+                self._pv_qimage, self._preview_name or "Texture", self)
+        except Exception as ex:  # noqa: BLE001 — Qt3D / GPU/driver issue
+            self._set_status(f"3D preview unavailable: {ex}", "#BF616A")
+            return
+        self._pv_3d_dlg = dlg          # keep a ref so it isn't GC'd
+        dlg.show()
 
     def _extract_raw(self) -> None:
         """Save the selected asset's real (decoded) bytes to a file."""

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -126,6 +126,16 @@ def _shape_records(records: dict, schema, positions: dict | None = None
     # (e.g. sequencerspawninfo) also list _key/_name among their schema
     # fields, which would render a redundant duplicate column — drop those.
     field_names = [f for f in field_names if f not in ("_key", "_name")]
+    # Verified-only gate: for a hand-curated table, only fields the author
+    # validated against real record data are shown decoded; the rest render
+    # `(unverified)` so a guessed byte never masquerades as fact.
+    verified = getattr(schema, "verified_fields", None) if schema else None
+
+    def _fieldval(k, c):
+        if verified is not None and c not in verified:
+            return "(unverified)"
+        return _cell(records[k].get(c))
+
     pos_col = "world pos (X, Y, Z)"
     cols = ["_key", "_name"] + ([pos_col] if positions else []) + field_names
     keys = sorted(records)[:_GRID_ROW_CAP]
@@ -139,12 +149,15 @@ def _shape_records(records: dict, schema, positions: dict | None = None
         row = [_cell(records[k].get("_key")), _cell(records[k].get("_name"))]
         if positions:
             row.append(_posval(k))
-        row += [_cell(records[k].get(c)) for c in field_names]
+        row += [_fieldval(k, c) for c in field_names]
         rows.append(row)
 
     suspect = 0
+    # Unverified fields are intentionally not decoded — exclude them from the
+    # health score so a curated table isn't penalised for hiding guesses.
+    scored_fields = ([f for f in field_names if verified is None or f in verified])
     sample = keys[:60]
-    for fn in field_names:
+    for fn in scored_fields:
         vals = [records[k].get(fn) for k in sample]
         sv = [str(v) for v in vals]
         const = len(set(sv)) == 1
@@ -159,7 +172,7 @@ def _shape_records(records: dict, schema, positions: dict | None = None
             pass
         if const or zero or seq:
             suspect += 1
-    health = (suspect / len(field_names)) if field_names else 0.0
+    health = (suspect / len(scored_fields)) if scored_fields else 0.0
     return cols, rows, len(records), health
 
 

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -16,9 +16,9 @@ import subprocess
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
-from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QSizePolicy,
-                               QSplitter, QTableWidgetItem, QVBoxLayout,
-                               QWidget)
+from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QHeaderView,
+                               QSizePolicy, QSplitter, QTableWidgetItem,
+                               QVBoxLayout, QWidget)
 
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
@@ -153,14 +153,17 @@ class GameDataPage(ToolPageBase):
         _tf = self._table.font()
         _tf.setPixelSize(15)
         self._table.setFont(_tf)
-        _hf = self._table.horizontalHeader().font()
+        _hdr = self._table.horizontalHeader()
+        _hf = _hdr.font()
         _hf.setPixelSize(15)
-        self._table.horizontalHeader().setFont(_hf)
+        _hdr.setFont(_hf)
+        # Path absorbs the slack; the other three size to their content. This
+        # keeps the columns spanning the full table width so the vertical
+        # scrollbar hugs the last column instead of floating far to its right.
+        _hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        for _c in (1, 2, 3):
+            _hdr.setSectionResizeMode(_c, QHeaderView.ResizeMode.ResizeToContents)
         self._table.verticalHeader().setDefaultSectionSize(36)
-        try:
-            self._table.setColumnWidth(0, 360)
-        except Exception:  # noqa: BLE001
-            pass
         self._table.itemSelectionChanged.connect(self._on_asset_selected)
         split.addWidget(self._table)
 

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -233,6 +233,24 @@ class _PreviewWorker(QObject):
                        text=game_index.hexdump(data, limit=self._hex_cap))
 
 
+class _VgmDownloadWorker(QObject):
+    """Downloads + installs the right vgmstream build off the UI thread so the
+    one-click 'Enable audio playback' can't freeze the app."""
+
+    done = Signal(bool, str)
+
+    def __init__(self, dest_dir: str):
+        super().__init__()
+        self._dest = dest_dir
+
+    def run(self) -> None:
+        try:
+            ok, msg = game_index.download_vgmstream(self._dest)
+        except Exception as ex:  # noqa: BLE001
+            ok, msg = False, str(ex)
+        self.done.emit(ok, msg)
+
+
 class _Texture3DView(QDialog):
     """Pop-up 3D material preview: the selected texture on a flat plane,
     sphere, or cube. Built with Qt3D, constructed lazily (Qt3D is only
@@ -559,6 +577,13 @@ class GameDataPage(ToolPageBase):
         self._pv_export_btn.setVisible(False)
         self._pv_export_btn.clicked.connect(self._on_export_wav)
         pv.addWidget(self._pv_export_btn)
+
+        # One-click "get the right vgmstream for my OS" — only shown for audio
+        # when vgmstream isn't found yet.
+        self._pv_getvgm_btn = PushButton("⬇  Enable audio playback", pane)
+        self._pv_getvgm_btn.setVisible(False)
+        self._pv_getvgm_btn.clicked.connect(self._on_get_vgmstream)
+        pv.addWidget(self._pv_getvgm_btn)
 
         self._pv_extract = PushButton("Extract raw file…", pane)
         self._pv_extract.setEnabled(False)
@@ -897,6 +922,7 @@ class GameDataPage(ToolPageBase):
         self._pv_3d_btn.setVisible(False)
         self._pv_play_btn.setVisible(False)
         self._pv_export_btn.setVisible(False)
+        self._pv_getvgm_btn.setVisible(False)
         self._pv_text.setVisible(True)
         self._pv_text.setLineWrapMode(
             self._pv_text.LineWrapMode.WidgetWidth if wrap
@@ -954,12 +980,14 @@ class GameDataPage(ToolPageBase):
         self._pv_play_btn.setEnabled(playable)
         self._pv_export_btn.setVisible(True)
         self._pv_export_btn.setEnabled(playable)
+        self._pv_getvgm_btn.setVisible(not has_vgm)   # one-click auto-install
 
     def _show_image(self, png: bytes) -> None:
         self._pv_text.setVisible(False)
         self._pv_grid.setVisible(False)
         self._pv_play_btn.setVisible(False)
         self._pv_export_btn.setVisible(False)
+        self._pv_getvgm_btn.setVisible(False)
         self._pv_img_scroll.setVisible(True)
         self._pv_qimage = QImage.fromData(png, "PNG") if png else None
         self._pv_3d_btn.setVisible(
@@ -981,6 +1009,7 @@ class GameDataPage(ToolPageBase):
         self._pv_3d_btn.setVisible(False)
         self._pv_play_btn.setVisible(False)
         self._pv_export_btn.setVisible(False)
+        self._pv_getvgm_btn.setVisible(False)
         self._pv_grid.setVisible(True)
         self._pv_grid.clear()
         self._pv_grid.setColumnCount(len(cols))
@@ -1112,3 +1141,37 @@ class GameDataPage(ToolPageBase):
                 os.unlink(wav)
             except OSError:
                 pass
+
+    def _on_get_vgmstream(self) -> None:
+        """One-click: download the right vgmstream build for this OS from the
+        official GitHub releases and install it into the app's tools folder."""
+        pkg = os.path.dirname(
+            os.path.dirname(os.path.abspath(game_index.__file__)))  # …/cdumm
+        dest = os.path.join(pkg, "tools", "vgmstream")
+        self._pv_getvgm_btn.setEnabled(False)
+        self._pv_getvgm_btn.setText("⬇  Downloading vgmstream…")
+        self._set_status("Downloading vgmstream from GitHub…", "#2E7D32")
+        th = QThread(self)
+        w = _VgmDownloadWorker(dest)
+        w.moveToThread(th)
+        th.started.connect(w.run)
+        w.done.connect(self._on_vgm_downloaded)
+        w.done.connect(th.quit)
+        w.done.connect(w.deleteLater)
+        th.finished.connect(th.deleteLater)
+        job = (th, w)
+        self._pv_jobs.append(job)
+        th.finished.connect(
+            lambda job=job: job in self._pv_jobs and self._pv_jobs.remove(job))
+        th.start()
+
+    def _on_vgm_downloaded(self, ok: bool, msg: str) -> None:
+        self._pv_getvgm_btn.setEnabled(True)
+        self._pv_getvgm_btn.setText("⬇  Enable audio playback")
+        if ok:
+            self._set_status(
+                f"vgmstream {msg} installed — audio playback enabled.",
+                "#2E7D32")
+            self._on_asset_selected()      # re-preview → Play/Export enable
+        else:
+            self._set_status(f"vgmstream setup failed: {msg}", "#BF616A")

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -157,12 +157,16 @@ class GameDataPage(ToolPageBase):
         _hf = _hdr.font()
         _hf.setPixelSize(15)
         _hdr.setFont(_hf)
-        # Path absorbs the slack; the other three size to their content. This
-        # keeps the columns spanning the full table width so the vertical
-        # scrollbar hugs the last column instead of floating far to its right.
+        # Path stretches to fill the slack; the other three get fixed widths.
+        # This keeps the columns spanning the full table width (so the vertical
+        # scrollbar hugs the last column) WITHOUT ResizeToContents, which
+        # re-measures every row on every update and can stall the UI thread.
         _hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
         for _c in (1, 2, 3):
-            _hdr.setSectionResizeMode(_c, QHeaderView.ResizeMode.ResizeToContents)
+            _hdr.setSectionResizeMode(_c, QHeaderView.ResizeMode.Interactive)
+        self._table.setColumnWidth(1, 90)
+        self._table.setColumnWidth(2, 140)
+        self._table.setColumnWidth(3, 130)
         self._table.verticalHeader().setDefaultSectionSize(36)
         self._table.itemSelectionChanged.connect(self._on_asset_selected)
         split.addWidget(self._table)
@@ -369,7 +373,9 @@ class GameDataPage(ToolPageBase):
     # ── preview pane ─────────────────────────────────────────────────
     _PREVIEW_TEXT_CAP = 200_000            # chars shown for text assets
     _PREVIEW_HEX_CAP = 4096               # bytes shown for the hex view
-    _PREVIEW_SIZE_LIMIT = 32 * 1024 * 1024  # don't inline-decode above this
+    _PREVIEW_SIZE_LIMIT = 4 * 1024 * 1024   # keep inline decode cheap: a 4 MB
+    #   read+LZ4+decode is ~tens of ms; a multi-MB table/texture would freeze
+    #   the UI thread (AppHang). Bigger assets show metadata + Extract raw only.
 
     def _selected_path(self) -> str | None:
         items = self._table.selectedItems()

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -204,119 +204,112 @@ class _PreviewWorker(QObject):
 
 
 class _Texture3DView(QDialog):
-    """Pop-up 3D material preview: the selected texture on an orbitable
-    sphere or cube. Built with Qt3D and constructed lazily (Qt3D is only
-    imported when the user opens a 3D preview). The caller wraps
-    construction in try/except so a GPU/driver problem can't take the app
-    down — it just reports the texture can't be shown in 3D."""
+    """Pop-up 3D material preview: the selected texture on a flat plane,
+    sphere, or cube. Built with Qt3D, constructed lazily (Qt3D is only
+    imported when the user opens a 3D preview), and the caller wraps
+    construction in try/except so a GPU/driver problem can't crash the app.
+
+    A flat plane is how billboard / decal / UI textures appear in game;
+    solid game meshes aren't attainable (the mesh formats are proprietary),
+    so the sphere/cube are for inspecting how a texture wraps and tiles."""
 
     def __init__(self, qimage, title="Texture — 3D preview", parent=None):
         super().__init__(parent)
-        # PySide6 6.10 nests the Qt3D classes under a same-named namespace
-        # (PySide6.Qt3DExtras.Qt3DExtras.Qt3DWindow, etc.), so pull them off
-        # the nested namespace rather than the top-level module.
+        # PySide6 6.10 nests the Qt3D classes under a same-named namespace.
         from PySide6.Qt3DExtras import Qt3DExtras as _E
         from PySide6.Qt3DCore import Qt3DCore as _C
         from PySide6.Qt3DRender import Qt3DRender as _R
-        Qt3DWindow = _E.Qt3DWindow
-        QOrbitCameraController = _E.QOrbitCameraController
-        QDiffuseMapMaterial = _E.QDiffuseMapMaterial
-        QSphereMesh = _E.QSphereMesh
-        QCuboidMesh = _E.QCuboidMesh
-        QEntity = _C.QEntity
-        QTransform = _C.QTransform
-        QTexture2D = _R.QTexture2D
-        QPaintedTextureImage = _R.QPaintedTextureImage
-        QPointLight = _R.QPointLight
         from PySide6.QtGui import QVector3D, QColor
+        from PySide6.QtCore import QUrl
         from qfluentwidgets import CaptionLabel, PushButton
 
-        class _Painted(QPaintedTextureImage):
-            def __init__(self):
-                super().__init__()
-                self._img = None
-
-            def set_image(self, img):
-                self._img = img
-                self.setSize(img.size())
-                self.update()
-
-            def paint(self, painter):
-                if self._img is not None:
-                    painter.drawImage(0, 0, self._img)
-
         self.setWindowTitle(title)
-        self.resize(720, 660)
+        self.resize(760, 700)
 
-        self._window = Qt3DWindow()
+        # Most portable way to get a QImage into a Qt3D texture across PySide6
+        # builds: a temp PNG loaded by QTextureLoader (a painted-texture
+        # subclass rendered nothing on this build).
+        fd, self._tmp_png = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        qimage.save(self._tmp_png, "PNG")
+
+        self._window = _E.Qt3DWindow()
         self._window.defaultFrameGraph().setClearColor(QColor("#20222E"))
         container = QWidget.createWindowContainer(self._window, self)
-        container.setMinimumSize(400, 400)
+        container.setMinimumSize(420, 420)
         container.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
         root_layout = QVBoxLayout(self)
         root_layout.setContentsMargins(8, 8, 8, 8)
         root_layout.setSpacing(8)
         bar = QHBoxLayout()
-        self._sphere_btn = PushButton("Sphere", self)
-        self._cube_btn = PushButton("Cube", self)
-        self._sphere_btn.clicked.connect(lambda: self._set_shape(True))
-        self._cube_btn.clicked.connect(lambda: self._set_shape(False))
-        hint = CaptionLabel("Drag to orbit · scroll to zoom", self)
-        bar.addWidget(self._sphere_btn)
-        bar.addWidget(self._cube_btn)
+        for label, shape in (("Plane", "plane"), ("Sphere", "sphere"),
+                             ("Cube", "cube")):
+            btn = PushButton(label, self)
+            btn.clicked.connect(lambda _=False, s=shape: self._set_shape(s))
+            bar.addWidget(btn)
         bar.addStretch(1)
-        bar.addWidget(hint)
+        bar.addWidget(CaptionLabel("Drag to orbit · scroll to zoom", self))
         root_layout.addLayout(bar)
         root_layout.addWidget(container, 1)
 
-        self._root = QEntity()
+        self._root = _C.QEntity()
         cam = self._window.camera()
-        cam.lens().setPerspectiveProjection(45.0, 1.0, 0.1, 1000.0)
-        cam.setPosition(QVector3D(0, 0, 3.5))
+        cam.lens().setPerspectiveProjection(45.0, 1.2, 0.1, 1000.0)
+        cam.setPosition(QVector3D(0, 0, 3.2))
         cam.setViewCenter(QVector3D(0, 0, 0))
-        ctrl = QOrbitCameraController(self._root)
+        ctrl = _E.QOrbitCameraController(self._root)
         ctrl.setCamera(cam)
-        ctrl.setLinearSpeed(50.0)
+        ctrl.setLinearSpeed(60.0)
         ctrl.setLookSpeed(180.0)
 
-        light_ent = QEntity(self._root)
-        light = QPointLight(light_ent)
-        light.setIntensity(1.1)
-        lt = QTransform()
-        lt.setTranslation(QVector3D(0, 0, 8))
-        light_ent.addComponent(light)
-        light_ent.addComponent(lt)
+        # Unlit texture material — shows the texture at full brightness with
+        # no lighting dependency, so the shape is always visible.
+        tex = _R.QTextureLoader(self._root)
+        tex.setSource(QUrl.fromLocalFile(self._tmp_png))
+        mat = _E.QTextureMaterial(self._root)
+        mat.setTexture(tex)
 
-        self._painted = _Painted()
-        tex = QTexture2D(self._root)
-        tex.addTextureImage(self._painted)
-        mat = QDiffuseMapMaterial(self._root)
-        mat.setDiffuse(tex)
-        mat.setAmbient(QColor(80, 80, 80))
-        mat.setSpecular(QColor(28, 28, 28))
-        mat.setShininess(8.0)
-
-        self._sphere = QEntity(self._root)
-        sm = QSphereMesh()
-        sm.setRadius(1.2)
-        sm.setRings(60)
-        sm.setSlices(60)
-        self._sphere.addComponent(sm)
-        self._sphere.addComponent(mat)
-
-        self._cube = QEntity(self._root)
-        cm = QCuboidMesh()
-        self._cube.addComponent(cm)
-        self._cube.addComponent(mat)
-        self._cube.setEnabled(False)
+        self._shapes = {}
+        # Plane — a flat card (thin cuboid, visible from both sides).
+        pe = _C.QEntity(self._root)
+        pmesh = _E.QCuboidMesh()
+        ptx = _C.QTransform()
+        ptx.setScale3D(QVector3D(2.0, 2.0, 0.03))
+        pe.addComponent(pmesh)
+        pe.addComponent(mat)
+        pe.addComponent(ptx)
+        self._shapes["plane"] = pe
+        # Sphere
+        se = _C.QEntity(self._root)
+        smesh = _E.QSphereMesh()
+        smesh.setRadius(1.2)
+        smesh.setRings(60)
+        smesh.setSlices(60)
+        se.addComponent(smesh)
+        se.addComponent(mat)
+        self._shapes["sphere"] = se
+        # Cube
+        ce = _C.QEntity(self._root)
+        cmesh = _E.QCuboidMesh()
+        ce.addComponent(cmesh)
+        ce.addComponent(mat)
+        self._shapes["cube"] = ce
 
         self._window.setRootEntity(self._root)
-        self._painted.set_image(qimage)
+        self._set_shape("plane")
 
-    def _set_shape(self, sphere: bool) -> None:
-        self._sphere.setEnabled(sphere)
-        self._cube.setEnabled(not sphere)
+    def _set_shape(self, which: str) -> None:
+        for name, ent in self._shapes.items():
+            ent.setEnabled(name == which)
+
+    def closeEvent(self, event):  # noqa: N802
+        try:
+            if getattr(self, "_tmp_png", None) and os.path.exists(self._tmp_png):
+                os.remove(self._tmp_png)
+        except Exception:  # noqa: BLE001
+            pass
+        super().closeEvent(event)
 
 
 class GameDataPage(ToolPageBase):

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -131,8 +131,30 @@ def _shape_records(records: dict, schema, positions: dict | None = None
     # `(unverified)` so a guessed byte never masquerades as fact.
     verified = getattr(schema, "verified_fields", None) if schema else None
 
+    # Mask fields the decoder can't trust. A field is an "unknown-width
+    # placeholder" when it has no struct format, no walker type descriptor, and
+    # isn't a CString — i.e. an upstream `direct_15B` / `reader_*` / complex
+    # field whose real size is unknown. The decoder reads it left-to-right, so
+    # the FIRST such field (wrong width) misaligns every field after it too.
+    # Show fields up to that point; render it and everything after
+    # `(unverified)` rather than present misleading bytes. (Tables with a
+    # hand-built override have real type descriptors, so nothing trips this.)
+    masked = set()
+    if schema:
+        hit = False
+        for f in schema.fields:
+            if f.name in ("_key", "_name"):
+                continue          # metadata from the index/header, always shown
+            if not hit and hasattr(f, "field_type") and (
+                    not getattr(f, "struct_fmt", None)
+                    and not getattr(f, "type_descriptor", None)
+                    and f.field_type != "CString"):
+                hit = True
+            if hit:
+                masked.add(f.name)
+
     def _fieldval(k, c):
-        if verified is not None and c not in verified:
+        if (verified is not None and c not in verified) or c in masked:
             return "(unverified)"
         return _cell(records[k].get(c))
 
@@ -155,7 +177,8 @@ def _shape_records(records: dict, schema, positions: dict | None = None
     suspect = 0
     # Unverified fields are intentionally not decoded — exclude them from the
     # health score so a curated table isn't penalised for hiding guesses.
-    scored_fields = ([f for f in field_names if verified is None or f in verified])
+    scored_fields = [f for f in field_names
+                     if (verified is None or f in verified) and f not in masked]
     sample = keys[:60]
     for fn in scored_fields:
         vals = [records[k].get(fn) for k in sample]

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -16,8 +16,9 @@ import subprocess
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
-from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QSplitter,
-                               QTableWidgetItem, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QFileDialog, QHBoxLayout, QSizePolicy,
+                               QSplitter, QTableWidgetItem, QVBoxLayout,
+                               QWidget)
 
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
@@ -102,18 +103,25 @@ class GameDataPage(ToolPageBase):
         self._open_btn.clicked.connect(self._open_location)
         loc_row.addWidget(self._open_btn)
         root.insertLayout(root.count() - 1, loc_row)
+        root.insertSpacing(root.count() - 1, 16)
 
-        # Search + results table
+        # Search box — capped width + left-aligned (it doesn't need to span
+        # the whole page), so it also stops crowding the buttons above it.
+        search_row = QHBoxLayout()
+        search_row.setContentsMargins(0, 0, 0, 0)
         self._search = LineEdit(self._container)
         self._search.setPlaceholderText(
             "Search assets by path (build the index first)…")
         self._search.setClearButtonEnabled(True)
         self._search.setFixedHeight(38)
+        self._search.setMaximumWidth(480)
         _sf = self._search.font()
         _sf.setPixelSize(15)
         self._search.setFont(_sf)
         self._search.textChanged.connect(self._on_search)
-        root.insertWidget(root.count() - 1, self._search)
+        search_row.addWidget(self._search)
+        search_row.addStretch(1)
+        root.insertLayout(root.count() - 1, search_row)
 
         self._hits = BodyLabel("", self._container)
         self._hits.setContentsMargins(2, 4, 0, 0)
@@ -121,12 +129,17 @@ class GameDataPage(ToolPageBase):
         _hitf.setPixelSize(15)
         self._hits.setFont(_hitf)
         root.insertWidget(root.count() - 1, self._hits)
+        root.insertSpacing(root.count() - 1, 8)
 
         # Results table (left) + live preview pane (right), in a draggable
-        # splitter so the user can trade list width for preview width.
+        # splitter. It's given stretch=1 (below) + an Expanding policy so it
+        # fills the page down to the bottom instead of sitting short with a
+        # big dead zone beneath it.
         split = QSplitter(Qt.Horizontal, self._container)
         split.setChildrenCollapsible(False)
-        split.setMinimumHeight(420)
+        split.setMinimumHeight(460)
+        split.setSizePolicy(QSizePolicy.Policy.Expanding,
+                            QSizePolicy.Policy.Expanding)
 
         self._table = TableWidget(split)
         self._table.setColumnCount(4)
@@ -188,7 +201,9 @@ class GameDataPage(ToolPageBase):
         split.setStretchFactor(1, 2)
         self._preview_bytes: bytes | None = None
         self._preview_name: str | None = None
-        root.insertWidget(root.count() - 1, split)
+        # stretch=1 makes this row absorb the page's spare vertical space
+        # (the base layout's trailing addStretch() has factor 0, so it yields).
+        root.insertWidget(root.count() - 1, split, 1)
 
     # ── engine wiring ────────────────────────────────────────────────
     def set_managers(self, **kwargs) -> None:

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -66,6 +66,50 @@ def _cell(v) -> str:
     return s if len(s) <= 200 else s[:200] + "…"
 
 
+_FILE_TYPE_GUIDE = """A quick guide to Crimson Desert's file types — what you're looking at, and which ones you actually edit to make a mod. (Some are Pearl Abyss's own undocumented formats; where a meaning is inferred it's marked "~".)
+
+━━ THE ONES MODDERS EDIT MOST ━━
+.pabgb / .pabgh   Game-data TABLES + their key index — items, NPCs (character), quests, skills, drops, gimmicks, spawns, stages. Stats and values live here; most gameplay mods edit these. Opens as a grid of records (the _key and _name columns are always reliable).
+.paz              The ARCHIVE everything is packed into (like a .zip). The mod manager reads/writes these for you — you rarely touch them by hand.
+
+━━ VISUALS ━━
+.dds              TEXTURES / images — armour, faces, UI, the world map. Opens as an image (with a 3D view too).
+.padxil           Compiled SHADERS (GPU code) that draw surfaces. ~
+.pami / .pam / .pamlod   Model / MESH data and level-of-detail versions. ~
+.meshinfo         Mesh + collision / physics info for an object.
+.prefab           A placed "scene object" with its components and transform.
+
+━━ ANIMATION & COMBAT ━━
+.paa              ANIMATIONS (Pearl Abyss "PAR" clips) — character/creature motion.
+.paa_metabin      Metadata that rides alongside an animation.
+.paac / .paatt    ACTION CHARTS + their attribute blocks — the combat/animation logic (which move plays and its properties). ~
+.hkx              HAVOK data — ragdoll / physics / some animation (third-party format; shown as a structure outline).
+
+━━ AUDIO ━━
+.wem              Wwise SOUND streams — SFX, voice, music. Windows can't play them raw; the previewer decodes them with vgmstream so you can hear + export them.
+.bnk              Wwise SOUNDBANK — a container of sounds + event data.
+
+━━ EFFECTS · CUTSCENES · WORLD ━━
+.pae              Particle / EFFECT data — fire, sparks, auras.
+.paseq / .paseqc  SEQUENCER — timeline / cutscene data.
+.paproj           Projectile definitions — arrows, bombs, spells. ~
+.palevel / .levelinfo    Level / world data. ~
+.road / .roadsector / .nav   Roads and AI navigation meshes. ~
+
+━━ TEXT & CONFIG ━━
+.xml / .pac_xml / .app_xml / .html / .css / .thtml   Human-readable text, config, and UI.
+
+━━ HOW THE PREVIEW DECIDES WHAT TO SHOW ━━
+• Text formats → shown as text.
+• Textures → shown as an image (+ 3D).
+• Data tables (.pabgb) → a record grid.
+• Reflection formats (.pae / .paseq / .prefab / .meshinfo …) → a Field → Type schema table, using the engine's OWN names.
+• Audio (.wem / .bnk) → metadata + Play / Export-to-WAV.
+• Everything else (packed formats like .paatt / .paa / .pabgh) → a typed word table: the exact bytes shown as unsigned / signed / float. These formats carry no field names inside the file, so the values are shown accurately as raw numbers you can still patch by offset.
+
+Tip: a name ending in "info" is almost always a game-data table you can edit."""
+
+
 def _shape_records(records: dict, schema) -> tuple[list, list, int, float]:
     """Turn parse_records output into (columns, rows, total, health).
 
@@ -472,6 +516,25 @@ class GameDataPage(ToolPageBase):
         _hitf.setPixelSize(15)
         self._hits.setFont(_hitf)
         root.insertWidget(root.count() - 1, self._hits)
+        root.insertSpacing(root.count() - 1, 8)
+
+        # Beginner-friendly file-type guide — a collapsible box so newcomers can
+        # learn what each format is without it taking over the page.
+        self._guide_btn = PushButton(
+            "📖  New to modding?  What these file types mean", self._container)
+        self._guide_btn.setCheckable(True)
+        self._guide_btn.clicked.connect(
+            lambda: self._guide_box.setVisible(self._guide_btn.isChecked()))
+        root.insertWidget(root.count() - 1, self._guide_btn)
+        self._guide_box = PlainTextEdit(self._container)
+        self._guide_box.setReadOnly(True)
+        self._guide_box.setPlainText(_FILE_TYPE_GUIDE)
+        _gbf = self._guide_box.font()
+        _gbf.setPixelSize(13)
+        self._guide_box.setFont(_gbf)
+        self._guide_box.setFixedHeight(300)
+        self._guide_box.setVisible(False)
+        root.insertWidget(root.count() - 1, self._guide_box)
         root.insertSpacing(root.count() - 1, 8)
 
         # Results table (left) + live preview pane (right), in a draggable

--- a/src/cdumm/main.py
+++ b/src/cdumm/main.py
@@ -668,6 +668,11 @@ def main() -> int:
     logger.info("Startup: main window constructed; showing")
     window.show()
     splash.finish(window)
+    # Bring the window to the foreground. Windows won't auto-raise a window
+    # spawned from an already-focused terminal, so without this it can open
+    # hidden behind other windows and look like it never launched.
+    window.raise_()
+    window.activateWindow()
 
     # ── Frame stall profiler ─────────────────────────────────────────
     # Fires a 16ms timer and logs whenever the main thread stalls > 50ms.

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -545,6 +545,141 @@ def parse_records(table_name: str, body_bytes: bytes, header_bytes: bytes
     return records
 
 
+# ── Display decode (read-only, for the Game Data grid) ───────────────────────
+#
+# parse_records() above is shared with the apply/diff pipeline (engine.py) and
+# must not change. The functions below are a *display-only* decoder: they honor
+# the override flags (no_entry_header / no_null_skip) and drive byte
+# consumption through the format3 walker (pabgb_types.consume_bytes), so keyed
+# tables with rich schema overrides — iteminfo, regioninfo, vehicleinfo,
+# fieldinfo, stageinfo, characterinfo — render their real fields in the grid
+# instead of stopping at the first variable-length field. When the walker can't
+# safely step past a field, decoding stops there: earlier fields are kept and
+# the rest are simply absent (never guessed).
+
+_DISPLAY_PRIM_FMT = {
+    "u8": "B", "i8": "b", "u16": "H", "i16": "h", "u32": "I", "i32": "i",
+    "u64": "Q", "i64": "q", "f32": "f", "f64": "d",
+}
+
+
+def _display_payload_start(entry: bytes, schema: "TableSchema",
+                           key_size: int) -> int:
+    """Byte offset of the first field, honoring the override flags."""
+    if schema.no_entry_header:
+        return 0
+    eid_size = 2 if key_size == 2 else 4
+    head = eid_size + 4
+    if len(entry) < head:
+        return 0
+    nlen = struct.unpack_from("<I", entry, eid_size)[0]
+    if nlen > 500 or head + nlen > len(entry):
+        return head
+    name_end = head + nlen
+    if schema.no_null_skip:
+        return name_end
+    return (name_end + 1
+            if name_end < len(entry) and entry[name_end] == 0 else name_end)
+
+
+def _display_value(td: str, body: bytes, off: int, width: int) -> Any:
+    """Human-readable value for a walked field. Strings decode inline;
+    arrays show their element count; optionals show present/absent; anything
+    without a scalar rendering falls back to compact hex."""
+    td = (td or "").strip()
+    fmt = _DISPLAY_PRIM_FMT.get(td)
+    if fmt:
+        try:
+            return struct.unpack_from("<" + fmt, body, off)[0]
+        except struct.error:
+            return None
+    if td == "CString":
+        slen = struct.unpack_from("<I", body, off)[0]
+        return body[off + 4:off + 4 + slen].decode("utf-8", "replace")
+    if td == "LocalizableString":
+        idx = struct.unpack_from("<Q", body, off + 1)[0]
+        slen = struct.unpack_from("<I", body, off + 9)[0]
+        if slen:
+            return body[off + 13:off + 13 + slen].decode("utf-8", "replace")
+        return f"loc#{idx}"          # text lives in the localization table
+    if td.startswith("CArray<"):
+        return f"[{struct.unpack_from('<I', body, off)[0]} items]"
+    if td.startswith("COptional<"):
+        return "—" if body[off] == 0 else "present"
+    return body[off:off + width].hex()
+
+
+def decode_record_display(entry_data: bytes, schema: "TableSchema",
+                          key_size: int) -> dict[str, Any]:
+    """Walk one entry into {field: display_value}, walker-driven."""
+    from cdumm.semantic import pabgb_types as _pt
+    off = _display_payload_start(entry_data, schema, key_size)
+    end = len(entry_data)
+    out: dict[str, Any] = {}
+    for spec in schema.fields:
+        if spec.type_descriptor:
+            w = _pt.consume_bytes(spec.type_descriptor, entry_data, off, end)
+            if w is None:
+                break
+            out[spec.name] = _display_value(
+                spec.type_descriptor, entry_data, off, w)
+            off += w
+        elif spec.struct_fmt:
+            w = spec.stream_size
+            if off + w > end:
+                break
+            out[spec.name] = struct.unpack_from(
+                "<" + spec.struct_fmt, entry_data, off)[0]
+            off += w
+        elif spec.field_type == "CString":
+            if off + 4 > end:
+                break
+            slen = struct.unpack_from("<I", entry_data, off)[0]
+            if off + 4 + slen > end:
+                break
+            out[spec.name] = entry_data[
+                off + 4:off + 4 + slen].decode("utf-8", "replace")
+            off += 4 + slen
+        else:
+            w = spec.stream_size or 0
+            if w == 0 or off + w > end:
+                break
+            out[spec.name] = entry_data[off:off + w].hex()
+            off += w
+    return out
+
+
+def parse_records_display(table_name: str, body_bytes: bytes,
+                          header_bytes: bytes) -> dict[int, dict[str, Any]]:
+    """Display-only variant of parse_records for the Game Data grid.
+
+    Same {key: {field: value}} shape, but flag- and walker-aware so richly
+    overridden tables decode fully. Never used by the apply/diff pipeline.
+    """
+    schema = get_schema(table_name)
+    if schema is None:
+        return {}
+    key_size, offsets = parse_pabgh_index(header_bytes, table_name)
+    if not offsets:
+        return {}
+    sorted_entries = sorted(offsets.items(), key=lambda x: x[1])
+    records: dict[int, dict[str, Any]] = {}
+    for idx, (key, entry_offset) in enumerate(sorted_entries):
+        entry_end = (sorted_entries[idx + 1][1]
+                     if idx + 1 < len(sorted_entries) else len(body_bytes))
+        if entry_offset >= len(body_bytes):
+            continue
+        entry_data = body_bytes[entry_offset:entry_end]
+        name = ""
+        if not schema.no_entry_header:
+            _eid, name, _ps = _parse_entry_header(entry_data, 0, key_size)
+        fields = decode_record_display(entry_data, schema, key_size)
+        fields["_key"] = key
+        fields["_name"] = name
+        records[key] = fields
+    return records
+
+
 def identify_table_from_path(entry_path: str) -> str | None:
     """Extract table name from a PAMT entry path.
 

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -91,6 +91,13 @@ class TableSchema:
     notes: 'There is NO per-entry name header in RegionInfo PABGB.
     The _key and _stringKey are regular fields read by the table
     reader')."""
+    verified_fields: frozenset[str] | None = None
+    """Verified-only display gate. ``None`` = table not yet hand-curated;
+    show every schema field as decoded (legacy behavior). A set = only
+    these fields have been validated against real record data; the GUI
+    renders any other field as ``(unverified)`` instead of a possibly-
+    wrong value. Set via ``_verified_fields: [...]`` in the override file.
+    ``_key`` / ``_name`` are always trustworthy and never gated."""
 
     @property
     def fixed_record_size(self) -> int | None:
@@ -156,6 +163,12 @@ def _load_schemas() -> dict[str, TableSchema]:
         table_overrides = overrides.get(table_name, {})
         no_null_skip = bool(table_overrides.get("_no_null_skip", False))
         no_entry_header = bool(table_overrides.get("_no_entry_header", False))
+        # `_verified_fields`: opt-in list of hand-validated fields. When
+        # present, the GUI shows only these as decoded values and marks
+        # every other field `(unverified)` — so a table can be worked
+        # incrementally without ever presenting an unproven column.
+        vf_raw = table_overrides.get("_verified_fields")
+        verified_fields = frozenset(vf_raw) if vf_raw is not None else None
         # `_ordered_fields` REPLACES the upstream schema's array order.
         # The upstream schema sorts by memory address; the actual
         # on-disk deserialization order often differs (verified
@@ -262,7 +275,8 @@ def _load_schemas() -> dict[str, TableSchema]:
             schemas[table_name.lower()] = TableSchema(
                 table_name=table_name, fields=fields,
                 no_null_skip=no_null_skip,
-                no_entry_header=no_entry_header)
+                no_entry_header=no_entry_header,
+                verified_fields=verified_fields)
 
     _loaded_schemas = schemas
     logger.info("Loaded %d PABGB table schemas (%d with type overrides)",

--- a/src/cdumm/tools/vgmstream/README.txt
+++ b/src/cdumm/tools/vgmstream/README.txt
@@ -1,0 +1,23 @@
+vgmstream — Wwise audio decoder for the Game Data tab
+=====================================================
+
+The game's sounds (.wem / .bnk) are Wwise Vorbis, which Windows cannot play
+directly. The Game Data tab uses vgmstream to decode them to standard WAV for
+the in-app "Play" button and "Export as WAV".
+
+To enable audio playback, drop the vgmstream CLI here:
+
+    src/cdumm/tools/vgmstream/vgmstream-cli.exe
+
+Download it from the official project (pick the Windows CLI build):
+
+    https://github.com/vgmstream/vgmstream
+    Releases: https://github.com/vgmstream/vgmstream/releases
+    (the file is vgmstream-cli.exe, inside vgmstream-win64.zip / vgmstream-win.zip)
+
+The app auto-detects it here, or anywhere on the system PATH. Until it's
+present, audio previews still show full Wwise metadata and the raw .wem/.bnk
+"Extract raw file" always works — only Play / Export as WAV need this binary.
+
+vgmstream is a separate open-source project with its own license; it is NOT
+part of CDUMM. This folder only tells the app where to find it.

--- a/src/cdumm/tools/vgmstream/README.txt
+++ b/src/cdumm/tools/vgmstream/README.txt
@@ -5,7 +5,12 @@ The game's sounds (.wem / .bnk) are Wwise Vorbis, which Windows cannot play
 directly. The Game Data tab uses vgmstream to decode them to standard WAV for
 the in-app "Play" button and "Export as WAV".
 
-To enable audio playback, drop the vgmstream CLI here:
+Easiest: in the Game Data tab, click an audio (.wem) asset and press
+"⬇ Enable audio playback" — it auto-detects your OS, downloads the correct
+latest vgmstream build from the official GitHub release, and installs it here
+for you. The rest of this file is the manual alternative.
+
+To enable audio playback manually, drop the vgmstream CLI here:
 
     src/cdumm/tools/vgmstream/vgmstream-cli.exe
 

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_game_data_shape.py
+++ b/tests/test_game_data_shape.py
@@ -1,0 +1,47 @@
+"""Grid-shaping guardrails for the Game Data table preview.
+
+Regression for the doubled ``_key`` column: several game-data tables list
+``_key`` (and sometimes ``_name``) among their own schema fields, and
+``_shape_records`` already prepends ``_key`` / ``_name`` as the leading
+columns — so those must be dropped from the schema-field list or the grid
+shows a redundant duplicate column (seen on ``sequencerspawninfo``).
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+pytest.importorskip("qfluentwidgets")
+
+
+def _schema(*names):
+    return SimpleNamespace(fields=[SimpleNamespace(name=n) for n in names])
+
+
+def test_shape_records_dedupes_key_and_name_columns():
+    from cdumm.gui.pages.game_data_page import _shape_records
+    # mirrors sequencerspawninfo: schema lists _key among its fields
+    schema = _schema("_isRandom", "_stageType", "_key", "_isBlocked")
+    records = {
+        1001: {"_key": 1001, "_name": "A", "_isRandom": 26,
+               "_stageType": 0, "_isBlocked": 236},
+        1002: {"_key": 1002, "_name": "B", "_isRandom": 23,
+               "_stageType": 0, "_isBlocked": 236},
+    }
+    cols, rows, total, _health = _shape_records(records, schema)
+    assert cols.count("_key") == 1          # leading col only, not duplicated
+    assert cols.count("_name") == 1
+    assert cols == ["_key", "_name", "_isRandom", "_stageType", "_isBlocked"]
+    assert total == 2
+    assert rows[0][0] == "1001" and rows[0][1] == "A"
+
+
+def test_shape_records_without_schema():
+    from cdumm.gui.pages.game_data_page import _shape_records
+    cols, _rows, _total, health = _shape_records(
+        {1: {"_key": 1, "_name": "x"}}, None)
+    assert cols == ["_key", "_name"] and health == 0.0

--- a/tests/test_game_data_shape.py
+++ b/tests/test_game_data_shape.py
@@ -45,3 +45,20 @@ def test_shape_records_without_schema():
     cols, _rows, _total, health = _shape_records(
         {1: {"_key": 1, "_name": "x"}}, None)
     assert cols == ["_key", "_name"] and health == 0.0
+
+
+def test_shape_records_position_column():
+    from cdumm.gui.pages.game_data_page import _shape_records
+    schema = _schema("_isRandom")
+    records = {
+        1: {"_key": 1, "_name": "A", "_isRandom": 5},
+        2: {"_key": 2, "_name": "B", "_isRandom": 6},
+    }
+    positions = {1: (-11534.5, 530.4, -6126.3)}      # only key 1 has a position
+    cols, rows, total, _h = _shape_records(records, schema, positions)
+    assert cols == ["_key", "_name", "world pos (X, Y, Z)", "_isRandom"]
+    assert rows[0][2] == "-11534.5, 530.4, -6126.3"
+    assert rows[1][2] == ""                           # key 2 → blank, not guessed
+    # no positions → no extra column
+    cols2, _r, _t, _h2 = _shape_records(records, schema)
+    assert "world pos (X, Y, Z)" not in cols2

--- a/tests/test_game_data_shape.py
+++ b/tests/test_game_data_shape.py
@@ -18,8 +18,10 @@ pytest.importorskip("PySide6")
 pytest.importorskip("qfluentwidgets")
 
 
-def _schema(*names):
-    return SimpleNamespace(fields=[SimpleNamespace(name=n) for n in names])
+def _schema(*names, verified=None):
+    return SimpleNamespace(
+        fields=[SimpleNamespace(name=n) for n in names],
+        verified_fields=verified)
 
 
 def test_shape_records_dedupes_key_and_name_columns():
@@ -62,3 +64,37 @@ def test_shape_records_position_column():
     # no positions → no extra column
     cols2, _r, _t, _h2 = _shape_records(records, schema)
     assert "world pos (X, Y, Z)" not in cols2
+
+
+def test_shape_records_verified_only_masks_unverified_fields():
+    """A hand-curated table shows only validated fields; the rest render
+    ``(unverified)`` instead of a possibly-wrong value, and unverified
+    columns don't drag the health score."""
+    from cdumm.gui.pages.game_data_page import _shape_records
+    schema = _schema("_increasePrice", "_isBlocked", "_useTargetPrice",
+                     verified=frozenset({"_increasePrice"}))
+    records = {
+        256: {"_key": 256, "_name": "", "_increasePrice": 100,
+              "_isBlocked": 0, "_useTargetPrice": 0},
+        262: {"_key": 262, "_name": "", "_increasePrice": 1500,
+              "_isBlocked": 0, "_useTargetPrice": 1},
+    }
+    cols, rows, _total, health = _shape_records(records, schema)
+    ci = {c: i for i, c in enumerate(cols)}
+    # verified field shows its real value
+    assert rows[0][ci["_increasePrice"]] == "100"
+    assert rows[1][ci["_increasePrice"]] == "1500"
+    # unverified fields are masked, never shown as a decoded guess
+    assert rows[0][ci["_isBlocked"]] == "(unverified)"
+    assert rows[0][ci["_useTargetPrice"]] == "(unverified)"
+    # only the (varying) verified field is scored → healthy
+    assert health == 0.0
+
+
+def test_shape_records_verified_none_shows_all_fields():
+    """Backward compat: verified_fields=None → every field decoded as before."""
+    from cdumm.gui.pages.game_data_page import _shape_records
+    schema = _schema("_a", "_b", verified=None)
+    records = {1: {"_key": 1, "_name": "x", "_a": 7, "_b": 9}}
+    _cols, rows, _total, _h = _shape_records(records, schema)
+    assert rows[0][-2:] == ["7", "9"]         # no masking anywhere

--- a/tests/test_game_data_shape.py
+++ b/tests/test_game_data_shape.py
@@ -98,3 +98,30 @@ def test_shape_records_verified_none_shows_all_fields():
     records = {1: {"_key": 1, "_name": "x", "_a": 7, "_b": 9}}
     _cols, rows, _total, _h = _shape_records(records, schema)
     assert rows[0][-2:] == ["7", "9"]         # no masking anywhere
+
+
+def test_shape_records_masks_from_first_placeholder():
+    """A field with no struct format / walker type / CString is an unknown-width
+    placeholder; it and every field after it are masked (its wrong width
+    misaligns the rest). Fields before it, and _key/_name, stay shown."""
+    from cdumm.gui.pages.game_data_page import _shape_records
+    from cdumm.semantic.parser import FieldSpec, TableSchema
+
+    def f(name, fmt=None, td=None, ft="direct_u8", sz=1):
+        return FieldSpec(name=name, stream_size=sz, field_type=ft,
+                         struct_fmt=fmt, type_descriptor=td)
+
+    schema = TableSchema("t", [
+        f("_a", fmt="B"),                                   # primitive → shown
+        f("_b", td="u32"),                                  # walker type → shown
+        f("_raw", ft="direct_15B", sz=15),                  # placeholder → mask here on
+        f("_c", fmt="B"),                                   # after placeholder → masked
+    ])
+    records = {1: {"_key": 1, "_name": "x", "_a": 5, "_b": 9,
+                   "_raw": "deadbeef", "_c": 7}}
+    cols, rows, _t, _h = _shape_records(records, schema)
+    ci = {c: i for i, c in enumerate(cols)}
+    assert rows[0][ci["_a"]] == "5"
+    assert rows[0][ci["_b"]] == "9"
+    assert rows[0][ci["_raw"]] == "(unverified)"
+    assert rows[0][ci["_c"]] == "(unverified)"    # cascade: after a placeholder

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -330,11 +330,13 @@ def test_decode_struct_typed_words_and_keys():
     assert rows[3][4] == "2"                                   # float 2.0
 
 
-def test_decode_struct_blanks_noise_floats():
+def test_decode_struct_always_populates_float():
     import struct as _s
-    # 0x123A6E00 as float32 is ~4e-28 — outside the sane range → blank cell
+    # the float column is never blank: it's the exact IEEE-754 reading of the
+    # bytes even when the word is really an int (a tiny/denormal number)
     data = _s.pack("<I", 1) + _s.pack("<I", 0x123A6E00)
-    assert gi.decode_struct(data)["rows"][1][4] == ""
+    rows = gi.decode_struct(data)["rows"]
+    assert rows[0][4] != "" and rows[1][4] != ""
     # an all-zero word is a legitimate 0.0 and shows "0"
     assert gi.decode_struct(bytes(8))["rows"][1][4] == "0"
 

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -1,0 +1,149 @@
+"""Headless tests for the game-data index engine (cdumm.engine.game_index).
+
+Exercises the schema, per-archive insert, query helpers, and the full
+build_index path with an injected fake parser + fake install dir — no real
+Crimson Desert install or archive bytes required.
+"""
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from cdumm.engine import game_index as gi
+
+
+def _entry(path, paz_file="0008/0.paz", offset=0, comp=10, orig=10, enc=False):
+    return SimpleNamespace(
+        path=path, paz_file=paz_file, offset=offset,
+        comp_size=comp, orig_size=orig,
+        compressed=(comp != orig), encrypted=enc)
+
+
+def _db(entries_by_archive):
+    con = sqlite3.connect(":memory:")
+    gi.create_schema(con)
+    for arch, ents in entries_by_archive.items():
+        gi.insert_archive(con, arch, ents)
+    gi.finalize(con)
+    gi.write_stats(con)
+    return con
+
+
+def test_category_and_ext_derivation():
+    assert gi.category_of("gamedata/iteminfo.pabgb") == "gamedata"
+    assert gi.category_of("sequencer/x.paseq") == "sequencer"
+    assert gi.category_of("root.txt") == "(root)"
+    assert gi.ext_of("a/b.PASEQ") == ".paseq"       # lower-cased
+    assert gi.ext_of("gamedata/iteminfo.pabgb") == ".pabgb"
+    assert gi.ext_of("noext") == "(none)"
+
+
+def test_schema_counts_and_flags():
+    con = _db({
+        "0008": [_entry("gamedata/iteminfo.pabgb", comp=100, orig=200),  # compressed
+                 _entry("gamedata/iteminfo.pabgh"),
+                 _entry("sequencer/x.paseq")],
+        "0014": [_entry("ui/y.xml", enc=True)],
+    })
+    st = gi.get_stats(con)
+    assert st["assets_total"] == "4"
+    assert st["archives"] == "2"
+    # flags persisted as 0/1
+    comp = con.execute(
+        "SELECT compressed FROM assets WHERE path='gamedata/iteminfo.pabgb'"
+    ).fetchone()[0]
+    enc = con.execute(
+        "SELECT encrypted FROM assets WHERE path='ui/y.xml'").fetchone()[0]
+    assert comp == 1 and enc == 1
+
+
+def test_search_by_substring_ext_category_archive():
+    con = _db({"0008": [
+        _entry("gamedata/iteminfo.pabgb"),
+        _entry("sequencer/loading.paseq"),
+        _entry("character/hero.paa"),
+    ], "0014": [_entry("sequencer/other.paseq")]})
+
+    r = gi.search_assets(con, query="iteminfo")
+    assert [x["path"] for x in r] == ["gamedata/iteminfo.pabgb"]
+
+    r = gi.search_assets(con, ext=".paseq")
+    assert {x["path"] for x in r} == {
+        "sequencer/loading.paseq", "sequencer/other.paseq"}
+
+    r = gi.search_assets(con, category="character")
+    assert [x["path"] for x in r] == ["character/hero.paa"]
+
+    r = gi.search_assets(con, ext=".paseq", archive="0014")
+    assert [x["path"] for x in r] == ["sequencer/other.paseq"]
+
+
+def test_search_limit_and_like_wildcards_are_literal():
+    con = _db({"0008": [_entry(f"gamedata/item{i}.pabgb") for i in range(10)]})
+    assert len(gi.search_assets(con, query="item", limit=3)) == 3
+    # a query containing % must match literally, not as a wildcard
+    con.execute("INSERT INTO assets VALUES('gamedata/50%off.txt','0008',"
+                "'gamedata','.txt','0008/0.paz',0,1,1,0,0)")
+    r = gi.search_assets(con, query="50%off")
+    assert [x["path"] for x in r] == ["gamedata/50%off.txt"]
+
+
+def test_data_tables_catalog_dedup_and_order():
+    con = _db({"0008": [
+        _entry("gamedata/iteminfo.pabgb", orig=555),
+        _entry("gamedata/stringinfo.pabgb", orig=999),
+        _entry("gamedata/iteminfo.pabgb", orig=555),   # dup name
+        _entry("character/hero.paa"),                  # not a table
+    ]})
+    tables = gi.list_data_tables(con)
+    assert [t["name"] for t in tables] == [
+        "stringinfo.pabgb", "iteminfo.pabgb"]          # largest first, deduped
+
+
+def test_category_counts():
+    con = _db({"0008": [
+        _entry("character/a.paa"), _entry("character/b.paa"),
+        _entry("sound/c.wem")]})
+    counts = {c["category"]: c["n"] for c in gi.category_counts(con)}
+    assert counts == {"character": 2, "sound": 1}
+
+
+def test_build_index_end_to_end(tmp_path):
+    """Full build_index path with a fake install + injected parser."""
+    game = tmp_path / "game"
+    for d in ("0008", "0014"):
+        (game / d).mkdir(parents=True)
+        (game / d / "0.pamt").write_bytes(b"")   # presence is all archive_dirs needs
+
+    fake = {
+        "0008": [_entry("gamedata/iteminfo.pabgb", orig=500),
+                 _entry("gamedata/iteminfo.pabgh", orig=20),
+                 _entry("character/hero.paa")],
+        "0014": [_entry("sequencer/loading.paseq")],
+    }
+
+    def fake_parse(pamt_path, paz_dir=None):
+        arch = pamt_path.replace("\\", "/").split("/")[-2]
+        return fake[arch]
+
+    seen = []
+    out = tmp_path / "idx.sqlite"
+    stats = gi.build_index(str(game), str(out),
+                           parse_pamt=fake_parse,
+                           progress=lambda a, n: seen.append((a, n)))
+
+    assert stats["assets_total"] == 4
+    assert stats["archives"] == 2
+    assert stats["data_table_distinct"] == 2      # iteminfo.pabgb + .pabgh
+    assert sorted(seen) == [("0008", 3), ("0014", 1)]
+
+    con = sqlite3.connect(str(out))
+    assert gi.search_assets(con, query="iteminfo")[0]["archive"] == "0008"
+    con.close()
+
+
+def test_build_index_no_archives_raises(tmp_path):
+    import pytest
+    with pytest.raises(ValueError):
+        gi.build_index(str(tmp_path), str(tmp_path / "x.sqlite"),
+                       parse_pamt=lambda *a, **k: [])

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -243,3 +243,22 @@ def test_hexdump_shape_and_truncation():
     assert "ABC.." in d
     big = gi.hexdump(b"\x00" * 100, limit=16)
     assert "showing first 16" in big and "100 bytes total" in big
+
+
+def test_decode_image_png_roundtrips_and_downscales():
+    import pytest
+    PILImage = pytest.importorskip("PIL.Image")
+    import io
+    buf = io.BytesIO()
+    PILImage.new("RGB", (2000, 1000), (10, 20, 30)).save(buf, format="PNG")
+    r = gi.decode_image(buf.getvalue(), "x.png", max_dim=512)
+    assert r is not None
+    assert r["orig_w"] == 2000 and r["orig_h"] == 1000
+    assert max(r["width"], r["height"]) == 512            # downscaled
+    assert r["png"][:8] == b"\x89PNG\r\n\x1a\n"             # valid PNG out
+
+
+def test_decode_image_rejects_non_images():
+    # Not an image and not an image extension → no decode attempt / None.
+    assert gi.decode_image(b"not an image at all", "x.bin") is None
+    assert gi.decode_image(bytes(64), "gamedata/iteminfo.pabgb") is None

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -304,3 +304,12 @@ def test_lz4_stream_decode_partial():
     full = b"HELLO_WORLD_" * 500
     comp = paz_crypto.lz4_compress(full)
     assert gi._lz4_stream_decode(comp, 0, 100) == full[:100]   # stop early
+
+
+def test_extract_strings_pulls_field_names():
+    blob = (b"\x00\x01Sequence\x00\x00_isAccessLock\x00\x04bool"
+            b"\x00\xffSequence\x00")
+    s = gi.extract_strings(blob, min_len=4)
+    assert "Sequence" in s and "_isAccessLock" in s and "bool" in s
+    assert s.count("Sequence") == 1                      # de-duplicated
+    assert gi.extract_strings(b"\x00\x01ab\x00", min_len=4) == []  # too short

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -313,3 +313,36 @@ def test_extract_strings_pulls_field_names():
     assert "Sequence" in s and "_isAccessLock" in s and "bool" in s
     assert s.count("Sequence") == 1                      # de-duplicated
     assert gi.extract_strings(b"\x00\x01ab\x00", min_len=4) == []  # too short
+
+
+def test_decode_struct_typed_words_and_keys():
+    import struct as _s
+    # version=1, a record key (1,000,040), a negative int, and a float 2.0
+    data = (_s.pack("<I", 1) + _s.pack("<I", 1_000_040)
+            + _s.pack("<i", -5) + _s.pack("<f", 2.0))
+    r = gi.decode_struct(data)
+    assert r is not None
+    assert r["total_words"] == 4 and r["shown"] == 4 and r["trailing"] == 0
+    rows = r["rows"]                     # (off, hex, u32, i32, float, ascii, key)
+    assert rows[0][0] == "0000" and rows[0][2] == "1" and rows[0][6] is False
+    assert rows[1][2] == "1000040" and rows[1][6] is True      # key flagged
+    assert rows[2][2] == "4294967291" and rows[2][3] == "-5"   # signed view
+    assert rows[3][4] == "2"                                   # float 2.0
+
+
+def test_decode_struct_blanks_noise_floats():
+    import struct as _s
+    # 0x123A6E00 as float32 is ~4e-28 — outside the sane range → blank cell
+    data = _s.pack("<I", 1) + _s.pack("<I", 0x123A6E00)
+    assert gi.decode_struct(data)["rows"][1][4] == ""
+    # an all-zero word is a legitimate 0.0 and shows "0"
+    assert gi.decode_struct(bytes(8))["rows"][1][4] == "0"
+
+
+def test_decode_struct_needs_two_words_and_caps():
+    assert gi.decode_struct(b"\x00\x00\x00") is None       # <1 word
+    assert gi.decode_struct(bytes(4)) is None              # only 1 word
+    r = gi.decode_struct(bytes(4000), max_words=512)       # 1000 words
+    assert r["total_words"] == 1000 and r["shown"] == 512
+    r2 = gi.decode_struct(bytes(9))                        # 2 words + 1 tail byte
+    assert r2["total_words"] == 2 and r2["trailing"] == 1

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -341,13 +341,25 @@ def test_decode_struct_always_populates_float():
     assert gi.decode_struct(bytes(8))["rows"][1][4] == "0"
 
 
-def test_decode_struct_needs_two_words_and_caps():
-    assert gi.decode_struct(b"\x00\x00\x00") is None       # <1 word
-    assert gi.decode_struct(bytes(4)) is None              # only 1 word
+def test_decode_struct_word_count_and_caps():
+    assert gi.decode_struct(b"\x00\x00\x00") is None       # <1 word → None
+    # a single word is enough now (closes the tiny-.pabgh raw-hex gap)
+    assert gi.decode_struct(bytes(4))["total_words"] == 1
     r = gi.decode_struct(bytes(4000), max_words=512)       # 1000 words
     assert r["total_words"] == 1000 and r["shown"] == 512
     r2 = gi.decode_struct(bytes(9))                        # 2 words + 1 tail byte
     assert r2["total_words"] == 2 and r2["trailing"] == 1
+
+
+def test_identify_binary_format_and_struct_label():
+    ident = gi._identify_binary_format
+    assert "PAR" in ident(b"PAR \x20\x03\x00\x01rest of the animation")
+    assert "AnimationMetaData" in ident(
+        b"\xff\xff\x04\x00" + bytes(10) + b"AnimationMetaData\x00")
+    assert ident(b"\x01\x02\x03\x04 not a known magic") is None
+    # decode_struct surfaces the label so the struct view can show it
+    d = b"PAR \x20\x03\x00\x01" + bytes(8)
+    assert gi.decode_struct(d)["format"] == "Pearl Abyss animation (PAR container)"
 
 
 # ── Wwise audio (.wem / .bnk) ───────────────────────────────────────

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -362,6 +362,14 @@ def test_identify_binary_format_and_struct_label():
     assert gi.decode_struct(d)["format"] == "Pearl Abyss animation (PAR container)"
 
 
+def test_decode_table_positions_never_guesses():
+    # only tables with a validated offset are decoded; others return {} — the
+    # position offset is table-specific (never a blanket guess)
+    assert gi.decode_table_positions("iteminfo", b"body", b"header") == {}
+    assert gi.decode_table_positions("questinfo", b"", b"") == {}
+    assert "factionnodespawninfo" in gi._TABLE_POSITION_OFFSET
+
+
 # ── Wwise audio (.wem / .bnk) ───────────────────────────────────────
 
 def _wem(tag=0xFFFF, ch=1, sr=44100, bits=0, data=b"\x00" * 100):

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -147,3 +147,99 @@ def test_build_index_no_archives_raises(tmp_path):
     with pytest.raises(ValueError):
         gi.build_index(str(tmp_path), str(tmp_path / "x.sqlite"),
                        parse_pamt=lambda *a, **k: [])
+
+
+# ── on-demand extraction + preview helpers ───────────────────────────
+
+def _con_with_asset(path, paz_file, offset, comp, orig, enc=0):
+    """In-memory index carrying exactly one hand-built asset row."""
+    con = sqlite3.connect(":memory:")
+    gi.create_schema(con)
+    con.execute(
+        "INSERT INTO assets VALUES(?,?,?,?,?,?,?,?,?,?)",
+        (path, "0008", gi.category_of(path), gi.ext_of(path),
+         paz_file, offset, comp, orig, int(comp != orig), enc))
+    gi.finalize(con)
+    return con
+
+
+def _write_paz(tmp_path, payload, prefix=b"PAZ0hdr!"):
+    """A fake .paz: prefix bytes then the stored payload; returns (path, off)."""
+    p = tmp_path / "0008" / "8.paz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(prefix + payload)
+    return str(p), len(prefix)
+
+
+def test_get_asset_returns_extract_fields():
+    con = _con_with_asset("ui/x.xml", "/g/0008/8.paz", 0, 5, 9, enc=1)
+    row = gi.get_asset(con, "ui/x.xml")
+    assert row["comp_size"] == 5 and row["orig_size"] == 9
+    assert row["compressed"] == 1 and row["encrypted"] == 1
+    assert gi.get_asset(con, "nope") is None
+
+
+def test_extract_uncompressed(tmp_path):
+    data = b"hello world, plain stored bytes"
+    paz, off = _write_paz(tmp_path, data)
+    con = _con_with_asset("gamedata/x.txt", paz, off, len(data), len(data))
+    assert gi.extract_asset(con, "gamedata/x.txt", str(tmp_path)) == data
+
+
+def test_extract_compressed_roundtrip(tmp_path):
+    import pytest
+    pytest.importorskip("lz4")
+    from cdumm.archive import paz_crypto
+    plain = b"<root>" + b"AB" * 500 + b"</root>"     # compressible
+    payload = paz_crypto.lz4_compress(plain)
+    assert len(payload) != len(plain)                # actually compressed
+    paz, off = _write_paz(tmp_path, payload)
+    con = _con_with_asset("gamedata/x.bin", paz, off, len(payload), len(plain))
+    assert gi.extract_asset(con, "gamedata/x.bin", str(tmp_path)) == plain
+
+
+def test_extract_encrypted_roundtrip(tmp_path):
+    import pytest
+    from cdumm.archive import paz_crypto
+    try:
+        stored = paz_crypto.encrypt(b"<xml>secret</xml>", "x.xml")
+    except Exception:                                # no crypto backend
+        pytest.skip("no ChaCha20 backend available")
+    paz, off = _write_paz(tmp_path, stored)
+    con = _con_with_asset("ui/x.xml", paz, off, len(stored), len(stored), enc=1)
+    assert gi.extract_asset(
+        con, "ui/x.xml", str(tmp_path)) == b"<xml>secret</xml>"
+
+
+def test_extract_reresolves_paz_under_game_dir(tmp_path):
+    data = b"relocated install bytes"
+    paz, off = _write_paz(tmp_path, data)            # real file at tmp/0008/8.paz
+    # Stored path is stale (old machine); extract must re-resolve via game_dir.
+    con = _con_with_asset("gamedata/x.txt",
+                          r"E:\old\0008\8.paz", off, len(data), len(data))
+    assert gi.extract_asset(con, "gamedata/x.txt", str(tmp_path)) == data
+
+
+def test_extract_missing_asset_and_missing_paz(tmp_path):
+    import pytest
+    con = _con_with_asset("gamedata/x.txt", str(tmp_path / "gone.paz"),
+                          0, 4, 4)
+    with pytest.raises(KeyError):
+        gi.extract_asset(con, "not/indexed", str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        gi.extract_asset(con, "gamedata/x.txt", str(tmp_path))
+
+
+def test_decode_text_accepts_text_rejects_binary():
+    assert gi.decode_text(b"<root>hi</root>\n") == "<root>hi</root>\n"
+    assert gi.decode_text("héllo".encode("utf-16-le")) == "héllo"
+    assert gi.decode_text(b"") == ""
+    assert gi.decode_text(bytes(range(256)) * 8) is None   # mostly non-print
+
+
+def test_hexdump_shape_and_truncation():
+    d = gi.hexdump(b"ABC\x00\xff", limit=64)
+    assert d.startswith("00000000  41 42 43 00 FF")
+    assert "ABC.." in d
+    big = gi.hexdump(b"\x00" * 100, limit=16)
+    assert "showing first 16" in big and "100 bytes total" in big

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -348,3 +348,46 @@ def test_decode_struct_needs_two_words_and_caps():
     assert r["total_words"] == 1000 and r["shown"] == 512
     r2 = gi.decode_struct(bytes(9))                        # 2 words + 1 tail byte
     assert r2["total_words"] == 2 and r2["trailing"] == 1
+
+
+# ── Wwise audio (.wem / .bnk) ───────────────────────────────────────
+
+def _wem(tag=0xFFFF, ch=1, sr=44100, bits=0, data=b"\x00" * 100):
+    import struct as _s
+    fmt = _s.pack("<HHIIHH", tag, ch, sr, 0, 0, bits)
+    body = (b"fmt " + _s.pack("<I", len(fmt)) + fmt
+            + b"data" + _s.pack("<I", len(data)) + data)
+    return b"RIFF" + _s.pack("<I", 4 + len(body)) + b"WAVE" + body
+
+
+def test_decode_audio_wem_wwise_vorbis():
+    m = gi.decode_audio(_wem(), "sound/195812854.wem")
+    assert m["kind"] == "wem" and m["codec"] == "Wwise Vorbis"
+    assert m["channels"] == 1 and m["sample_rate"] == 44100
+    assert m["data_bytes"] == 100
+    assert "fmt" in m["chunks"] and "data" in m["chunks"]
+
+
+def test_decode_audio_wem_pcm_duration():
+    # PCM stereo / 16-bit / 48kHz, 192,000 data bytes → exactly 1.0 s
+    m = gi.decode_audio(_wem(tag=1, ch=2, sr=48000, bits=16,
+                             data=b"\x00" * 192_000), "x.wem")
+    assert m["codec"] == "PCM" and abs(m["duration"] - 1.0) < 1e-6
+
+
+def test_decode_audio_bnk_soundbank():
+    import struct as _s
+    bkhd = b"BKHD" + _s.pack("<I", 4) + _s.pack("<I", 150)     # version 150
+    didx = b"DIDX" + _s.pack("<I", 24) + b"\x00" * 24          # 2 streams
+    m = gi.decode_audio(bkhd + didx, "sound/y.bnk")
+    assert m["kind"] == "bnk" and m["bank_version"] == 150
+    assert m["sections"] == ["BKHD", "DIDX"] and m["embedded_streams"] == 2
+
+
+def test_decode_audio_rejects_non_audio():
+    assert gi.decode_audio(b"\x01\x00\x00\x00not audio", "x.paatt") is None
+
+
+def test_find_vgmstream_never_raises():
+    r = gi.find_vgmstream()          # str path if bundled/on PATH, else None
+    assert r is None or isinstance(r, str)

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -410,3 +410,30 @@ def test_pick_vgmstream_asset_by_os():
     assert pick(assets, "Darwin", "arm64")["name"] == "vgmstream-mac.zip"
     assert pick([], "Windows", "AMD64") is None      # nothing published
     assert pick(assets, "Plan9", "") is None          # unknown OS
+
+
+# ── reflection schema (.pae / .paseq / .prefab / .meshinfo …) ────────
+
+def test_decode_reflection_pairs_fields_types_and_objects():
+    # magic → class → field/type pairs → nested object → a reference
+    parts = [b"PARC", b"EffectData",
+             b"_effectName", b"staticstringA",
+             b"_lights", b"bool",
+             b"_life", b"float",
+             b"TimelineRootNode",                 # nested object section
+             b"_nodeId", b"uint32",
+             b"fx/thing.action.effect"]           # asset reference
+    r = gi.decode_reflection(b"\x00".join(parts) + b"\x00")
+    assert r is not None
+    assert r["objects"] == ["EffectData", "TimelineRootNode"]
+    fmap = {(o, f): t for o, f, t in r["fields"]}
+    assert fmap[("EffectData", "_effectName")] == "staticstringA"
+    assert fmap[("EffectData", "_lights")] == "bool"
+    assert fmap[("TimelineRootNode", "_nodeId")] == "uint32"
+    assert "fx/thing.action.effect" in r["refs"]
+    assert r["nfields"] == 4
+
+
+def test_decode_reflection_rejects_non_schema():
+    # plain strings, no _field/type pairs → not a reflection binary
+    assert gi.decode_reflection(b"hello\x00world\x00foo\x00bar\x00") is None

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -262,3 +262,19 @@ def test_decode_image_rejects_non_images():
     # Not an image and not an image extension → no decode attempt / None.
     assert gi.decode_image(b"not an image at all", "x.bin") is None
     assert gi.decode_image(bytes(64), "gamedata/iteminfo.pabgb") is None
+
+
+def test_dds_split_decompress_roundtrips():
+    import pytest
+    pytest.importorskip("lz4")
+    from cdumm.archive import paz_crypto
+    header = b"DDS " + bytes(124)            # 128-byte plaintext DDS header
+    body = b"PIXELDATA" * 400                # compressible pixel body
+    stored = header + paz_crypto.lz4_compress(body)   # header + LZ4 body
+    out = gi._dds_split_decompress(stored, len(header) + len(body))
+    assert out == header + body
+
+
+def test_dds_split_decompress_rejects_non_dds():
+    assert gi._dds_split_decompress(b"\x00" * 200, 500) is None       # no magic
+    assert gi._dds_split_decompress(b"DDS " + bytes(60), 500) is None  # too short

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -278,3 +278,29 @@ def test_dds_split_decompress_roundtrips():
 def test_dds_split_decompress_rejects_non_dds():
     assert gi._dds_split_decompress(b"\x00" * 200, 500) is None       # no magic
     assert gi._dds_split_decompress(b"DDS " + bytes(60), 500) is None  # too short
+
+
+def test_dds_top_mip_recovers_from_lz4_stream():
+    import pytest
+    pytest.importorskip("lz4")
+    from cdumm.archive import paz_crypto
+    mip0 = bytes(range(256)) * 4          # 1024 bytes of top-mip "pixels"
+    tail = b"\xAB" * 4000                 # stands in for the lower mip chain
+    body = paz_crypto.lz4_compress(mip0 + tail)   # continuous LZ4 body
+    hdr = bytearray(b"DDS " + bytes(124))
+    hdr[20:24] = len(mip0).to_bytes(4, "little")  # dwPitchOrLinearSize = mip0
+    hdr[84:88] = b"DXT1"
+    out = gi._dds_top_mip_dds(bytes(hdr) + body)
+    assert out is not None
+    assert out[:4] == b"DDS "
+    assert out[28:32] == (1).to_bytes(4, "little")     # mipcount forced to 1
+    assert out[128:128 + len(mip0)] == mip0            # top mip recovered
+
+
+def test_lz4_stream_decode_partial():
+    import pytest
+    pytest.importorskip("lz4")
+    from cdumm.archive import paz_crypto
+    full = b"HELLO_WORLD_" * 500
+    comp = paz_crypto.lz4_compress(full)
+    assert gi._lz4_stream_decode(comp, 0, 100) == full[:100]   # stop early

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -134,7 +134,7 @@ def test_build_index_end_to_end(tmp_path):
 
     assert stats["assets_total"] == 4
     assert stats["archives"] == 2
-    assert stats["data_table_distinct"] == 2      # iteminfo.pabgb + .pabgh
+    assert stats["data_table_distinct"] == 1      # one table (iteminfo); .pabgh not double-counted
     assert sorted(seen) == [("0008", 3), ("0014", 1)]
 
     con = sqlite3.connect(str(out))

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -391,3 +391,22 @@ def test_decode_audio_rejects_non_audio():
 def test_find_vgmstream_never_raises():
     r = gi.find_vgmstream()          # str path if bundled/on PATH, else None
     assert r is None or isinstance(r, str)
+
+
+def test_pick_vgmstream_asset_by_os():
+    # Real asset names from the vgmstream GitHub release (r2117): all .zip,
+    # no "cli" suffix, plus non-OS artifacts that must be ignored.
+    assets = [
+        {"name": "foo_input_vgmstream.fb2k-component", "browser_download_url": "u0"},
+        {"name": "vgmstream-linux.zip", "browser_download_url": "u1"},
+        {"name": "vgmstream-mac.zip", "browser_download_url": "u2"},
+        {"name": "vgmstream-wasm.zip", "browser_download_url": "u3"},
+        {"name": "vgmstream-win.zip", "browser_download_url": "u4"},
+        {"name": "vgmstream-win64.zip", "browser_download_url": "u5"},
+    ]
+    pick = gi._pick_vgmstream_asset
+    assert pick(assets, "Windows", "AMD64")["name"] == "vgmstream-win64.zip"
+    assert pick(assets, "Linux", "x86_64")["name"] == "vgmstream-linux.zip"
+    assert pick(assets, "Darwin", "arm64")["name"] == "vgmstream-mac.zip"
+    assert pick([], "Windows", "AMD64") is None      # nothing published
+    assert pick(assets, "Plan9", "") is None          # unknown OS

--- a/tests/test_parse_records_display.py
+++ b/tests/test_parse_records_display.py
@@ -1,0 +1,74 @@
+"""Display-only decoder for the Game Data grid.
+
+parse_records_display / decode_record_display honor the override flags
+(no_entry_header / no_null_skip) and drive byte consumption through the
+format3 walker, so richly-overridden tables (iteminfo, regioninfo, ...) show
+their real fields. These are display-only and must never affect the shared
+apply/diff parse_records path.
+"""
+from __future__ import annotations
+
+import struct
+
+from cdumm.semantic.parser import (
+    FieldSpec, TableSchema,
+    _display_value, _display_payload_start, decode_record_display,
+)
+
+
+def _f(name, td=None, fmt=None, size=0, ftype=""):
+    return FieldSpec(name=name, stream_size=size, field_type=ftype,
+                     struct_fmt=fmt, type_descriptor=td)
+
+
+def test_display_value_scalars_strings_arrays():
+    # primitive
+    assert _display_value("u16", struct.pack("<H", 1500), 0, 2) == 1500
+    # CString: u32 len + bytes
+    cs = struct.pack("<I", 5) + b"hello"
+    assert _display_value("CString", cs, 0, len(cs)) == "hello"
+    # CArray<T>: leading u32 count → shown as "[N items]"
+    assert _display_value("CArray<u32>", struct.pack("<I", 3), 0, 4) == "[3 items]"
+    # COptional present/absent
+    assert _display_value("COptional<u32>", b"\x00", 0, 1) == "—"
+    assert _display_value("COptional<u32>", b"\x01", 0, 1) == "present"
+    # LocalizableString with no inline text → loc#index
+    ls = struct.pack("<B", 0) + struct.pack("<Q", 42) + struct.pack("<I", 0)
+    assert _display_value("LocalizableString", ls, 0, len(ls)) == "loc#42"
+
+
+def test_display_payload_start_honors_flags():
+    body = b"\x06\x01" + b"\x00\x00\x00\x00" + b"\x00" + b"rest"
+    # normal: entry header (key2 + nlen4 + null1) = 7
+    normal = TableSchema("T", [], no_entry_header=False, no_null_skip=False)
+    assert _display_payload_start(body, normal, key_size=2) == 7
+    # no_null_skip: stop before the null terminator → 6
+    nns = TableSchema("T", [], no_entry_header=False, no_null_skip=True)
+    assert _display_payload_start(body, nns, key_size=2) == 6
+    # no_entry_header: first field at byte 0
+    neh = TableSchema("T", [], no_entry_header=True)
+    assert _display_payload_start(body, neh, key_size=2) == 0
+
+
+def test_decode_record_display_no_entry_header_walks_fields():
+    # mirrors regioninfo: no header, _key(u16) then _stringKey(CString)
+    entry = struct.pack("<H", 7) + struct.pack("<I", 11) + b"Region_Test" + b"\x03"
+    schema = TableSchema(
+        "regionlike",
+        [_f("_key", td="u16"), _f("_stringKey", td="CString"),
+         _f("_regionType", td="u8")],
+        no_entry_header=True)
+    got = decode_record_display(entry, schema, key_size=2)
+    assert got["_key"] == 7
+    assert got["_stringKey"] == "Region_Test"
+    assert got["_regionType"] == 3
+
+
+def test_decode_record_display_stops_cleanly_when_walker_blocks():
+    # a field whose bytes run past the entry → decode keeps earlier fields,
+    # never guesses the rest
+    entry = struct.pack("<H", 9)                      # only 2 bytes
+    schema = TableSchema(
+        "t", [_f("_a", td="u16"), _f("_b", td="u32")], no_entry_header=True)
+    got = decode_record_display(entry, schema, key_size=2)
+    assert got == {"_a": 9}                            # _b absent, not guessed


### PR DESCRIPTION
## What

Adds a full **Game Data** tab to CDUMM — an in-app browser + previewer for everything a Crimson Desert install ships. It indexes every archived asset (**1,660,550** files across 33 PAZ archives) plus the **133** keyed game-data tables, then lets you search and preview any of them without leaving the mod manager. Built for mod-makers who need to find, understand, and grab the files they want to change.

Everything runs on `cdumm.engine.game_index`, a pure, headless, unit-tested index engine that the GUI drives — so the same capability is reusable and testable outside Qt.

## The tab at a glance

- **One-click index** — builds/refreshes a searchable SQLite catalog of the whole install on a background thread (~18s), with progress and summary stat cards (assets / archives / data tables) plus the largest keyed tables. The index stores only metadata; asset bytes are read on demand.
- **Search** with a **file-type filter** dropdown (narrow to `.dds`, `.pabgb`, `.wem`, …; populated from the extensions actually present, with a count on each) and a result-count selector (100 → 20,000). Pick a type and you can browse every file of it with no search text.
- **Live preview pane** — click any asset and it's decrypted → LZ4-decompressed → decoded on a background worker (the UI never freezes, even on large assets), then routed to the best viewer for its type.
- **Beginner file-type guide** — a collapsible "New to modding?" box explaining every format and how the previewer decides what to show.

## Preview decoders — every file type is covered

| Viewer | Formats | What you get |
|---|---|---|
| Text | `.xml` `.html` `.css` … | rendered text |
| **Image (+ 3D + save)** | `.dds` `.png` | decoded texture, incl. compressed **multi-mip DDS** (~98% of textures); an **Unreal-style orbit 3D view** (fixed-pivot — drag to orbit, wheel to zoom); and **Save as PNG / JPEG** (PNG keeps transparency; JPEG flattens onto white) |
| **Data-table grid** | `.pabgb` | records as a grid — `_key` / `_name` authoritative; other columns now **walker-decoded** where the schema is known (see below); optional **world `(X, Y, Z)` coordinates** for validated tables |
| **Field → Type schema** | `.pae` `.paseq` `.prefab` `.meshinfo` … | the engine's own reflection schema as an **Object / Field / Type** table + an asset-reference list (real names, read straight from the file) |
| **Audio (play / export)** | `.wem` `.bnk` (Wwise) | header metadata + **▶ Play** / **Export-to-WAV** via vgmstream, with a one-click OS-aware auto-installer |
| **Struct word-table** | `.paatt` `.pabgh` `.paa` `.paa_metabin` … | packed formats shown as exact **uint / int / float** per 4-byte word (+ a format-ID line for `.paa` / `.paa_metabin`) |

No file type falls back to a raw hex wall.

## Accurate per-field table decoding

The grid used to show only `_key` / `_name` reliably. Two additions make the *other* columns trustworthy:

- **Walker-driven display decoder** — the grid now honours the schema override flags (`no_entry_header` / `no_null_skip`) and steps through variable-length fields via the format3 walker, so richly-schema'd tables render their real columns instead of stopping at the first array. Validated across all 84 keyed tables in a real install: **0 regressions, 80 byte-identical**, and where the schemas live — `regioninfo` **0 → 21** fields (real region names), `vehicleinfo` **4 → 20**, `fieldinfo` **9 → 19**. Isolated from the shared apply/diff parser. Net result: **73 of 84** keyed tables now fully decode.
- **Verified-only field gate** — a table can mark exactly which fields have been hand-validated against real data; every other field renders `(unverified)` instead of a possibly-wrong guess. First user: `wantedinfo` (`_increasePrice` now decodes to real gold — 30 / 50 / 100 / 500 / 1500 by wanted tier; previously `None`).
- **Undecodable fields are masked, not faked** — some tables' upstream schema uses unknown-width placeholder types (`direct_15B` / `reader_*` / complex, with no override). The first such field's wrong width misaligns everything after it, so those columns can't be trusted. The grid shows fields up to the first placeholder, then renders it and everything after `(unverified)` — `_key` / `_name` (from the index/header) always show. On a real install this lands at **28 tables fully shown, 22 partially masked, 34 mostly masked** — so **nothing in any grid is a guess**, and the honestly-unknown fields are clearly flagged for a future contributor to pick up.

A live per-table decode-status checklist is posted in the PR comments.

## Fixes that ride along with the tab

- `fix(game-data)` — the **Data tables** stat double-counted (`.pabgb` blob + `.pabgh` index = 266 for 133 tables); now counts real tables → **133**. Nothing was missing from the scan.
- `fix(3d-viewer)` — the texture 3D view used `QOrbitCameraController`, which also pans the pivot, so dragging flung the asset off-screen and it vanished at the window edges. Replaced with a fixed-pivot orbit (camera revolves around the origin), so the asset stays framed however you spin it.
- `fix(window)` — disabled the Windows 11 Mica backdrop, which tinted the window from the wallpaper and dimmed on focus loss, so the whole background visibly changed every time the app gained/lost focus. Now one steady background.
- `fix(startup)` — `raise()` + `activateWindow()` on launch so a terminal-spawned window comes to the foreground instead of opening hidden.
- `fix(activity)` — corrected category-chip and per-entry badge colours (Qt `#AARRGGBB` alpha-order bug + full 12-category palette).
- `fix(game-data)` — no UI hang when previewing large assets (all read/decode/parse on a worker); Path column stretches so the scrollbar hugs the table.

## Honest scope (accuracy is the point of this tab)

- **Raw data is 100% accurate** — the file inventory, extracted bytes, offsets, and every typed value shown are exact.
- **Packed formats** (`.paatt` / `.paa` / `.pabgh`) carry no field *names* in the shipped files (they live only in the engine binary), so they're shown as accurate typed values, not invented field names.
- **Data-table fields** — every value shown in a grid is either authoritative (`_key` / `_name`), decoded via a hand-built RE'd override (regioninfo, vehicleinfo, fieldinfo, …), or read as a clean primitive up to the first unknown-width field. Anything the upstream schema can't size reliably is marked `(unverified)` rather than shown as a misleading blob. The genuinely-broken tables (`statusinfo`, `categoryinfo`, `materialrelationinfo`, …) sit behind that gate: their real field order lives only in the game binary and isn't recoverable without a reference, so they're flagged for a future contributor instead of guessed at.
- **`iteminfo`** (the 113-field flagship) decodes its first 11 fields correctly and stops rather than guessing: it stalls on a nested custom struct, and the bundled authoritative parser (`crimson_rs`) crashes under the dev Python, so pushing further would either show garbage or risk the app. Tracked honestly in the checklist.
- **Audio playback** needs vgmstream (bundled location + one-click installer); raw `.wem` / `.bnk` extract always works.
- A fully-plotted interactive map was investigated and **not** shipped: coordinates decode accurately, but the world→map-image projection isn't present in the game files. The decoded coordinates are surfaced in the grid instead.

## Testing

**46 unit tests** across `tests/test_game_index.py`, `tests/test_game_data_shape.py`, and `tests/test_parse_records_display.py` — index build/search/extract, on-demand byte extraction (uncompressed / LZ4 / ChaCha20), DDS decode, struct + format-ID decode, reflection-schema parsing, Wwise header parsing, the vgmstream OS-picker, the world-position registry, the data-table count, the verified-only + placeholder-field masks, and the walker display decoder (flag-aware payload start, string/array/optional values, clean stop-on-block). Changed GUI files compile; the tab constructs cleanly headless.

## Scope

**12 files** — the engine (`game_index.py`), the tab (`game_data_page.py`), the semantic parser + type overrides (`parser.py`, `pabgb_type_overrides.json`), their tests, the vgmstream README, and small riding fixes in `main.py` (startup raise), `activity_page.py` + `fluent_window.py` (activity-log colours), and one apply-test assertion update. Targets `master` and merges cleanly.

## Verification checklist

- [x] Index builds on a real install (1,660,550 assets / 133 tables)
- [x] GUI smoke-test — tab appears, build runs, previews work, type filter + image-save + 3D orbit work
- [x] 46 unit tests pass; both changed GUI files compile
- [x] Walker decoder validated on all 84 keyed tables — 0 regressions
- [x] Targets `master` and merges cleanly
