### PR TITLE
feat: Format 3 verified-only field modding + wantedinfo bounty-price support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ JSON patches also support `editable_value` metadata for inline value editing in 
 
 ### Field-name JSON mods (Format 3)
 
-CDUMM supports the field-name JSON format (`.field.json`) for these tables: items (`iteminfo.pabgb`), mounts (`vehicleinfo.pabgb`), terrain (`fieldinfo.pabgb`), stages (`stageinfo.pabgb`), regions (`regioninfo.pabgb`), mount character data (`characterinfo.pabgb`), buffs (`buffinfo.pabgb`), drop sets (`dropsetinfo.pabgb`), and skills (`skill.pabgb`). Other tables show a clean "no schema for this table yet" message naming the missing schema. See `field_schema/README.md` to author a schema for an unsupported table.
+CDUMM supports the field-name JSON format (`.field.json`) for these tables: items (`iteminfo.pabgb`), mounts (`vehicleinfo.pabgb`), terrain (`fieldinfo.pabgb`), stages (`stageinfo.pabgb`), regions (`regioninfo.pabgb`), mount character data (`characterinfo.pabgb`), buffs (`buffinfo.pabgb`), drop sets (`dropsetinfo.pabgb`), skills (`skill.pabgb`), and wanted-bounty prices (`wantedinfo.pabgb` — the `increase_price` field). Other tables show a clean "no schema for this table yet" message naming the missing schema. See `field_schema/README.md` to author a schema for an unsupported table.
+
+Coverage grows as more tables get a validated schema: a table becomes moddable field-by-field as each field is confirmed against real record data (via `_verified_fields` in `schemas/pabgb_type_overrides.json`). Only fields proven to sit at a known offset are writable — an unproven field is refused rather than risk writing to the wrong byte.
 
 Both file shapes work: the original singular `{"format": 3, "target": "iteminfo.pabgb", "intents": [...]}` and the newer multi-target `{"format": 3, "targets": [{"file": "...", "intents": [...]}, ...]}` form. The `op` key is optional and defaults to `"set"`.
 

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -409,5 +409,13 @@
     "_callMercenaryCoolTime": {"type": "u64"},
     "_callMercenarySpawnDuration": {"type": "u64"},
     "_mercenaryCoolTimeType": {"type": "u8"}
