### PR TITLE
feat: mod-maker foundation - Format 3 builder (Part 1, engine bridge)

### DIFF
--- a/src/cdumm/engine/format3_builder.py
+++ b/src/cdumm/engine/format3_builder.py
@@ -93,7 +93,7 @@ def build_format3_json(
             "author": author,
             "description": description
             or f"{len(intents)} field edit(s) made with CDUMM's mod maker",
-            "note": "Format 3 — created with CDUMM's in-app mod maker",
+            "note": "Format 3 - created with CDUMM's in-app mod maker",
         },
         "format": 3,
         "target": targets[0],

--- a/src/cdumm/engine/format3_builder.py
+++ b/src/cdumm/engine/format3_builder.py
@@ -1,0 +1,156 @@
+"""Mod-maker foundation — turn staged Game Data edits into a Format 3
+(``.field.json``) mod, and optionally import it.
+
+This is the Qt-free bridge between the Game Data tab's (future) editable
+grid and CDUMM's existing Format 3 pipeline. It assembles the exact
+``.field.json`` shape that ``import_from_natt_format_3`` already knows how
+to validate (``validate_intents``) and apply, so every safety layer is
+inherited unchanged:
+
+* schema / ``field_schema`` resolution decides whether a field is writable;
+* the verified-fields gate (``TableSchema.verified_fields``) makes
+  ``validate_intents`` *skip* any edit to an unverified field; and
+* the round-trip apply is the same one downloaded mods go through.
+
+The builder holds no offsets, no struct packing and no apply logic of its
+own — it only serialises intents. That keeps the mod maker safe by
+construction: it can never write bytes the engine wouldn't already accept
+from a hand-authored mod.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class FieldEdit:
+    """One staged edit captured from the Game Data grid.
+
+    ``target`` is the ``.pabgb`` table (e.g. ``"wantedinfo.pabgb"``);
+    ``entry``/``key`` identify the record (display name + numeric id);
+    ``field`` is the schema field name; and ``new`` is the replacement
+    value, whose type must match the field (int / float / str / list) —
+    the caller validates that against the ``FieldSpec`` before staging.
+    ``old`` is optional, used for display/audit only, and is never written
+    into the mod.
+    """
+
+    target: str
+    entry: str
+    key: int
+    field: str
+    new: object
+    old: object = None
+
+
+def _safe_filename(name: str) -> str:
+    stem = re.sub(r"[^\w.\- ]+", "", str(name)).strip().replace(" ", "_")
+    return stem or "cdumm_mod"
+
+
+def build_format3_json(
+    edits: Iterable[FieldEdit],
+    *,
+    title: str,
+    author: str = "CDUMM Mod Maker",
+    version: str = "1.0",
+    description: str | None = None,
+) -> dict:
+    """Assemble a Format 3 mod ``dict`` from one or more :class:`FieldEdit`.
+
+    A Format 3 mod carries a single ``target`` table, so every edit must
+    target the same table. Raises ``ValueError`` on no edits or mixed
+    targets. ``old`` is intentionally dropped — it is display metadata, not
+    part of the mod.
+    """
+    edits = list(edits)
+    if not edits:
+        raise ValueError("no edits — nothing to build a mod from")
+    targets = sorted({e.target for e in edits})
+    if len(targets) != 1:
+        raise ValueError(
+            "all edits must target one table; got " + ", ".join(targets))
+
+    intents = [
+        {
+            "entry": e.entry,
+            "key": int(e.key),
+            "field": e.field,
+            "op": "set",
+            "new": e.new,
+        }
+        for e in edits
+    ]
+    return {
+        "modinfo": {
+            "title": title,
+            "version": version,
+            "author": author,
+            "description": description
+            or f"{len(intents)} field edit(s) made with CDUMM's mod maker",
+            "note": "Format 3 — created with CDUMM's in-app mod maker",
+        },
+        "format": 3,
+        "target": targets[0],
+        "intents": intents,
+    }
+
+
+def write_field_json(mod: dict, out_path: str | Path) -> Path:
+    """Serialise a Format 3 mod ``dict`` to ``out_path`` as UTF-8 JSON.
+
+    The *export* primitive — a future "Export .field.json" button calls
+    this so a user can save/share the mod without importing it. Parent
+    directories are created as needed.
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(mod, indent=2, ensure_ascii=False), encoding="utf-8")
+    return out_path
+
+
+def create_mod_from_edits(
+    edits: Iterable[FieldEdit],
+    *,
+    title: str,
+    game_dir: Path,
+    db,
+    snapshot,
+    deltas_dir: Path,
+    author: str = "CDUMM Mod Maker",
+    existing_mod_id: int | None = None,
+):
+    """Build a Format 3 mod from ``edits``, write it to a ``.field.json``
+    under ``deltas_dir``, and import it through the normal Format 3 path.
+
+    Returns the ``ModImportResult`` from ``import_from_natt_format_3``. Its
+    ``.error`` is set if the engine rejected the edits — e.g. an edit to an
+    unverified or unsupported field, which ``validate_intents`` skips — so
+    the caller (GUI) should surface ``.error`` and, on success, refresh the
+    mod list from the returned ``mod_id``.
+    """
+    # Imported lazily so this module stays importable (and unit-testable)
+    # without pulling the full import handler in at module load.
+    from cdumm.engine.import_handler import import_from_natt_format_3
+
+    mod = build_format3_json(edits, title=title, author=author)
+
+    Path(deltas_dir).mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix="cdumm_modmaker_", dir=str(deltas_dir)))
+    json_path = write_field_json(
+        mod, stage / f"{_safe_filename(title)}.field.json")
+
+    return import_from_natt_format_3(
+        json_path=json_path,
+        game_dir=Path(game_dir),
+        db=db,
+        snapshot=snapshot,
+        deltas_dir=Path(deltas_dir),
+        existing_mod_id=existing_mod_id,
+    )

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_format3_builder.py
+++ b/tests/test_format3_builder.py
@@ -1,0 +1,145 @@
+"""Mod-maker foundation (Game Data tab): tests for
+``cdumm.engine.format3_builder`` — turning staged field edits into a
+Format 3 mod, exporting it, and importing it through the existing pipeline.
+
+The build/import round trip reuses the same real-sqlite + mocked-PAMT
+harness as ``test_format3_import_wiring`` so it exercises the actual
+``import_from_natt_format_3`` path, not a stub.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cdumm.engine.format3_builder import (
+    FieldEdit, build_format3_json, write_field_json, create_mod_from_edits,
+)
+
+
+# ── build_format3_json ──────────────────────────────────────────────
+
+def test_build_shapes_single_target_intents():
+    edits = [
+        FieldEdit(target="wantedinfo.pabgb", entry="Wanted_A", key=1,
+                  field="_increasePrice", new=5000, old=1500),
+        FieldEdit(target="wantedinfo.pabgb", entry="Wanted_B", key=2,
+                  field="_increasePrice", new=9999),
+    ]
+    mod = build_format3_json(edits, title="Rich Bounties", author="me")
+    assert mod["format"] == 3
+    assert mod["target"] == "wantedinfo.pabgb"
+    assert mod["modinfo"]["title"] == "Rich Bounties"
+    assert mod["modinfo"]["author"] == "me"
+    assert len(mod["intents"]) == 2
+    assert mod["intents"][0] == {
+        "entry": "Wanted_A", "key": 1, "field": "_increasePrice",
+        "op": "set", "new": 5000}
+    # `old` is display-only and must NOT leak into the mod
+    assert "old" not in mod["intents"][0]
+
+
+def test_build_rejects_empty():
+    with pytest.raises(ValueError):
+        build_format3_json([], title="x")
+
+
+def test_build_rejects_mixed_targets():
+    with pytest.raises(ValueError):
+        build_format3_json([
+            FieldEdit("a.pabgb", "E", 1, "f", 1),
+            FieldEdit("b.pabgb", "E", 2, "f", 2),
+        ], title="x")
+
+
+def test_build_key_coerced_to_int():
+    mod = build_format3_json(
+        [FieldEdit("t.pabgb", "E", "42", "f", 1)], title="x")
+    assert mod["intents"][0]["key"] == 42
+    assert isinstance(mod["intents"][0]["key"], int)
+
+
+# ── write_field_json (export primitive) ─────────────────────────────
+
+def test_write_field_json_roundtrips(tmp_path):
+    mod = build_format3_json(
+        [FieldEdit("wantedinfo.pabgb", "W", 1, "_increasePrice", 7000)],
+        title="Export Me")
+    out = write_field_json(mod, tmp_path / "sub" / "mymod.field.json")
+    assert out.exists()
+    assert json.loads(out.read_text(encoding="utf-8")) == mod
+
+
+# ── create_mod_from_edits (build -> import round trip) ───────────────
+
+def _real_db(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "t.db"))
+    conn.execute(
+        "CREATE TABLE mods (id INTEGER PRIMARY KEY, name TEXT, mod_type TEXT, "
+        "enabled INTEGER DEFAULT 0, json_source TEXT, priority INTEGER, "
+        "author TEXT, version TEXT, description TEXT, game_version_hash TEXT, "
+        "disabled_patches TEXT)")
+    conn.execute(
+        "CREATE TABLE mod_deltas (id INTEGER PRIMARY KEY, mod_id INTEGER, "
+        "file_path TEXT, delta_path TEXT, byte_start INTEGER, byte_end "
+        "INTEGER, entry_path TEXT, kind TEXT)")
+    conn.execute(
+        "CREATE TABLE mod_config (mod_id INTEGER PRIMARY KEY, "
+        "custom_values TEXT)")
+    conn.commit()
+
+    class _W:
+        def __init__(self, c):
+            self.connection = c
+    return _W(conn)
+
+
+def test_create_mod_from_edits_imports_and_persists(tmp_path, monkeypatch):
+    """A supported edit builds a Format 3 mod, writes a .field.json, and
+    imports it: a mods row lands with json_source pointing at a real file
+    that really is Format 3 with our intent."""
+    fake_entry = MagicMock()
+    fake_entry.paz_file = "/fake/0008/0.paz"
+    fake_entry.path = "dropsetinfo.pabgb"
+    fake_entry.offset = 100
+    fake_entry.comp_size = 50
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._find_pamt_entry",
+        lambda gf, gd: fake_entry)
+
+    db = _real_db(tmp_path)
+    edits = [FieldEdit(target="dropsetinfo.pabgb", entry="DropSet_X",
+                       key=100000, field="_dropTagNameHash", new=1234)]
+
+    res = create_mod_from_edits(
+        edits, title="Maker Test Mod", game_dir=tmp_path, db=db,
+        snapshot=MagicMock(), deltas_dir=tmp_path)
+
+    assert res.error is None, res.error
+    assert res.mod_id is not None
+    rows = db.connection.execute(
+        "SELECT name, json_source FROM mods").fetchall()
+    assert len(rows) == 1
+    name, json_source = rows[0]
+    assert "Maker Test Mod" in name
+    assert json_source and Path(json_source).exists()
+    saved = json.loads(Path(json_source).read_text(encoding="utf-8"))
+    assert saved["format"] == 3
+    assert saved["intents"][0]["field"] == "_dropTagNameHash"
+
+
+def test_create_mod_from_edits_surfaces_unknown_table(tmp_path):
+    """An edit to a table with no schema comes back as an error via the
+    same validate path a hand-authored mod hits — not a crash, and no row."""
+    db = _real_db(tmp_path)
+    res = create_mod_from_edits(
+        [FieldEdit("totallyfaketable.pabgb", "X", 1, "y", 42)],
+        title="Bad", game_dir=tmp_path, db=db,
+        snapshot=MagicMock(), deltas_dir=tmp_path)
+    assert res.error
+    assert ("schema" in res.error.lower()
+            or "totallyfaketable" in res.error.lower())
+    assert db.connection.execute("SELECT COUNT(*) FROM mods").fetchone()[0] == 0


### PR DESCRIPTION
## Part 1 of the in-app mod maker (Game Data tab)

The **foundation** for turning the read-only Game Data grid into a mod maker: a Qt-free engine module that turns staged field edits into a Format 3 (`.field.json`) mod and imports it through the existing pipeline. **No GUI yet** - the editable-grid affordance comes in a follow-up that stacks on #242 (Game Data tab) + #244 (verified-fields gate) and calls into this module.

### What is here
`src/cdumm/engine/format3_builder.py`:
- `FieldEdit(target, entry, key, field, new, old)` - one staged grid edit
- `build_format3_json(edits, ...) -> dict` - assembles the `.field.json` (single target enforced)
- `write_field_json(mod, path)` - export primitive (a future "Export .field.json" button)
- `create_mod_from_edits(...)` - writes a temp `.field.json` then `import_from_natt_format_3`

### Safe by construction
The builder holds no offsets, no struct packing, and no apply logic - it only serialises intents, so it inherits every existing safety layer unchanged: schema / `field_schema` resolution decides what is writable, the **verified-fields gate** makes `validate_intents` skip edits to unverified fields, and the round-trip apply is the same one downloaded mods go through. It cannot write bytes the engine would not already accept from a hand-authored mod. The GUI will only expose *verified* fields, so coverage grows automatically as more tables get verified (wantedinfo today; iteminfo scalars once the 1.13 drift work lands).

### Tests
`tests/test_format3_builder.py` (7): JSON shape + single-target/empty/mixed guards + int coercion; `write_field_json` round trip; a full **build -> import** round trip on dropsetinfo (real sqlite + mocked PAMT, same harness as `test_format3_import_wiring`) persisting a real mods row with a `.field.json` json_source; and unknown-table -> clean error, no row. 7 passed locally.

> Draft, for visibility + CI. The red `fast tests` check is the pre-existing baseline failure fixed in #250, unrelated to this change.