### PR TITLE
macOS: launch Steam installs via steam://rungameid instead of `open <app>`

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -6590,13 +6590,25 @@ class CdummWindow(FluentWindow):
 
         # ── macOS native branch ─────────────────────────────────────
         if IS_MACOS:
+            from cdumm.storage.game_finder import is_steam_install
             app_bundle = _find_app_bundle_above(self._game_dir)
             try:
-                if app_bundle is not None:
+                if is_steam_install(self._game_dir):
+                    # Steam install: hand the launch off THROUGH Steam so
+                    # the DRM / ownership check passes. `open <app>` starts
+                    # the bundle outside Steam's launch flow, and Crimson
+                    # Desert aborts with "Steam needs to be running" even
+                    # when the client is running (macOS Steam DRM). Mirrors
+                    # the Windows branch, which always routes Steam installs
+                    # through the rungameid URI.
+                    from cdumm.engine.game_monitor import get_steam_app_id
+                    app_id = get_steam_app_id(self._game_dir)
+                    subprocess.Popen(["open", f"steam://rungameid/{app_id}"])
+                elif app_bundle is not None:
+                    # Non-Steam (e.g. a standalone .app): launch directly.
                     subprocess.Popen(["open", str(app_bundle)])
                 else:
-                    # Steam URI works on macOS via the Steam client , 
-                    # falls back to the App ID lookup below.
+                    # Last resort: try the Steam URI via App ID lookup.
                     from cdumm.engine.game_monitor import get_steam_app_id
                     app_id = get_steam_app_id(self._game_dir)
                     subprocess.Popen(["open", f"steam://rungameid/{app_id}"])


### PR DESCRIPTION
## What this does

On macOS, the **Launch Game** button ran `open <Crimson Desert.app>` whenever it could locate the bundle. For a **Steam** install that starts the game *outside* Steam's launch flow, so Crimson Desert's Steam DRM/ownership check fails and the game aborts with **"Steam needs to be running"** -- even though the Steam client is running. (The message comes from the game, not CDUMM, so CDUMM shows a green "launched" toast while the game never appears.)

This routes **Steam installs on macOS through the `steam://rungameid/<id>` URI** (the same handoff the Windows branch already uses), so the DRM/overlay check passes. `open <app>` is kept only for non-Steam standalone bundles, and the App-ID URI remains the final fallback.

## Repro
- macOS, Steam install of Crimson Desert, Steam client running.
- Click Launch Game in CDUMM → game briefly starts then exits with "Steam needs to be running".
- With this change → game launches normally through Steam.

## Notes
- `is_steam_install()` gates the new path; `get_steam_app_id()` resolves the id (verified `3321460` on a live Steam install).
- No change to Windows/Xbox/non-Steam behavior.
