### PR TITLE
fix: iteminfo Format 3 apply hangs on unmodelled game layout (#247)

### DIFF
--- a/src/cdumm/engine/iteminfo_native_parser.py
+++ b/src/cdumm/engine/iteminfo_native_parser.py
@@ -186,6 +186,22 @@ class _Reader:
 
     def carray(self, elem_reader) -> list:
         n = self.u32()
+        # A real array can't have more elements than there are bytes left
+        # to read them from — every element is at least one byte wide. On a
+        # game-version layout shift the parse desyncs and this count comes
+        # out as garbage (millions/billions); without this guard the list
+        # comprehension spins building a giant list until it finally
+        # overruns, long enough to trip the apply watchdog and kill the
+        # whole run (GitHub #247, CD 1.13). Fail fast so the writer's
+        # parse-guard turns it into a clean "this game version isn't
+        # supported yet" skip instead of a hang. Never fires on valid data
+        # (a legitimate count is always <= remaining bytes).
+        remaining = len(self.data) - self.pos
+        if n > remaining:
+            raise ValueError(
+                f"iteminfo carray count {n} exceeds {remaining} remaining "
+                f"bytes at offset {self.pos}; likely a game-version layout "
+                f"shift the parser does not model yet")
         return [elem_reader(self) for _ in range(n)]
 
 

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_iteminfo_carray_guard.py
+++ b/tests/test_iteminfo_carray_guard.py
@@ -1,0 +1,48 @@
+"""Regression for GitHub #247 (CD 1.13 apply hang).
+
+When the game ships a layout shift the native iteminfo parser doesn't
+model yet, a CArray length prefix decodes as garbage (millions/billions).
+Before this guard, ``_Reader.carray`` ran ``range(n)`` and spun building a
+giant list until it finally overran — long enough that a Format 3 iteminfo
+mod (e.g. Fat Stacks, 2000+ intents) tripped the 180s apply watchdog and
+killed the whole run, taking every other mod down with it.
+
+The parser must instead fail fast so ``build_iteminfo_intent_change``'s
+existing try/except turns it into a clean "game version not supported yet"
+skip, letting the non-iteminfo mods apply.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.iteminfo_native_parser import _Reader
+
+
+def test_carray_rejects_billions_count_fast():
+    # count = ~4 billion with no element bytes following. A real array
+    # can't have more elements than remaining bytes, so this must raise
+    # immediately rather than attempt to build range(4_000_000_000).
+    r = _Reader(struct.pack("<I", 4_000_000_000))
+    with pytest.raises(ValueError):
+        r.carray(_Reader.u8)
+
+
+def test_carray_rejects_count_exceeding_remaining():
+    # count=1000 but only 3 payload bytes -> impossible -> raise.
+    r = _Reader(struct.pack("<I", 1000) + b"\x01\x02\x03")
+    with pytest.raises(ValueError):
+        r.carray(_Reader.u8)
+
+
+def test_carray_accepts_valid_count():
+    # count=3 with exactly 3 payload bytes decodes normally; the guard
+    # never fires on valid data (a real count is always <= remaining).
+    r = _Reader(struct.pack("<I", 3) + bytes([10, 20, 30]))
+    assert r.carray(_Reader.u8) == [10, 20, 30]
+
+
+def test_carray_empty_is_fine():
+    r = _Reader(struct.pack("<I", 0))
+    assert r.carray(_Reader.u8) == []


### PR DESCRIPTION
## Problem

Fixes #247. On **CD 1.13.00** the `iteminfo` record layout shifted again. Applying a Format 3 `iteminfo` mod (the reporter had **Fat Stacks**, 2254 `_maxStackCount` intents) **hangs the apply** - the 180s watchdog fires and kills the run, so **all 24 enabled mods fail**:

```
Format 3 whole-table dispatch entering for iteminfo.pabgb: 2254 intent(s) batched
Watchdog: no progress for 180.0s, killing apply PID 3744
```

## Root cause

All iteminfo intents are force-batched through `iteminfo_writer.build_iteminfo_intent_change`, which does a whole-table `parse → apply → re-serialize` via the native parser. On the unmodelled 1.13 layout the parse desyncs and a `CArray` length prefix decodes as garbage (millions/billions); `_Reader.carray` then ran `range(n)`, spinning until it overran - long enough to trip the watchdog.

The writer is *already* built to fail gracefully (wraps the parse in `try/except` → returns `None`, plus a round-trip pre-flight). But **a hang can't be caught by `try/except`** - the parser has to fail fast.

## Fix

Bound the `CArray` count: an array can't have more elements than remaining bytes, so raise immediately on an impossible count instead of looping. The existing writer guard then turns it into a clean *"game version not supported yet"* skip, and the **non-iteminfo mods apply normally**.

- Never fires on valid data (a real count is always ≤ remaining bytes).
- 4 self-contained unit tests (`tests/test_iteminfo_carray_guard.py`); native-parser suite green (`5 passed, 6 skipped` - skips are live-fixture tests).

## Scope

Fixes the **hang / total-apply failure** so other mods apply and the user gets a clear skip. It does **not** add `iteminfo` modding on 1.13 - that needs the new layout modelled (see `docs/GAME_DATA_UNLOCK_ROADMAP.md`). Format 2 / offset-based iteminfo patches are unaffected.