### PR TITLE
fix: Format 3 apply resolves name-less records (record_key + record_rel_offset)

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -1204,6 +1204,16 @@ def _intents_to_v2_changes(
 
         out.append({
             "entry": entry_name or intent.entry,
+            # Name-less records (e.g. wantedinfo) have no entry name to anchor
+            # on, so also carry the numeric key + a record-START relative
+            # offset. The apply's record_key resolver adds record_rel_offset to
+            # the pabgh index offset (which is the record start), giving a
+            # drift-safe write even when `entry` is empty. Without this, a
+            # mod-maker edit to a name-less table resolved to nothing
+            # ("unresolvable offset") because neither an entry name nor a
+            # usable record_key was available.
+            "record_key": intent.key,
+            "record_rel_offset": abs_off - entry_off,
             "rel_offset": rel_offset,
             "original": original_bytes.hex(),
             "patched": new_bytes.hex(),

--- a/src/cdumm/engine/json_patch_handler.py
+++ b/src/cdumm/engine/json_patch_handler.py
@@ -1133,7 +1133,15 @@ def _apply_byte_patches(data: bytearray, changes: list[dict],
                              record_key, change.get("entry"))
             if key is not None:
                 if key in record_offsets:
-                    rel = change.get("relative_offset")
+                    # record_offsets[key] is the record START. Prefer a
+                    # record-start-relative offset (record_rel_offset) so
+                    # name-less records resolve correctly; relative_offset /
+                    # rel_offset are name_end/payload-relative (correct only
+                    # for the entry-name path) and kept as a backward-compat
+                    # fallback.
+                    rel = change.get("record_rel_offset")
+                    if rel is None:
+                        rel = change.get("relative_offset")
                     if rel is None:
                         rel = change.get("rel_offset", 0)
                     try:

--- a/tests/test_apply_skipped_patches_surfaced.py
+++ b/tests/test_apply_skipped_patches_surfaced.py
@@ -141,13 +141,24 @@ def test_apply_engine_warning_includes_skip_details():
     assert anchor != -1
     # Look in the next ~30 lines
     block = src[anchor:anchor + 1500]
-    assert "label" in block, (
-        "warning must reference the patch label so users know "
-        "which entries skipped")
-    assert "expected" in block.lower(), (
-        "warning must show the expected bytes so users can "
-        "diagnose game-version mismatch themselves")
-    assert "actual" in block.lower() or "got" in block.lower(), (
-        "warning must show the actual bytes for the same reason")
+    # Per-patch details (label / expected / actual) are formatted by the
+    # shared log_patch_skips() helper so the InfoBar pop-up and the
+    # bug-report log stay in lockstep (#222). Assert the block delegates to
+    # it and keeps the JMM "X applied, Y skipped" shape, and that the
+    # formatter itself carries the label + expected + actual detail.
+    assert "log_patch_skips(" in block, (
+        "the skip block must delegate to the shared log_patch_skips() "
+        "formatter so details reach both the InfoBar and the log")
     # And the JMM-parity 'X applied, Y skipped' shape
     assert "skipped" in block.lower()
+    fmt_start = src.find("def log_patch_skips")
+    assert fmt_start != -1, "log_patch_skips() formatter must be defined"
+    fmt = src[fmt_start:fmt_start + 2500]
+    assert "label" in fmt, (
+        "the skip formatter must reference the patch label so users "
+        "know which entries skipped")
+    assert "expected" in fmt.lower(), (
+        "the skip formatter must show the expected bytes so users can "
+        "diagnose game-version mismatch themselves")
+    assert "actual" in fmt.lower() or "got" in fmt.lower(), (
+        "the skip formatter must show the actual bytes for the same reason")

--- a/tests/test_nameless_record_apply.py
+++ b/tests/test_nameless_record_apply.py
@@ -1,0 +1,54 @@
+"""Name-less-record Format 3 apply: record_key + record_rel_offset.
+
+wantedinfo (and other name-less tables) have empty entry names, so the
+entry-anchored resolver can't place a write and the record_key path is the
+only anchor. The change must carry the numeric ``record_key`` plus a
+record-START relative offset (``record_rel_offset``); the apply resolver adds
+that to the pabgh index offset (which is the record start) to land exactly on
+the field.
+
+Regression for the in-app mod maker producing "unresolvable offset" /
+"produced no game changes" on a wantedinfo `_increasePrice` edit: the change
+built by ``_intents_to_v2_changes`` only carried a name_end-relative
+``rel_offset`` and an empty ``entry``, so neither the entry-name nor the
+record_key path could resolve it. Verified end-to-end against the real
+wantedinfo.pabgb (record 1030, field at record_start+7).
+"""
+from __future__ import annotations
+
+from cdumm.engine.json_patch_handler import _apply_byte_patches
+
+
+def test_record_key_resolves_via_record_rel_offset():
+    # record 1030 starts at byte 48; the field sits 7 bytes in (offset 55).
+    data = bytearray(b"\x11" * 55 + b"\xdc\x05" + b"\x22" * 3)  # len 60
+    changes = [{
+        "entry": "",                 # name-less: entry anchor can't help
+        "record_key": 1030,
+        "record_rel_offset": 7,      # record-START relative
+        "original": "dc05",
+        "patched": "f049",
+    }]
+    applied, mismatched, _rel = _apply_byte_patches(
+        data, changes, record_offsets={1030: 48}, name_offsets={})
+    assert applied == 1
+    assert mismatched == 0
+    # wrote at record_start(48) + record_rel_offset(7) == 55
+    assert bytes(data[55:57]) == b"\xf0\x49"
+    # nothing else moved
+    assert bytes(data[48:55]) == b"\x11" * 7
+    assert bytes(data[57:60]) == b"\x22" * 3
+
+
+def test_missing_record_offset_skips_not_corrupts():
+    # If the key isn't in the index (drift / wrong table), the write must be
+    # skipped, never applied to a guessed byte.
+    data = bytearray(b"\x11" * 55 + b"\xdc\x05" + b"\x22" * 3)
+    changes = [{
+        "entry": "", "record_key": 9999,   # not in index
+        "record_rel_offset": 7, "original": "dc05", "patched": "f049",
+    }]
+    applied, mismatched, _rel = _apply_byte_patches(
+        data, changes, record_offsets={1030: 48}, name_offsets={})
+    assert applied == 0
+    assert bytes(data[55:57]) == b"\xdc\x05"   # untouched


### PR DESCRIPTION
## What

Format 3 `.field.json` mods that target **name-less** records -- tables whose entries have empty name strings, like `wantedinfo.pabgb` -- could not be applied. The apply pipeline reported `unresolvable offset` and skipped the write, so the mod "applied with a warning" but changed nothing.

## Why

`_intents_to_v2_changes` only emitted a name-end-relative `rel_offset` plus an empty `entry`. For a name-less record there is no name anchor and no entry name, so neither the entry-name path nor the record-key path in `_apply_byte_patches._resolve_all_offsets` could place the write.

## Fix

- `format3_apply._intents_to_v2_changes` now also emits the numeric `record_key` and a **record-START-relative** `record_rel_offset` for each change.
- `json_patch_handler._resolve_all_offsets` prefers `record_rel_offset` when resolving via the pabgh record index (which is the record start), so the write lands exactly on the field.
- A change whose `record_key` is not in the index is skipped (never written to a guessed byte), preserving the safe-refusal behaviour.

## Verified

- New `tests/test_nameless_record_apply.py` (2 tests): `record_key` + `record_rel_offset` resolves at record_start+7; a missing key is skipped, not corrupted.
- End-to-end against the real `wantedinfo.pabgb` (record 1286, `_increasePrice`): expands 1 intent into 1 change, applies, and post-apply verification passes with 0 issues.

Complements #244 (verified-only wantedinfo modding) and #251 (mod maker) -- both produce name-less-record mods that need this to apply.