### PR TITLE
fix(iteminfo): apply Format 3 item-price mods (price_list nested path) (#259)

### DIFF
--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -723,7 +723,11 @@ def _diagnose_unsupported_intent(
                     or f.startswith("gimmick_visual_prefab_data_list[")
                     # GitHub #135: docking_child_data.<subfield> resolves
                     # via the iteminfo writer's nested-path walker.
-                    or f.startswith("docking_child_data.")):
+                    or f.startswith("docking_child_data.")
+                    # GitHub #259: price_list[N].price.price (an item's
+                    # sell/buy price) resolves via the same nested-path
+                    # walker. "Cheap Gold Bars" and other price mods.
+                    or f.startswith("price_list[")):
                 return None
         # GitHub #125 (Refinement Cost Reforged): multichangeinfo
         # fixed_material_data_list[N].item_info / .count are resolved

--- a/src/cdumm/engine/iteminfo_writer.py
+++ b/src/cdumm/engine/iteminfo_writer.py
@@ -493,6 +493,31 @@ def _build_change_relocated_layout(
         if intent.field in UNWRITEABLE_KNOWN_FIELDS:
             skipped_field += 1
             continue
+        # Nested path (dotted / indexed) — walk the parsed dict to the
+        # assignment target. The full-schema writer already does this; the
+        # 1.13 relocated-layout writer needs it too so item-price mods
+        # (price_list[N].price.price) apply on the current game. Mirrors the
+        # path block below; uses this function's own counters.
+        if "." in intent.field or "[" in intent.field:
+            target = _resolve_path_target(item, intent.field)
+            if target is None:
+                skipped_field += 1
+                continue
+            parent, last_seg = target
+            try:
+                existing_nested = parent[last_seg]
+            except (KeyError, IndexError, TypeError):
+                existing_nested = None
+            if not shape_matches(existing_nested, intent.new):
+                skipped_field += 1
+                continue
+            try:
+                parent[last_seg] = intent.new
+                applied += 1
+                decoded_edits += 1
+            except (KeyError, IndexError, TypeError):
+                skipped_field += 1
+            continue
         target_field = _resolve_field_name(intent.field, item)
         if target_field is None:
             if intent.field in SUPPORTED_FIELDS:

--- a/tests/test_iteminfo_price_path.py
+++ b/tests/test_iteminfo_price_path.py
@@ -1,0 +1,81 @@
+"""Format 3 nested-path writes for iteminfo item prices (GitHub #259).
+
+"Cheap Gold Bars" and similar price mods target the dotted/indexed path
+``price_list[0].price.price`` (an item's sell/buy value). Two things have to
+line up for that intent to apply, and before #259 the first one blocked it:
+
+1. The import-time validator (``_diagnose_unsupported_intent``) must NOT reject
+   the dotted path -- ``price_list[`` is on the iteminfo nested-path allowlist.
+2. The 1.13 relocated-layout writer (``_build_change_relocated_layout``) must
+   resolve the path on the parsed record and assign the new value.
+
+price_list decodes as ``[{"key": N, "price": {"price": P, ...}}]``, so the
+editable value is the path ``price_list[0].price.price``. These pin both halves
+with no game fixture (CI-runnable). The whole-table byte-exact apply is verified
+live against the installed 1.13 iteminfo (GoldBar key 53, 50000 -> 1: exactly
+the 2 bytes of the u64 price change, 0 collateral records).
+"""
+from __future__ import annotations
+
+from cdumm.engine.format3_handler import _diagnose_unsupported_intent
+from cdumm.engine.iteminfo_writer import _resolve_path_target, shape_matches
+
+
+def _item():
+    # shape exactly as the native parser emits for a decoded 1.13 record
+    return {
+        "key": 53,
+        "price_list": [
+            {"key": 1, "price": {"price": 50000, "sym_no": 0,
+                                 "item_info_wrapper": 1}}
+        ],
+    }
+
+
+# --- validator gate (#259) ------------------------------------------------
+
+def test_price_path_passes_validation():
+    # The dotted price path must NOT be rejected at import time.
+    assert _diagnose_unsupported_intent(
+        "price_list[0].price.price", 1, "iteminfo") is None
+
+
+def test_unrelated_iteminfo_nested_path_still_rejected():
+    # The allowlist stays specific: an unknown nested path is still refused,
+    # so the gate keeps its "refuse rather than guess" discipline.
+    msg = _diagnose_unsupported_intent(
+        "some_unknown_list[0].value", 1, "iteminfo")
+    assert msg is not None and "nested" in msg.lower()
+
+
+# --- writer path resolution -----------------------------------------------
+
+def test_price_path_resolves_to_the_inner_price_value():
+    it = _item()
+    target = _resolve_path_target(it, "price_list[0].price.price")
+    assert target is not None
+    parent, seg = target
+    # parent is the nested price dict; seg the final assignable key
+    assert parent is it["price_list"][0]["price"]
+    assert seg == "price"
+    assert parent[seg] == 50000
+
+
+def test_price_path_assignment_sets_the_value():
+    it = _item()
+    parent, seg = _resolve_path_target(it, "price_list[0].price.price")
+    parent[seg] = 1  # exactly what the writer branch does
+    assert it["price_list"][0]["price"]["price"] == 1
+
+
+def test_price_value_shape_gate():
+    # int -> int passes; a wrong-shaped new value is refused before serialize
+    assert shape_matches(50000, 1) is True
+    assert shape_matches(50000, [1, 2]) is False
+    assert shape_matches(50000, {"x": 1}) is False
+
+
+def test_price_path_bad_segments_return_none():
+    it = _item()
+    assert _resolve_path_target(it, "price_list[9].price.price") is None  # OOR
+    assert _resolve_path_target(it, "price_list[0].nope.price") is None   # missing key


### PR DESCRIPTION
Closes #259.

`Cheap Gold Bars` and similar price mods target the dotted/indexed path `price_list[0].price.price` (an item's sell/buy value). On CD 1.13 the import failed with:

> field 'price_list[0].price.price' targets a nested struct sub-field (dotted path). Format 3 nested-field writes are not implemented for this field yet.

Two gaps caused it:

1. **Validator gate** — `_diagnose_unsupported_intent` (`format3_handler.py`) has an allowlist of iteminfo nested-path prefixes it accepts (`prefab_data_list[`, `drop_default_data.`, `gimmick_visual_prefab_data_list[`, `docking_child_data.`). `price_list[` wasn't on it, so the intent was rejected at import time.
2. **1.13 writer** — `_build_change_relocated_layout` (`iteminfo_writer.py`, the relocated-layout path used on 1.13) only resolved flat field names, so even past the gate the intent would silently no-op. The full-schema writer already had a nested/indexed path walk; the 1.13 writer didn't.

### Fix
- Add `price_list[` to the iteminfo nested-path allowlist.
- Give the 1.13 relocated-layout writer the same `_resolve_path_target` nested/indexed walk + `shape_matches` gate the full-schema writer uses.

### Verification
- **Byte-exact, live** against the installed CD 1.13 `iteminfo.pabgb`: GoldBar (key 53) `price_list[0].price.price` 50000 → 1 — exactly the 2 bytes of the u64 price change, same table length, **0 collateral records**.
- New CI-runnable tests (`tests/test_iteminfo_price_path.py`, no game fixture) pin the gate acceptance + a still-rejected unknown path + the resolver/assignment/shape gate.
- `272 passed, 32 skipped` across the format3 / iteminfo suite; no regressions.

Scope is intentionally narrow: only `price_list[...]` is added to the allowlist, so the "refuse rather than guess" discipline holds for every other nested path.