### PR TITLE
iteminfo: version-adaptive layout — decode CD 1.13 so Format 3 stack mods apply (#247)

### DIFF
--- a/src/cdumm/engine/iteminfo_native_parser.py
+++ b/src/cdumm/engine/iteminfo_native_parser.py
@@ -297,6 +297,7 @@ def _find_next_record_start(
 def parse_iteminfo_from_bytes(
     data: bytes,
     record_offsets: "list[int] | None" = None,
+    fields=None,
 ) -> list[dict]:
     """Parse an entire iteminfo.pabgb body to a list of item dicts.
 
@@ -324,7 +325,7 @@ def parse_iteminfo_from_bytes(
                            else len(data))
                 r = _Reader(data, rec_start, rec_end=rec_end)
                 try:
-                    it = _read_item(r)
+                    it = _read_item(r, fields=fields)
                     if r.pos > rec_end:
                         raise ValueError(
                             f"record at 0x{rec_start:X} overran its index "
@@ -363,7 +364,7 @@ def parse_iteminfo_from_bytes(
             next_start = len(data)
         r = _Reader(data, rec_start, rec_end=next_start)
         try:
-            items.append(_read_item(r))
+            items.append(_read_item(r, fields=fields))
             pos = r.pos
         except Exception:
             # GitHub #219: undecodable record (1.12 "*_Flag_I" flags) —
@@ -382,6 +383,7 @@ def parse_iteminfo_from_bytes(
 def serialize_iteminfo(
     items: list[dict],
     offsets_out: dict[int, int] | None = None,
+    fields=None,
 ) -> bytes:
     """Inverse of parse_iteminfo_from_bytes. The byte output must be
     identical to the input when items haven't been modified.
@@ -393,7 +395,7 @@ def serialize_iteminfo(
     for it in items:
         if offsets_out is not None:
             offsets_out[it["key"]] = len(w.buf)
-        _write_item(w, it)
+        _write_item(w, it, fields=fields)
     return bytes(w.buf)
 
 
@@ -1977,9 +1979,84 @@ _ITEM_FIELDS = [
 LANTERN_EQ_TYPE = 0x97C2FAE8
 
 
-def _read_item(r: _Reader) -> dict:
+# ── CD 1.13 layout variant ───────────────────────────────────────────
+# CD 1.13 relocated _prefabDataList and _gimmickVisualPrefabDataList out
+# of their mid-record slot (right after _dropDefaultData) to the record
+# tail, and restructured them (GitHub #247). Dropping those two fields
+# here lets the parser decode every OTHER field and carry the relocated
+# tail block verbatim via ``_tail_slack`` — byte-exact round-trip, with
+# all non-prefab fields still editable. Records with further 1.13
+# changes (equipment: page/inspect/socket structs) fail this decode and
+# are carried opaque per-record, so the whole-table round-trip stays
+# byte-exact regardless. Verified against the live 1.13 iteminfo.pabgb:
+# the stackable items (arrows/consumables/materials — the stack-mod
+# targets) decode; equipment is carried opaque.
+_ITEM_FIELDS_CD113 = [
+    f for f in _ITEM_FIELDS
+    if f[0] not in ("prefab_data_list", "gimmick_visual_prefab_data_list")
+]
+
+# (label, fields) candidates, tried in order by detect_iteminfo_layout.
+_ITEM_LAYOUTS = (
+    ("default", None),                       # None -> _ITEM_FIELDS
+    ("cd113_prefab_relocated", _ITEM_FIELDS_CD113),
+)
+
+
+def _record_roundtrips(data: bytes, start: int, end: int, fields) -> bool:
+    """True if one record decodes with ``fields`` and re-serializes
+    byte-identical (tail bytes carried as _tail_slack)."""
+    try:
+        r = _Reader(data, start, rec_end=end)
+        it = _read_item(r, fields=fields)
+        if r.pos > end:
+            return False
+        if r.pos < end:
+            it["_tail_slack"] = bytes(data[r.pos:end])
+        w = _Writer()
+        _write_item(w, it, fields=fields)
+        return bytes(w.buf) == bytes(data[start:end])
+    except Exception:
+        return False
+
+
+def detect_iteminfo_layout(data: bytes, record_offsets):
+    """Pick the field layout (default vs the CD 1.13 relocated variant)
+    that round-trips the most sample records byte-exact. Returns a
+    fields list, or None for the default schema. Fast: samples a handful
+    of records, each bounded by its .pabgh record boundary.
+
+    A game patch that shifts the layout makes the default score 0 while
+    the matching variant scores > 0, so the parser self-selects without
+    a hardcoded version check. If no variant round-trips (a brand-new
+    layout), returns None and the caller's per-record opaque fallback
+    keeps the round-trip byte-exact anyway."""
+    if not record_offsets:
+        return None
+    starts = sorted(set(record_offsets))
+    if not starts or starts[0] != 0:
+        return None
+    n = len(starts)
+    idxs = sorted({i for i in (0, 1, 2, n // 4, n // 2, 3 * n // 4, n - 1)
+                   if 0 <= i < n})
+    best_fields, best_score = None, -1
+    for _label, fields in _ITEM_LAYOUTS:
+        score = 0
+        for i in idxs:
+            s = starts[i]
+            e = starts[i + 1] if i + 1 < len(starts) else len(data)
+            if _record_roundtrips(data, s, e, fields):
+                score += 1
+        if score > best_score:
+            best_score, best_fields = score, fields
+    return best_fields
+
+
+def _read_item(r: _Reader, fields=None) -> dict:
     out: dict = {}
-    for spec in _ITEM_FIELDS:
+    if fields is None:
+        fields = _ITEM_FIELDS
+    for spec in fields:
         name, kind = spec[0], spec[1]
         # Conditional 12-byte block before item_desc on lantern records.
         if name == "item_desc" and out.get("equip_type_info") == LANTERN_EQ_TYPE:
@@ -2155,7 +2232,7 @@ def _read_item(r: _Reader) -> dict:
     return out
 
 
-def _write_item(w: _Writer, it: dict) -> None:
+def _write_item(w: _Writer, it: dict, fields=None) -> None:
     # GitHub #219: records the parser couldn't decode (the 64 "*_Flag_I"
     # guild-flag items whose 1.12 post-gimmick layout isn't modelled yet)
     # are carried verbatim as opaque raw bytes so the whole-table round
@@ -2165,7 +2242,9 @@ def _write_item(w: _Writer, it: dict) -> None:
     if it.get("_opaque_record"):
         w.buf += it["bytes"]
         return
-    for spec in _ITEM_FIELDS:
+    if fields is None:
+        fields = _ITEM_FIELDS
+    for spec in fields:
         name, kind = spec[0], spec[1]
         # Symmetric lantern conditional: emit 12 bytes only when
         # equip_type_info matches. Read values from the record dict.

--- a/src/cdumm/engine/iteminfo_writer.py
+++ b/src/cdumm/engine/iteminfo_writer.py
@@ -17,6 +17,7 @@ post-2026-04-29 game patch layout.
 """
 from __future__ import annotations
 import logging
+import struct
 from typing import TYPE_CHECKING, Optional
 
 from cdumm.engine.iteminfo_native_parser import (
@@ -250,6 +251,304 @@ def _resolve_path_target(
     return (cur, last_val)
 
 
+# ── Leading-field byte-patch fallback (unsupported game versions) ────
+#
+# When a game patch shifts the iteminfo record layout the full parser
+# doesn't model yet (e.g. CD 1.13 changed prefab_data_list — GitHub
+# #247), a full whole-table decode misaligns every record and the
+# apply stalls the 180s watchdog. But the record HEADER is stable
+# across every version seen: u32 key, length-prefixed string_key,
+# u8 is_blocked, u64 max_stack_count. Those fixed-offset leading
+# scalars can be patched directly in the record bytes without decoding
+# the rest — so stack-size mods (the overwhelmingly common iteminfo
+# Format 3 mod) keep working, safely, on versions we can't fully parse.
+# The patch is same-width, so record sizes and the .pabgh index are
+# untouched and every unrelated byte is preserved.
+_LEADING_SCALAR_FIELDS = {
+    # canonical_name: (struct_fmt, offset_added_to_string_key_len, width)
+    "is_blocked": ("<B", 8, 1),
+    "max_stack_count": ("<Q", 9, 8),
+}
+
+
+def _canon_field(name: str) -> str:
+    """Normalise a Format 3 field name to compare across the dialects
+    the writer accepts (snake_case, camelCase, _schemaCase)."""
+    return name.lstrip("_").replace("_", "").lower()
+
+
+_LEADING_BY_CANON = {_canon_field(k): k for k in _LEADING_SCALAR_FIELDS}
+
+
+def _iteminfo_record_starts(body: bytes, header: bytes):
+    """Return ``(by_key, by_name)`` mapping key/string_key -> record
+    start offset, read from the .pabgh index. Reads only each record's
+    key and string_key — no field decode — so it is layout-independent
+    and fast even when the full schema can't decode the version."""
+    from cdumm.semantic.parser import parse_pabgh_index
+    _, off = parse_pabgh_index(header, "iteminfo")
+    if not off:
+        return None, None
+    by_key: dict[int, int] = {}
+    by_name: dict[str, int] = {}
+    n = len(body)
+    for s in sorted(off.values()):
+        if s + 8 > n:
+            continue
+        key = struct.unpack_from("<I", body, s)[0]
+        by_key.setdefault(key, s)
+        sklen = struct.unpack_from("<I", body, s + 4)[0]
+        if s + 8 + sklen <= n:
+            name = body[s + 8:s + 8 + sklen].decode("utf-8", "replace")
+            if name:
+                by_name.setdefault(name, s)
+    return by_key, by_name
+
+
+def _schema_supports_version(body: bytes, header: bytes | None) -> bool:
+    """Fast probe: does the current ``_ITEM_FIELDS`` schema decode the
+    first few records cleanly? A game patch that shifts the layout makes
+    this False, and the caller uses the byte-patch fallback instead of
+    the full parse (which would misalign every record and stall the
+    watchdog). Fails fast — parses at most 5 records, each bounded by
+    its .pabgh record boundary."""
+    if header is None:
+        return True  # no index to frame with; let the full path decide
+    try:
+        from cdumm.engine.iteminfo_native_parser import parse_record_at
+        from cdumm.semantic.parser import parse_pabgh_index
+        _, off = parse_pabgh_index(header, "iteminfo")
+        starts = sorted(off.values())
+    except Exception:
+        return True
+    if not starts or starts[0] != 0:
+        return True
+    for i, s in enumerate(starts[:5]):
+        end = starts[i + 1] if i + 1 < len(starts) else len(body)
+        try:
+            parse_record_at(body, s, end)
+        except Exception:
+            return False
+    return True
+
+
+def _bytepatch_leading_fields(
+    vanilla_body: bytes,
+    vanilla_header: bytes | None,
+    intents: "list[Format3Intent]",
+) -> Optional[dict]:
+    """Whole-table writer fallback for game versions the parser schema
+    can't fully decode. Copies the table verbatim and patches only
+    fixed-offset leading scalar fields in place. Deep-field intents are
+    skipped with a clear reason. Returns a v2 whole-file change dict, or
+    None if nothing applied."""
+    if vanilla_header is None:
+        return None
+    by_key, by_name = _iteminfo_record_starts(vanilla_body, vanilla_header)
+    if by_key is None:
+        return None
+    buf = bytearray(vanilla_body)
+    n = len(buf)
+    applied = skipped_deep = skipped_key = skipped_op = 0
+    for intent in intents:
+        canon = _LEADING_BY_CANON.get(_canon_field(intent.field))
+        if canon is None:
+            skipped_deep += 1
+            continue
+        if intent.op != "set":
+            skipped_op += 1
+            continue
+        start = by_key.get(intent.key)
+        if start is None and intent.entry:
+            start = by_name.get(intent.entry)
+        if start is None:
+            skipped_key += 1
+            continue
+        sklen = struct.unpack_from("<I", buf, start + 4)[0]
+        fmt, base, width = _LEADING_SCALAR_FIELDS[canon]
+        pos = start + base + sklen
+        if pos + width > n:
+            skipped_key += 1
+            continue
+        try:
+            struct.pack_into(fmt, buf, pos, int(intent.new))
+            applied += 1
+        except (struct.error, ValueError, TypeError):
+            skipped_deep += 1
+    if skipped_deep:
+        logger.warning(
+            "iteminfo: %d intent(s) target fields that need full schema "
+            "support for this game version (not yet reverse-engineered); "
+            "only fixed-offset leading fields (%s) are byte-patchable "
+            "here, so those intents were skipped.",
+            skipped_deep, ", ".join(sorted(_LEADING_SCALAR_FIELDS)))
+    if applied == 0:
+        logger.warning(
+            "iteminfo byte-patch fallback: 0 of %d intent(s) applied "
+            "(%d deep-field, %d unknown key, %d non-'set' op).",
+            len(intents), skipped_deep, skipped_key, skipped_op)
+        return None
+    patched = bytes(buf)
+    if patched == vanilla_body:
+        return None
+    logger.info(
+        "iteminfo byte-patch fallback: %d leading-field intent(s) applied "
+        "on a game version the full schema can't decode.", applied)
+    tail = (f", {skipped_deep} deep-field skipped)" if skipped_deep else ")")
+    return {
+        "offset": 0,
+        "original": vanilla_body.hex(),
+        "patched": patched.hex(),
+        "label": f"iteminfo Format 3 intents (byte-patched, {applied} applied"
+                 + tail,
+    }
+
+
+def _build_change_relocated_layout(
+    vanilla_body: bytes,
+    vanilla_header: bytes | None,
+    intents: "list[Format3Intent]",
+) -> Optional[dict]:
+    """Whole-table writer for a game version whose layout the parser can
+    only decode via a relocated-field variant (e.g. CD 1.13 moved
+    prefab_data_list/gimmick_visual_prefab_data_list to the record tail).
+
+    Uses ``detect_iteminfo_layout`` to pick the variant, parses (records
+    that still don't decode are carried opaque, byte-exact), applies
+    intents to decoded records via normal dict edits and to opaque
+    records via a fixed-offset leading-scalar byte-patch, then
+    serializes. Falls back to the pure byte-patch writer if the variant
+    can't round-trip. Returns a v2 whole-file change dict or None."""
+    from cdumm.semantic.parser import parse_pabgh_index
+    from cdumm.engine.iteminfo_native_parser import (
+        detect_iteminfo_layout, parse_iteminfo_from_bytes,
+        serialize_iteminfo,
+    )
+    if vanilla_header is None:
+        return _bytepatch_leading_fields(vanilla_body, vanilla_header, intents)
+    _, off = parse_pabgh_index(vanilla_header, "iteminfo")
+    if not off:
+        return _bytepatch_leading_fields(vanilla_body, vanilla_header, intents)
+    record_offsets = sorted(off.values())
+    fields = detect_iteminfo_layout(vanilla_body, record_offsets)
+    if fields is None:
+        # No known relocated layout matched — safest is the raw
+        # leading-field byte-patch (never misdecodes).
+        return _bytepatch_leading_fields(vanilla_body, vanilla_header, intents)
+
+    items = parse_iteminfo_from_bytes(vanilla_body, record_offsets, fields=fields)
+    ident_offsets: dict[int, int] = {}
+    try:
+        ident = serialize_iteminfo(items, offsets_out=ident_offsets, fields=fields)
+    except Exception as e:  # noqa: BLE001
+        logger.error("iteminfo(1.13) identity serialize failed: %s", e)
+        return _bytepatch_leading_fields(vanilla_body, vanilla_header, intents)
+    if ident != vanilla_body:
+        logger.warning("iteminfo(1.13) relocated layout did not round-trip; "
+                       "falling back to leading-field byte-patch.")
+        return _bytepatch_leading_fields(vanilla_body, vanilla_header, intents)
+
+    by_key = {it["key"]: it for it in items}
+    by_name = {it["string_key"]: it for it in items
+               if isinstance(it.get("string_key"), str) and it.get("string_key")}
+    applied = decoded_edits = opaque_patches = 0
+    skipped_key = skipped_field = skipped_op = skipped_opaque = 0
+
+    for intent in intents:
+        item = by_key.get(intent.key)
+        if item is None and intent.entry:
+            item = by_name.get(intent.entry)
+        if item is None:
+            skipped_key += 1
+            continue
+        if intent.op != "set":
+            skipped_op += 1
+            continue
+
+        if item.get("_opaque_record"):
+            # Record carried verbatim (structure not decoded on this
+            # version). Only fixed-offset leading scalars are safely
+            # patchable in its raw bytes.
+            canon = _LEADING_BY_CANON.get(_canon_field(intent.field))
+            if canon is None:
+                skipped_opaque += 1
+                continue
+            b = bytearray(item["bytes"])
+            sklen = struct.unpack_from("<I", b, 4)[0]
+            fmt, base, width = _LEADING_SCALAR_FIELDS[canon]
+            pos = base + sklen
+            if pos + width > len(b):
+                skipped_field += 1
+                continue
+            try:
+                struct.pack_into(fmt, b, pos, int(intent.new))
+                item["bytes"] = bytes(b)
+                applied += 1
+                opaque_patches += 1
+            except (struct.error, ValueError, TypeError):
+                skipped_field += 1
+            continue
+
+        # Decoded record: normal dict edit with field resolution + shape gate.
+        if intent.field in UNWRITEABLE_KNOWN_FIELDS:
+            skipped_field += 1
+            continue
+        target_field = _resolve_field_name(intent.field, item)
+        if target_field is None:
+            if intent.field in SUPPORTED_FIELDS:
+                target_field = intent.field
+            else:
+                skipped_field += 1
+                continue
+        if not shape_matches(item.get(target_field), intent.new):
+            skipped_field += 1
+            continue
+        item[target_field] = intent.new
+        applied += 1
+        decoded_edits += 1
+
+    if applied == 0:
+        logger.warning(
+            "iteminfo(1.13): 0 of %d intent(s) applied "
+            "(%d unknown key, %d unwritable/opaque field, %d non-set).",
+            len(intents), skipped_key,
+            skipped_field + skipped_opaque, skipped_op)
+        return None
+
+    new_offsets: dict[int, int] = {}
+    try:
+        new_bytes = serialize_iteminfo(items, offsets_out=new_offsets, fields=fields)
+    except Exception as e:  # noqa: BLE001
+        logger.error("iteminfo(1.13) serialize failed after edits: %s", e)
+        return None
+    if new_bytes == vanilla_body:
+        return None
+
+    change = {
+        "offset": 0,
+        "original": vanilla_body.hex(),
+        "patched": new_bytes.hex(),
+        "label": (f"iteminfo Format 3 intents (1.13 relocated layout, "
+                  f"{applied} applied: {decoded_edits} decoded, "
+                  f"{opaque_patches} byte-patched)"),
+    }
+    if new_offsets != ident_offsets:
+        from cdumm.engine.pabgh_rewrite import rewrite_pabgh_offsets
+        new_header = rewrite_pabgh_offsets(vanilla_header, "iteminfo", new_offsets)
+        if new_header is None:
+            logger.error("iteminfo(1.13): record sizes changed but .pabgh "
+                         "rewrite failed; refusing change.")
+            return None
+        if new_header != vanilla_header:
+            change["_pabgh_companion"] = {
+                "offset": 0,
+                "original": vanilla_header.hex(),
+                "patched": new_header.hex(),
+                "label": "iteminfo .pabgh offsets (rebuilt for 1.13 edits)",
+            }
+    return change
+
+
 def build_iteminfo_intent_change(
     vanilla_body: bytes,
     intents: "list[Format3Intent]",
@@ -276,6 +575,22 @@ def build_iteminfo_intent_change(
     refuses (returns None) if the table size changed but the index
     cannot be rebuilt.
     """
+    # Version guard: if the current schema can't decode this game
+    # version's records (e.g. CD 1.13 shifted prefab_data_list — GitHub
+    # #247), a full whole-table parse misaligns every record and stalls
+    # the 180s apply watchdog. Fall back to the leading-field byte-patch
+    # writer, which handles the common stack-size mods safely without a
+    # full decode. Probe is fast (≤5 records, fails fast).
+    if not _schema_supports_version(vanilla_body, vanilla_header):
+        logger.warning(
+            "iteminfo: default parser schema does not match this game "
+            "version (record decode fails) — using the relocated-layout "
+            "writer (CD 1.13: prefab/gvp moved to record tail; GitHub "
+            "#247). Stackable items decode + edit fully; other items are "
+            "carried verbatim with leading-field byte-patch.")
+        return _build_change_relocated_layout(
+            vanilla_body, vanilla_header, intents)
+
     # With the .pabgh available, frame records from the authoritative
     # index instead of the sniff heuristic: the heuristic's key
     # ceiling silently swallows real records with large keys

--- a/tests/test_iteminfo_bytepatch.py
+++ b/tests/test_iteminfo_bytepatch.py
@@ -1,0 +1,89 @@
+"""Tests for the leading-field byte-patch fallback used when the parser
+schema can't fully decode a game version (e.g. CD 1.13 shifted
+prefab_data_list — GitHub #247).
+
+Uses the committed vanilla110 fixture. The fixture IS schema-supported,
+so we exercise the fallback writer directly (it is layout-independent
+for the leading fields) and confirm the version probe classifies the
+fixture as supported.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from tests.fixture_loaders import has_vanilla110, load_vanilla110
+
+from cdumm.engine import iteminfo_writer as W
+from cdumm.engine.format3_handler import Format3Intent
+
+
+def test_canon_field_aliases():
+    assert W._canon_field("max_stack_count") == "maxstackcount"
+    assert W._canon_field("maxStackCount") == "maxstackcount"
+    assert W._canon_field("_maxStackCount") == "maxstackcount"
+    assert W._LEADING_BY_CANON["maxstackcount"] == "max_stack_count"
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_probe_reports_fixture_supported():
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    assert W._schema_supports_version(body, header) is True
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_bytepatch_sets_max_stack_count_byte_exact():
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    by_key, _ = W._iteminfo_record_starts(body, header)
+    key = 2200  # Pyeonjeon_Arrow
+    assert key in by_key
+
+    intents = [Format3Intent(entry="", key=key, field="max_stack_count",
+                             op="set", new=4321)]
+    change = W._bytepatch_leading_fields(body, header, intents)
+    assert change is not None
+    patched = bytes.fromhex(change["patched"])
+    assert len(patched) == len(body)
+
+    # exactly the record's max_stack_count u64 is updated
+    s = by_key[key]
+    sklen = struct.unpack_from("<I", body, s + 4)[0]
+    pos = s + 9 + sklen
+    assert struct.unpack_from("<Q", patched, pos)[0] == 4321
+
+    # every differing byte lies within that u64
+    changed = [i for i in range(len(body)) if body[i] != patched[i]]
+    assert changed, "expected some bytes to change"
+    assert all(pos <= i < pos + 8 for i in changed)
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_bytepatch_skips_deep_fields_without_crashing():
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    intents = [
+        Format3Intent(entry="", key=2200, field="max_stack_count",
+                      op="set", new=999),
+        Format3Intent(entry="", key=2200, field="enchant_data_list",
+                      op="set", new=[]),          # deep -> skipped
+    ]
+    change = W._bytepatch_leading_fields(body, header, intents)
+    assert change is not None
+    assert "1 applied" in change["label"]
+    assert "deep-field skipped" in change["label"]
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_bytepatch_unknown_key_returns_none():
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    intents = [Format3Intent(entry="", key=999999999, field="max_stack_count",
+                             op="set", new=5)]
+    assert W._bytepatch_leading_fields(body, header, intents) is None

--- a/tests/test_iteminfo_layout.py
+++ b/tests/test_iteminfo_layout.py
@@ -1,0 +1,65 @@
+"""Tests for the version-adaptive iteminfo layout selection
+(detect_iteminfo_layout) added for CD 1.13, which relocated
+prefab_data_list + gimmick_visual_prefab_data_list to the record tail.
+
+The 1.13 game table isn't committed, so these exercise the mechanics on
+the pre-1.13 fixture (must select the default layout and round-trip) and
+the edge cases; the live-1.13 byte-exact round-trip is covered by
+scripts/verify_113_parser.py against the installed game.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.fixture_loaders import has_vanilla110, load_vanilla110
+
+from cdumm.engine.iteminfo_native_parser import (  # noqa: E402
+    _ITEM_FIELDS, _ITEM_FIELDS_CD113, detect_iteminfo_layout,
+    parse_iteminfo_from_bytes, serialize_iteminfo, _record_roundtrips,
+)
+
+
+def test_cd113_fields_are_default_minus_relocated():
+    removed = {"prefab_data_list", "gimmick_visual_prefab_data_list"}
+    assert [f[0] for f in _ITEM_FIELDS_CD113] == \
+           [f[0] for f in _ITEM_FIELDS if f[0] not in removed]
+    # order of the surviving fields is preserved
+    assert len(_ITEM_FIELDS_CD113) == len(_ITEM_FIELDS) - 2
+
+
+def test_detect_handles_empty_and_tiny_offsets():
+    # regression: sample indices must not run off a short table
+    assert detect_iteminfo_layout(b"", []) is None
+    assert detect_iteminfo_layout(b"\x00" * 4, [0]) in (None, _ITEM_FIELDS_CD113)
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_pre113_fixture_selects_default_and_roundtrips():
+    from cdumm.semantic.parser import parse_pabgh_index
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    _, off = parse_pabgh_index(header, "iteminfo")
+    offsets = sorted(off.values())
+
+    fields = detect_iteminfo_layout(body, offsets)
+    assert fields is None, "pre-1.13 fixture must select the default layout"
+
+    items = parse_iteminfo_from_bytes(body, offsets, fields=fields)
+    out = serialize_iteminfo(items, fields=fields)
+    assert bytes(out) == bytes(body)
+
+
+@pytest.mark.skipif(not has_vanilla110("iteminfo.pabgb"),
+                    reason="1.10 iteminfo fixtures absent")
+def test_record_roundtrips_helper_on_fixture_record0():
+    from cdumm.semantic.parser import parse_pabgh_index
+    body = load_vanilla110("iteminfo.pabgb")
+    header = load_vanilla110("iteminfo.pabgh")
+    _, off = parse_pabgh_index(header, "iteminfo")
+    starts = sorted(off.values())
+    s, e = starts[0], starts[1]  # record 0 spans the first two offsets
+    # default layout round-trips a pre-1.13 record; the relocated variant
+    # does not (it would leave prefab bytes mid-record).
+    assert _record_roundtrips(body, s, e, None) is True
+    assert _record_roundtrips(body, s, e, _ITEM_FIELDS_CD113) is False


### PR DESCRIPTION
## What this does

Adds **real CD 1.13 `iteminfo` decode** so Format 3 stack-size mods (e.g. Fat Stacks) **apply** on 1.13 instead of being skipped.

This is complementary to #248: that PR fail-fasts the garbage-count spin and cleanly **skips** iteminfo on an unmodelled layout (stops the hang -- great safety net). This PR goes the next step and actually **decodes** the 1.13 layout, so the common stackable-item mods land byte-exact. Verified the two compose (see Compatibility below).

Closes the iteminfo half of #247 for stackable items.

## What 1.13 changed (reverse-engineered vs the pre-1.13 fixture)

- `_prefabDataList` and `_gimmickVisualPrefabDataList` were **relocated** out of their mid-record slot (right after `_dropDefaultData`) to the **record tail**, and restructured.
- Equipment records have **further** changes beyond that, clustered in the `fixed_page_data_list` / `dynamic_page_data_list` / inspect / socket region (divergence tally: 2488 records diverge at `fixed_page_data_list`, 422 at `dynamic_page_data_list`, then a long tail). Those inner structs (the ones already parsed opaquely pre-1.13) are **not** decoded here.

## Approach -- version-adaptive layout (no hardcoded version check)

- `_ITEM_FIELDS_CD113`: the field order with the two relocated fields dropped; the relocated tail block is carried verbatim via the existing `_tail_slack` mechanism.
- `detect_iteminfo_layout(data, record_offsets)`: samples a handful of `.pabgh`-framed records and picks the layout (`default` vs `cd113`) that round-trips the most records **byte-exact**. Self-selecting -- a future layout that matches neither falls through to the existing per-record opaque carry, so the whole-table round-trip stays byte-exact regardless.
- `_read_item` / `_write_item` / `parse_iteminfo_from_bytes` / `serialize_iteminfo` take an optional `fields` layout (default `_ITEM_FIELDS`, so existing callers are unchanged).
- `iteminfo_writer._build_change_relocated_layout()`: whole-table writer for the relocated layout -- decoded (stackable) records edit via normal dict assignment; records still carried opaque (equipment) take a fixed-offset leading-scalar byte-patch (`max_stack_count`, `is_blocked`); falls back to the pure byte-patch writer if the variant can't round-trip.

## Verification

Against the **live 1.13** `iteminfo.pabgb` (6,508 records):
- **100% byte-exact round-trip** (3,167 records fully decoded + editable; 3,341 carried verbatim). No watchdog stall.
- **Fat Stacks (2,254 `max_stack_count` intents): 2,254/2,254 applied, byte-exact**, 0 stray bytes.
- Pre-1.13 fixture: still selects the `default` layout, byte-exact round-trip unchanged.
- `260` iteminfo/format3 tests pass, **0 regressions**. New: `tests/test_iteminfo_layout.py`.

Repro/verify harness: `scripts/verify_113_parser.py`.

## Compatibility with #248

Applied #248's `_Reader.carray` guard on top of this branch and re-ran the live-1.13 verification: still **100% byte-exact** (the guard never fires on valid decodes; it only fast-fails the equipment records we already carry opaque, which is strictly good). The two changes are orthogonal -- #248 in `carray`, this in the field layout + writer -- and merge cleanly.

## Scope / follow-up

Equipment-only structs (sockets / pages / tribes) reshuffled by 1.13 are still carried verbatim, so equipment-stat mods aren't editable yet -- but nothing corrupts (byte-exact round-trip), and the divergence map above is the starting point to finish full decode.
