### PR TITLE
Fix #241: compound armor mods (Format 3 icons + NNNN/0.paz model dir) drop the model half

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -2909,12 +2909,20 @@ def _import_from_extracted(
     from cdumm.engine.json_patch_handler import is_natt_format_3
     f3_jsons = [p for p in tmp_path.rglob("*.json")
                 if is_natt_format_3(p)]
-    if len(f3_jsons) == 1:
+    # #241: a lone Format 3 JSON short-circuits here — but when the archive
+    # ALSO bundles a standalone NNNN/0.paz mod (Female Armor Module 3029:
+    # 0036/ armor-model swap + a Format 3 icons JSON), returning now
+    # silently drops the model PAZ. Defer the JSON and fall through to the
+    # PAZ-dir flow; it is re-imported as a sibling once the model mod lands.
+    _deferred_f3_json = None
+    if len(f3_jsons) == 1 and _bundled_paz_root(tmp_path) is None:
         return import_from_natt_format_3(
             json_path=f3_jsons[0], game_dir=game_dir, db=db,
             snapshot=snapshot, deltas_dir=deltas_dir,
             existing_mod_id=existing_mod_id,
         )
+    if len(f3_jsons) == 1:
+        _deferred_f3_json = f3_jsons[0]
     if len(f3_jsons) > 1:
         # Variant pack messaging mirrored from import_from_zip's flow
         # so RAR/7z drops of multi-Format-3 archives get the same
@@ -3006,6 +3014,13 @@ def _import_from_extracted(
     # mods are purely XML patches and have no other game files.
     result = _register_partial_patches_into_result(
         tmp_path, result, mod_name, modinfo, db, deltas_dir)
+
+    # #241: compound archive — the PAZ-dir model mod has landed; now import
+    # the deferred Format 3 sibling JSON (armor icons) as its own mod.
+    if (_deferred_f3_json is not None and result.changed_files
+            and not result.error and result.mod_id is not None):
+        _import_sibling_format3(
+            _deferred_f3_json, game_dir, db, snapshot, deltas_dir)
 
     return result
 
@@ -3371,11 +3386,21 @@ def import_from_zip(
         f3_jsons = [p for p in tmp_path.rglob("*.json")
                     if "_asi_staging" not in p.parts
                     and is_natt_format_3(p)]
-        if len(f3_jsons) == 1:
+        # #241: a lone Format 3 JSON short-circuits here — but when the
+        # archive ALSO bundles a standalone NNNN/0.paz mod (Female Armor
+        # Module 3029: 0036/ armor-model swap + a Format 3 icons JSON),
+        # returning now silently drops the model PAZ (icons change in-game
+        # but the models don't). Defer the JSON and fall through to the
+        # PAZ-dir flow; it is re-imported as a sibling once the model mod
+        # lands. Format 3 analogue of the #34 compound guard.
+        _deferred_f3_json = None
+        if len(f3_jsons) == 1 and _bundled_paz_root(tmp_path) is None:
             return _with_asi(import_from_natt_format_3(
                 json_path=f3_jsons[0], game_dir=game_dir, db=db,
                 snapshot=snapshot, deltas_dir=deltas_dir,
                 existing_mod_id=existing_mod_id))
+        if len(f3_jsons) == 1:
+            _deferred_f3_json = f3_jsons[0]
         if len(f3_jsons) > 1:
             # Variant pack (CrimsonWings: 10pct/25pct/50pct/75pct/
             # infinite of one mod) is detected via stem prefix +
@@ -3468,6 +3493,15 @@ def import_from_zip(
         # though the identical content imported fine from a .7z.
         result = _register_partial_patches_into_result(
             tmp_path, result, mod_name, modinfo, db, deltas_dir)
+
+        # #241: compound archive — the PAZ-dir model mod has landed; now
+        # import the deferred Format 3 sibling JSON (armor icons) as its
+        # own mod so the user can toggle it independently. Runs inside the
+        # staging context so the JSON path still exists on disk.
+        if (_deferred_f3_json is not None and result.changed_files
+                and not result.error and result.mod_id is not None):
+            _import_sibling_format3(
+                _deferred_f3_json, game_dir, db, snapshot, deltas_dir)
 
         # _process_extracted_files builds a fresh ModImportResult — re-attach
         # any ASI files we staged at the top of import_from_zip so the GUI
@@ -3873,11 +3907,18 @@ def import_from_folder(
     from cdumm.engine.json_patch_handler import is_natt_format_3
     f3_jsons = [p for p in folder_path.rglob("*.json")
                 if is_natt_format_3(p)]
-    if len(f3_jsons) == 1:
+    # #241: defer a lone Format 3 JSON (don't short-circuit) when the
+    # folder ALSO bundles a standalone NNNN/0.paz mod, or the PAZ model
+    # data is silently dropped. Re-imported as a sibling after the PAZ-dir
+    # mod lands. Format 3 analogue of the #34 compound guard.
+    _deferred_f3_json = None
+    if len(f3_jsons) == 1 and _bundled_paz_root(folder_path) is None:
         return import_from_natt_format_3(
             json_path=f3_jsons[0], game_dir=game_dir, db=db,
             snapshot=snapshot, deltas_dir=deltas_dir,
             existing_mod_id=existing_mod_id)
+    if len(f3_jsons) == 1:
+        _deferred_f3_json = f3_jsons[0]
     if len(f3_jsons) > 1:
         result = ModImportResult(mod_name)
         f3_pack = _scan_format3_variant_pack(folder_path)
@@ -3986,6 +4027,15 @@ def import_from_folder(
             logger.warning(
                 "Compound-layout sibling JSON scan failed: %s", e)
 
+    # #241: compound archive with a Format 3 sibling (e.g. Female Armor
+    # Module icons JSON) — import it as its own mod after the PAZ-dir
+    # model mod lands. The Format 2 block above uses the JSON-patch
+    # helper, which doesn't handle the Format 3 (intents) dialect.
+    if (_deferred_f3_json is not None and result.changed_files
+            and not result.error and result.mod_id is not None):
+        _import_sibling_format3(
+            _deferred_f3_json, game_dir, db, snapshot, deltas_dir)
+
     return result
 
 
@@ -4011,6 +4061,63 @@ def _first_numbered_parent(root: Path, max_depth: int = 4) -> Path | None:
             continue
         return None
     return None
+
+
+def _bundled_paz_root(root: Path) -> Path | None:
+    """Return the directory that directly holds a standalone ``NNNN/0.paz``
+    mod (searching ``root`` and single-subdir wrappers), else ``None``.
+
+    Detects *compound* archives that bundle a PAZ-dir model/mesh mod
+    alongside a sibling JSON patch. Example: Female Armor Module (Nexus
+    3029) ships ``0036/0.paz`` (the armor-model swap) + ``meta/0.papgt``
+    next to a Format 3 icons JSON, all under a ``Female Armor Module/``
+    wrapper. The Format 3 branch used to short-circuit on the JSON and
+    silently drop the PAZ half — icons changed in-game but the models did
+    not (GitHub #241). ``_first_numbered_parent`` already handles the
+    wrapper descent, so reuse it and confirm the numbered dir actually
+    carries a ``0.paz``.
+    """
+    base = _first_numbered_parent(root) or root
+    try:
+        for d in base.iterdir():
+            if (d.is_dir() and d.name.isdigit() and len(d.name) == 4
+                    and (d / "0.paz").exists()):
+                return base
+    except OSError:
+        pass
+    return None
+
+
+def _import_sibling_format3(
+    json_path: Path, game_dir: Path, db: Database,
+    snapshot: SnapshotManager, deltas_dir: Path,
+) -> None:
+    """Import a Format 3 JSON that lives alongside a primary PAZ-dir mod
+    (a compound archive) as its own separate mod, so the user can toggle
+    it independently.
+
+    Mirrors ``_import_sibling_json_patches`` but for the Format 3 (intents)
+    dialect, which that Format 2-only helper cannot handle. Failures are
+    logged, never raised — a bad sibling must not sink the primary model
+    import. GitHub #241 (Female Armor Module: ``0036/`` model swap + a
+    Format 3 icons JSON in one archive).
+    """
+    try:
+        res = import_from_natt_format_3(
+            json_path=json_path, game_dir=game_dir, db=db,
+            snapshot=snapshot, deltas_dir=deltas_dir, existing_mod_id=None)
+        if res is not None and getattr(res, "error", None):
+            logger.info(
+                "Compound sibling Format 3 '%s' not imported: %s",
+                json_path.name, res.error)
+        else:
+            logger.info(
+                "Compound mod: sibling Format 3 '%s' imported as its "
+                "own mod", json_path.name)
+    except Exception as e:
+        logger.warning(
+            "Compound sibling Format 3 '%s' import failed: %s",
+            json_path.name, e)
 
 
 def _find_best_variant(folder_path: Path) -> Path | None:

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_compound_format3_plus_paz_dir.py
+++ b/tests/test_compound_format3_plus_paz_dir.py
@@ -1,0 +1,155 @@
+"""GitHub #241: compound archives (a standalone NNNN/0.paz model mod +
+a sibling Format 3 JSON) must import BOTH halves.
+
+Female Armor Module (Nexus 3029) ships, in one zip under a wrapper
+folder: ``0036/0.paz`` (+ ``0.pamt``) — the armor-model swap — plus
+``meta/0.papgt`` and a Format 3 ``...With Icons.json``. CDUMM's Format 3
+branch used to ``rglob`` for the JSON, import only it, and return —
+silently dropping the ``0036/`` model data. In-game the icons changed
+but the armor models did not (woowoots, issue #241).
+
+Fix: a wrapper-aware compound guard (``_bundled_paz_root``). When a
+bundled PAZ-dir mod is present, the Format 3 JSON is deferred; the
+PAZ-dir model mod imports as primary, then the JSON is re-imported as a
+sibling via ``_import_sibling_format3``. Same shape as the #34 guard that
+already protects the Format 2 branch.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from cdumm.engine import import_handler as ih
+from cdumm.engine.import_handler import ModImportResult, _bundled_paz_root
+
+
+def _f3(target: str = "stringinfo.pabgb") -> str:
+    return json.dumps({
+        "modinfo": {"title": "FAM Icons"},
+        "format": 3, "target": target,
+        "intents": [{"entry": "X", "key": 1, "field": "y",
+                     "op": "set", "new": 1}],
+    })
+
+
+def _make_game(tmp_path: Path) -> Path:
+    g = tmp_path / "game"
+    (g / "bin64").mkdir(parents=True)
+    (g / "bin64" / "CrimsonDesert.exe").write_bytes(b"EXE")
+    return g
+
+
+def _write_compound_tree(base: Path) -> Path:
+    """base/Female Armor Module/{0036/0.paz,0036/0.pamt,meta/0.papgt,icons.json}"""
+    inner = base / "Female Armor Module"
+    (inner / "0036").mkdir(parents=True)
+    (inner / "0036" / "0.paz").write_bytes(b"PAZ" * 100)
+    (inner / "0036" / "0.pamt").write_bytes(b"PAMT")
+    (inner / "meta").mkdir()
+    (inner / "meta" / "0.papgt").write_bytes(b"PAPGT")
+    (inner / "Female Armor Module - With Icons.json").write_text(
+        _f3(), encoding="utf-8")
+    return inner
+
+
+# ── _bundled_paz_root unit ──────────────────────────────────────────
+
+def test_bundled_paz_root_sees_through_wrapper(tmp_path):
+    inner = _write_compound_tree(tmp_path)
+    # Extract root has only the wrapper as a child; the 0036/0.paz mod
+    # is one level down. The guard must still find it.
+    assert _bundled_paz_root(tmp_path) == inner
+
+
+def test_bundled_paz_root_none_for_json_only(tmp_path):
+    d = tmp_path / "mod"
+    d.mkdir()
+    (d / "icons.json").write_text(_f3(), encoding="utf-8")
+    assert _bundled_paz_root(tmp_path) is None
+
+
+def test_bundled_paz_root_direct_no_wrapper(tmp_path):
+    (tmp_path / "0036").mkdir()
+    (tmp_path / "0036" / "0.paz").write_bytes(b"x")
+    assert _bundled_paz_root(tmp_path) == tmp_path
+
+
+# ── functional spies ────────────────────────────────────────────────
+
+def _spies(monkeypatch):
+    calls = {"pef": 0, "f3": 0}
+
+    def stub_pef(*a, **k):
+        calls["pef"] += 1
+        r = ModImportResult("Female Armor Module")
+        r.changed_files = ["0036/0.paz"]
+        r.mod_id = 1
+        return r
+
+    def stub_f3(*a, **k):
+        calls["f3"] += 1
+        return ModImportResult("FAM Icons")
+
+    monkeypatch.setattr(ih, "_process_extracted_files", stub_pef)
+    monkeypatch.setattr(ih, "import_from_natt_format_3", stub_f3)
+    return calls
+
+
+def test_compound_zip_imports_paz_model_and_f3_icons(tmp_path, monkeypatch):
+    build = tmp_path / "build"
+    inner = _write_compound_tree(build)
+    z = tmp_path / "fam.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        for p in inner.rglob("*"):
+            if p.is_file():
+                zf.write(p, arcname=str(
+                    Path("Female Armor Module") / p.relative_to(inner)))
+
+    calls = _spies(monkeypatch)
+    ih.import_from_zip(
+        zip_path=z, game_dir=_make_game(tmp_path), db=MagicMock(),
+        snapshot=MagicMock(), deltas_dir=tmp_path)
+
+    assert calls["pef"] == 1, (
+        "#241 regression: the PAZ-dir model mod was dropped — the Format 3 "
+        "branch short-circuited instead of importing the 0036/ model data")
+    assert calls["f3"] == 1, "icons JSON must still import as a sibling"
+
+
+def test_compound_folder_imports_paz_model_and_f3_icons(
+        tmp_path, monkeypatch):
+    folder = tmp_path / "drop"
+    _write_compound_tree(folder)  # folder/Female Armor Module/...
+
+    calls = _spies(monkeypatch)
+    ih.import_from_folder(
+        folder_path=folder, game_dir=_make_game(tmp_path), db=MagicMock(),
+        snapshot=MagicMock(), deltas_dir=tmp_path)
+
+    assert calls["pef"] == 1, (
+        "#241 regression (folder path): PAZ model data dropped")
+    assert calls["f3"] == 1
+
+
+def test_json_only_zip_still_short_circuits_to_format3(
+        tmp_path, monkeypatch):
+    """Guard: a zip with ONLY a Format 3 JSON (no PAZ dir) must still
+    route straight to the Format 3 handler and NOT reach the PAZ path.
+    The compound fix is additive, not a behaviour change for the common
+    single-JSON case."""
+    p = tmp_path / "solo.json"
+    p.write_text(_f3(), encoding="utf-8")
+    z = tmp_path / "solo.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.write(p, arcname="solo.json")
+
+    calls = _spies(monkeypatch)
+    ih.import_from_zip(
+        zip_path=z, game_dir=_make_game(tmp_path), db=MagicMock(),
+        snapshot=MagicMock(), deltas_dir=tmp_path)
+
+    assert calls["f3"] == 1
+    assert calls["pef"] == 0, (
+        "a JSON-only Format 3 zip must not fall through to the PAZ path")

--- a/tests/test_folder_import_compound_json_and_paz.py
+++ b/tests/test_folder_import_compound_json_and_paz.py
@@ -57,7 +57,10 @@ def test_compound_branch_defers_json_siblings_to_helper():
     src = _src()
     anchor = src.find("def import_from_folder(")
     assert anchor != -1
-    body = src[anchor:anchor + 16000]
+    # Window bumped 16000 -> 18000 (2026-07, #241): the Format 3 compound
+    # guard added ~20 lines to import_from_folder, pushing the second
+    # (compound-branch) _import_sibling_json_patches call to offset ~16120.
+    body = src[anchor:anchor + 18000]
     # Must reference the sibling helper in the compound branch.
     sibling_call_count = body.count("_import_sibling_json_patches(")
     # Pre-C1 the file had ONE call (the CB branch). Post-C1 must


### PR DESCRIPTION
## Problem

Female Armor Module (Nexus 3029), reported in #241 by @woowoots: after importing, the armor **icons** change in-game but the armor **models** don't.

The current main file (Nexus 3029, file 12105, "Chest and Gloves") is a **compound archive** - one zip that, under a `Female Armor Module/` wrapper, ships:

```
Female Armor Module/
  0036/0.paz          (1.68 MB)   <- the armor-model swap
  0036/0.pamt
  meta/0.papgt                    <- registers dir 0036 so the game loads it
  Female Armor Module - With Icons.json   <- the icons (Format 3)
```

One file does **both** the model swap (a standalone `NNNN/0.paz` mod) **and** the icons (a Format 3 intents JSON). On import CDUMM applied the icons and silently dropped the model half.

## Root cause

All three import entry points - `import_from_zip`, `import_from_folder`, `_import_from_extracted` - run their Format 3 single-JSON branch early:

```python
f3_jsons = [p for p in <root>.rglob("*.json") if is_natt_format_3(p)]
if len(f3_jsons) == 1:
    return import_from_natt_format_3(...)   # returns -> 0036/ never imported
```

`detect_json_patch` (Format 2) doesn't match the icons JSON (it's Format 3), and `detect_crimson_browser` returns None, so nothing catches the `0036/` PAZ dir first. The Format 3 branch `rglob`s the JSON (through the wrapper), imports only it, and returns.

The **Format 2** branch already got a compound guard for #34 (Character Creator - Female and Male: JSON + `NNNN/0.paz`). The **Format 3** branch never did.

## Fix

Add a wrapper-aware `_bundled_paz_root()` (reuses `_first_numbered_parent` for wrapper descent) and guard all three Format 3 branches: when the archive also bundles a standalone `NNNN/0.paz` mod, **defer** the Format 3 JSON and fall through to the PAZ-dir flow so the model mod imports as primary - then re-import the JSON as a sibling via a new `_import_sibling_format3()` helper (the existing `_import_sibling_json_patches` is Format-2-only and can't handle the intents dialect).

Net: the compound mod now imports as **two** mods - the `0036/` model mod (primary) + the icons Format 3 mod (sibling) - toggleable independently, mirroring the #34 behaviour.

## Verification

- Pulled the actual mod (Nexus 3029, file 12105) and confirmed the tree above.
- Ran CDUMM's real detectors on it: `detect_crimson_browser` -> None, `detect_json_patch` -> None, the icons JSON `is_natt_format_3` -> True; the pre-fix path returned Format-3-only (model dropped).

## Tests

`tests/test_compound_format3_plus_paz_dir.py`:
- compound **zip** imports both halves (PAZ model path reached + icons sibling) - fails before this change, passes after
- compound **folder** import, same
- `_bundled_paz_root` unit: wrapper / direct / json-only
- a **JSON-only** Format 3 zip still short-circuits to the Format 3 handler (no behaviour change for the common case)

Widened the #34 source-window guard in `test_folder_import_compound_json_and_paz.py` (`import_from_folder` grew ~20 lines, pushing the 2nd `_import_sibling_json_patches` call past the 16k window).

**384 passed / 17 skipped** across the import + format3 + compound + paz + zip + folder + sibling selection (Python 3.14).

Fixes #241.