+  },
+  "WantedInfo": {
+    "_meta_note": "Verified-only pass 2026-07-03. Only _increasePrice is validated: read as u64 at payload offset 0 (the default entry header consumes exactly key(2)+name_len(4, always 0)+null(1) = 7 bytes on every record, landing on the price). Values track the wanted tier — 30/50/100/500/1500 gold, consistent across all 5 key groups. _isBlocked/_useTargetPrice are all-zero in shipped data except one toggling flag byte whose name mapping can't be proven from the files alone (the field defs live only in the exe), so they are listed but gated as unverified rather than guessed. _stringKey (untyped in the base schema) stays dropped.",
+    "_ordered_fields": ["_increasePrice", "_isBlocked", "_useTargetPrice"],
+    "_verified_fields": ["_increasePrice"],
+    "_increasePrice": {"type": "u64"},
+    "_isBlocked": {"type": "u8"},
+    "_useTargetPrice": {"type": "u8"}
   }
 }

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -1617,6 +1617,15 @@ def _resolve_write_pos(
             break
     if spec is None or not spec.struct_fmt or not spec.stream_size:
         return None
+    # Honor the verified-only gate. A table may mark which fields have been
+    # validated against real record data (schemas/pabgb_type_overrides.json
+    # `_verified_fields`). Fields it doesn't vouch for render `(unverified)`
+    # in the grid because their real offset isn't proven — so a Format 3 mod
+    # must not write to them either, or the write could land on the wrong
+    # byte. Only affects tables that opt in; every other table is unchanged.
+    vf = getattr(schema, "verified_fields", None)
+    if vf is not None and target_name not in vf:
+        return None
     # Walk schema fields up to target. For each field, use its actual
     # binary footprint so variable-length fields (CString, etc.) are
     # consumed correctly. Pure stream_size summation breaks when any

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -91,6 +91,13 @@ class TableSchema:
     notes: 'There is NO per-entry name header in RegionInfo PABGB.
     The _key and _stringKey are regular fields read by the table
     reader')."""
+    verified_fields: frozenset[str] | None = None
+    """Verified-only display gate. ``None`` = table not yet hand-curated;
+    show every schema field as decoded (legacy behavior). A set = only
+    these fields have been validated against real record data; the GUI
+    renders any other field as ``(unverified)`` instead of a possibly-
+    wrong value. Set via ``_verified_fields: [...]`` in the override file.
+    ``_key`` / ``_name`` are always trustworthy and never gated."""
 
     @property
     def fixed_record_size(self) -> int | None:
@@ -156,6 +163,12 @@ def _load_schemas() -> dict[str, TableSchema]:
         table_overrides = overrides.get(table_name, {})
         no_null_skip = bool(table_overrides.get("_no_null_skip", False))
         no_entry_header = bool(table_overrides.get("_no_entry_header", False))
+        # `_verified_fields`: opt-in list of hand-validated fields. When
+        # present, the GUI shows only these as decoded values and marks
+        # every other field `(unverified)` — so a table can be worked
+        # incrementally without ever presenting an unproven column.
+        vf_raw = table_overrides.get("_verified_fields")
+        verified_fields = frozenset(vf_raw) if vf_raw is not None else None
         # `_ordered_fields` REPLACES the upstream schema's array order.
         # The upstream schema sorts by memory address; the actual
         # on-disk deserialization order often differs (verified
@@ -262,7 +275,8 @@ def _load_schemas() -> dict[str, TableSchema]:
             schemas[table_name.lower()] = TableSchema(
                 table_name=table_name, fields=fields,
                 no_null_skip=no_null_skip,
-                no_entry_header=no_entry_header)
+                no_entry_header=no_entry_header,
+                verified_fields=verified_fields)
 
     _loaded_schemas = schemas
     logger.info("Loaded %d PABGB table schemas (%d with type overrides)",

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_format3_verified_gate.py
+++ b/tests/test_format3_verified_gate.py
@@ -1,0 +1,60 @@
+"""Format 3 apply honors the verified-only field gate.
+
+A table can mark which fields are validated (`_verified_fields` in the type
+overrides). Those fields decode in the Game Data grid AND are writable by
+Format 3 `.field.json` mods; fields it doesn't vouch for render `(unverified)`
+and must be refused by the apply path too — writing to an unproven offset
+could land on the wrong byte. First real user: wantedinfo (`_increasePrice`
+validated; `_isBlocked` / `_useTargetPrice` not).
+"""
+from __future__ import annotations
+
+import struct
+
+from cdumm.engine.format3_apply import _resolve_write_pos
+from cdumm.engine.format3_handler import Format3Intent
+from cdumm.semantic.parser import FieldSpec, TableSchema
+
+
+def _schema(verified):
+    return TableSchema(
+        "wantedlike",
+        [FieldSpec("_increasePrice", 8, "direct_u64", "Q", "u64"),
+         FieldSpec("_isBlocked", 1, "direct_u8", "B", "u8")],
+        verified_fields=verified)
+
+
+def _intent(field):
+    return Format3Intent(entry="", key=1, field=field, op="set", new=5)
+
+
+def test_verified_field_resolves():
+    schema = _schema(frozenset({"_increasePrice"}))
+    fs = {f.name: f for f in schema.fields}
+    body = struct.pack("<Q", 1500) + b"\x01"
+    # the validated field writes at payload offset 0, u64
+    assert _resolve_write_pos(
+        _intent("increase_price"), {}, fs, schema, body, 0, len(body)
+    ) == (0, 8, "Q")
+
+
+def test_unverified_field_refused():
+    schema = _schema(frozenset({"_increasePrice"}))
+    fs = {f.name: f for f in schema.fields}
+    body = struct.pack("<Q", 1500) + b"\x01"
+    # not vouched for → apply must refuse (no write to an unproven byte)
+    assert _resolve_write_pos(
+        _intent("_isBlocked"), {}, fs, schema, body, 0, len(body)) is None
+
+
+def test_no_gate_when_verified_is_none():
+    # tables that don't opt in are unaffected — both fields resolve
+    schema = _schema(None)
+    fs = {f.name: f for f in schema.fields}
+    body = struct.pack("<Q", 1500) + b"\x01"
+    assert _resolve_write_pos(
+        _intent("increase_price"), {}, fs, schema, body, 0, len(body)
+    ) == (0, 8, "Q")
+    assert _resolve_write_pos(
+        _intent("_isBlocked"), {}, fs, schema, body, 0, len(body)
+    ) == (8, 1, "B")


### PR DESCRIPTION
## Summary

Adds a **verified-only gate** to the Format 3 (`.field.json`) mod-apply pipeline so PABGB data-table fields can be modded **by friendly name** - but only for fields whose byte offset has been reverse-engineered and hand-verified against real record data. Unlocks the first such table beyond the existing set: **wantedinfo** (bounty `increase_price`).

Self-contained on `master` - the 5 files below are the whole change. No dependency on the Game Data tab PR (#242); either can merge first.

## What's in it

- **`src/cdumm/semantic/parser.py`** - `TableSchema` gains a `verified_fields` set, loaded from `_verified_fields` in the override file.
- **`src/cdumm/engine/format3_apply.py`** - `_resolve_write_pos` refuses to write any field a table's `verified_fields` doesn't vouch for (unproven offset could land on the wrong byte).
- **`schemas/pabgb_type_overrides.json`** - `WantedInfo` block: hand-RE'd field order (`_increasePrice` u64, `_isBlocked` u8, `_useTargetPrice` u8), gated by `_verified_fields: ["_increasePrice"]`.
- **`README.md`** - documents wantedinfo as a supported target + the field-by-field verification model.
- **`tests/test_format3_verified_gate.py`** - 3 tests: verified field resolves + writes; unverified field is refused; tables with no gate behave exactly as before.

## Note on overlap with #242

The `verified_fields` loader (parser.py) and the `WantedInfo` override are a small shared primitive that the Game Data tab (#242) also uses - for *display* masking there, for the *apply* gate here. Whichever PR merges first, the other's overlapping hunks are identical and resolve cleanly (they simply drop out of the second PR's diff). There is no ordering requirement.

## Why only one field / one table

`_increasePrice` was verifiable because its value (1500) matches the in-game bounty economy, so its offset could be confirmed by hand. The wider table set can't be bulk-unlocked: the upstream schema orders fields by memory address rather than disk order, so any table lacking a hand-RE'd override reads from the wrong offsets. Verified empirically - e.g. `mercenaryinfo`'s boolean fields decode to the ASCII bytes of the name string "mer**cenary**", and `relationinfo` reads the high halves of floats. The `_verified_fields` gate is the safe primitive: a future contributor can unlock each field as they verify its offset, with no risk of mods that silently patch the wrong bytes.

## Testing
`pytest tests/test_format3_verified_gate.py` - 3 passed.