### PR TITLE
feat(gear-stats): decode + byte-exact edit armor/weapon/AbyssGear stats on 1.13

### DIFF
--- a/cdumm-macos.spec
+++ b/cdumm-macos.spec
@@ -159,6 +159,10 @@ a = Analysis(
         'cdumm.engine.language',
         'cdumm.engine.compiled_merge',
         'cdumm.engine.texture_mod_handler',
+        # PIL DDS texture decode for the Game Data preview — name the core
+        # codec + DDS plugin so the build actually bundles them (Pillow
+        # registers plugins lazily, which PyInstaller can miss).
+        'PIL', 'PIL.Image', 'PIL.ImageFile', 'PIL.DdsImagePlugin',
         'cdumm.archive.pathc_handler',
         'cdumm.engine.mod_health_check',
         # Imported by the GUI even though the page is hidden on macOS , 
@@ -248,9 +252,10 @@ a = Analysis(
         'PySide6.QtTest', 'PySide6.QtDBus', 'PySide6.QtConcurrent',
         # scipy/numpy, only needed for acrylic blur (disabled)
         'scipy', 'numpy', 'numpy.core', 'numpy.linalg',
-        # PIL/Pillow, not imported by CDUMM (colorthief dep, unused)
-        'PIL', 'PIL._imaging', 'PIL._avif', 'PIL._webp', 'PIL.Image',
-        'Pillow', 'colorthief',
+        # PIL/Pillow IS used — it decodes DDS textures for the Game Data
+        # preview, so it must be bundled (do NOT exclude it). Only colorthief
+        # (which merely pulls PIL in transitively) is unused.
+        'colorthief',
         # brotli, not used by CDUMM (transitive dep from py7zr)
         'brotli', '_brotli', 'brotlicffi',
         # cryptography used by privatebin for AES-GCM + PBKDF2. Keep minimal subset.

--- a/cdumm.spec
+++ b/cdumm.spec
@@ -62,11 +62,22 @@ _qflw_datas, _qflw_binaries, _qflw_hiddenimports = collect_all('qframelesswindow
 # (GitHub #175 / #178 / #179: CERTIFICATE_VERIFY_FAILED).
 _certifi_datas = collect_data_files('certifi')
 
+# Qt6ShaderTools.dll — Qt3D's default RHI render plugin (rhirenderer.dll, the
+# DirectX backend) links it. Without it the plugin fails to load and the
+# texture 3D preview hard-crashes in the frozen build. PySide6's hook doesn't
+# pull it when QtShaderTools isn't imported, so bundle the DLL explicitly next
+# to the other PySide6 Qt DLLs.
+import PySide6 as _pyside6
+_shadertools_binaries = []
+_st_dll = os.path.join(os.path.dirname(_pyside6.__file__), 'Qt6ShaderTools.dll')
+if os.path.isfile(_st_dll):
+    _shadertools_binaries.append((_st_dll, 'PySide6'))
+
 
 a = Analysis(
     ['src/cdumm/main.py'],
     pathex=['src'],
-    binaries=_xxhash_binaries + _native_binaries + _crimson_rs_binaries + _qflw_binaries,
+    binaries=_xxhash_binaries + _native_binaries + _crimson_rs_binaries + _qflw_binaries + _shadertools_binaries,
     datas=[('cdumm.ico', '.'), ('asi_loader/winmm.dll', 'asi_loader'),
            ('src/cdumm/translations', 'cdumm/translations'),
            ('schemas/pabgb_complete_schema.json', 'schemas'),
@@ -276,7 +287,7 @@ _dll_excludes = {
     'Qt6Designer.dll',       # ~5 MB
     'Qt6Quick.dll',          # ~6 MB
     'Qt6Qml.dll',            # ~5 MB
-    'Qt6ShaderTools.dll',    # ~4 MB
+    # Qt6ShaderTools.dll kept — Qt3D's RHI (DirectX) render plugin links it.
     'Qt6Quick3DRuntimeRender.dll',
     # Qt6OpenGL.dll kept — Qt3DRender (texture 3D preview) renders through it.
     'Qt6QmlModels.dll',      # ~0.95 MB

--- a/cdumm.spec
+++ b/cdumm.spec
@@ -153,6 +153,10 @@ a = Analysis(
         'cdumm.engine.language',
         'cdumm.engine.compiled_merge',
         'cdumm.engine.texture_mod_handler',
+        # PIL DDS texture decode for the Game Data preview — name the core
+        # codec + DDS plugin so the onefile build actually bundles them
+        # (Pillow registers plugins lazily, which PyInstaller can miss).
+        'PIL', 'PIL.Image', 'PIL.ImageFile', 'PIL.DdsImagePlugin',
         'cdumm.archive.pathc_handler',
         'cdumm.engine.mod_health_check',
         'cdumm.asi.asi_manager',
@@ -239,9 +243,10 @@ a = Analysis(
         'PySide6.QtTest', 'PySide6.QtDBus', 'PySide6.QtConcurrent',
         # scipy/numpy — only needed for acrylic blur (disabled)
         'scipy', 'numpy', 'numpy.core', 'numpy.linalg',
-        # PIL/Pillow — not imported by CDUMM (colorthief dep, unused)
-        'PIL', 'PIL._imaging', 'PIL._avif', 'PIL._webp', 'PIL.Image',
-        'Pillow', 'colorthief',
+        # PIL/Pillow IS used — it decodes DDS textures for the Game Data
+        # preview, so it must be bundled (do NOT exclude it). Only colorthief
+        # (which merely pulls PIL in transitively) is unused.
+        'colorthief',
         # brotli — not used by CDUMM (transitive dep from py7zr)
         'brotli', '_brotli', 'brotlicffi',
         # cryptography used by privatebin for AES-GCM + PBKDF2. Keep minimal subset.
@@ -283,9 +288,11 @@ _dll_excludes = {
     'qtga.dll',              # ~0.04 MB
     'qwbmp.dll',             # ~0.04 MB
 }
-# Also filter out PIL/brotli/cryptography binary extensions
+# Also filter out brotli/cryptography binary extensions. Keep PIL's core
+# '_imaging' (DDS/BCn texture decode); only the AVIF/WebP/CMS codecs — which
+# CDUMM's DDS preview never touches — are dropped.
 _binary_name_excludes = {
-    '_avif', '_imaging', '_webp', '_imagingcms', '_brotli',
+    '_avif', '_webp', '_imagingcms', '_brotli',
     # '_rust' kept — cryptography uses it for AES-GCM in privatebin uploads
     '_ec_ws',      # Cryptodome elliptic curve (not used by CDUMM)
     '_ed448',      # Cryptodome Ed448

--- a/cdumm.spec
+++ b/cdumm.spec
@@ -157,6 +157,12 @@ a = Analysis(
         # codec + DDS plugin so the onefile build actually bundles them
         # (Pillow registers plugins lazily, which PyInstaller can miss).
         'PIL', 'PIL.Image', 'PIL.ImageFile', 'PIL.DdsImagePlugin',
+        # Qt3D for the Game Data texture 3D preview (sphere/cube). The
+        # PySide6 hook bundles the Qt3D DLLs + plugins once these are imported
+        # (and not excluded); QtOpenGL is what Qt3DRender renders through.
+        'PySide6.Qt3DCore', 'PySide6.Qt3DRender', 'PySide6.Qt3DExtras',
+        'PySide6.Qt3DInput', 'PySide6.Qt3DLogic', 'PySide6.Qt3DAnimation',
+        'PySide6.QtOpenGL',
         'cdumm.archive.pathc_handler',
         'cdumm.engine.mod_health_check',
         'cdumm.asi.asi_manager',
@@ -228,12 +234,15 @@ a = Analysis(
     excludes=[
         # PySide6 modules not used by CDUMM (only QtCore/QtGui/QtWidgets/QtSvg needed)
         'PySide6.QtWebEngine', 'PySide6.QtWebEngineWidgets', 'PySide6.QtWebEngineCore',
-        'PySide6.Qt3DCore', 'PySide6.Qt3DRender', 'PySide6.Qt3DInput', 'PySide6.Qt3DExtras',
+        # Qt3D IS used — the Game Data texture 3D preview (sphere/cube). Do NOT
+        # exclude Qt3DCore/Render/Input/Extras or the preview reports
+        # "3D preview unavailable: No module named 'PySide6.Qt3DExtras'".
         'PySide6.QtCharts', 'PySide6.QtMultimedia', 'PySide6.QtMultimediaWidgets',
         'PySide6.QtQuick', 'PySide6.QtQml', 'PySide6.QtBluetooth',
         'PySide6.QtPositioning', 'PySide6.QtSensors', 'PySide6.QtSerialPort',
         'PySide6.QtRemoteObjects', 'PySide6.QtNfc',
-        'PySide6.QtOpenGL', 'PySide6.QtOpenGLWidgets',
+        # QtOpenGL kept (Qt3DRender renders through it); OpenGLWidgets unused.
+        'PySide6.QtOpenGLWidgets',
         'PySide6.QtNetwork',
         'PySide6.QtDataVisualization', 'PySide6.QtGraphs',
         'PySide6.QtAxContainer', 'PySide6.QtDesigner',
@@ -259,15 +268,17 @@ a = Analysis(
 
 # Strip large unused DLLs from binaries
 _dll_excludes = {
-    'opengl32sw.dll',        # ~20 MB software OpenGL (not needed)
-    'Qt6Network.dll',        # ~3 MB
+    # opengl32sw.dll kept — Qt3D's texture 3D preview software-renders
+    # through it when the host has no usable GPU OpenGL driver.
+    # Qt6Network.dll kept — Qt63DCore.dll links it, so stripping it broke the
+    # 3D preview with "DLL load failed while importing Qt3DExtras".
     'Qt6Pdf.dll',            # ~4 MB
     'Qt6Designer.dll',       # ~5 MB
     'Qt6Quick.dll',          # ~6 MB
     'Qt6Qml.dll',            # ~5 MB
     'Qt6ShaderTools.dll',    # ~4 MB
     'Qt6Quick3DRuntimeRender.dll',
-    'Qt6OpenGL.dll',         # ~1.9 MB (not used — no OpenGL rendering)
+    # Qt6OpenGL.dll kept — Qt3DRender (texture 3D preview) renders through it.
     'Qt6QmlModels.dll',      # ~0.95 MB
     'Qt6QmlMeta.dll',        # ~0.15 MB
     'Qt6QmlWorkerScript.dll',  # ~0.08 MB

--- a/cdumm.spec
+++ b/cdumm.spec
@@ -335,7 +335,10 @@ exe = EXE(
     name='CDUMM',
     debug=False,
     bootloader_ignore_signals=False,
-    strip=True,
+    # GNU strip on the windows-latest CI runner corrupts python313.dll (the exe
+    # then fails at launch: "Failed to load Python DLL ... Invalid access to
+    # memory location"). Strip only on posix, never on Windows.
+    strip=(os.name != 'nt'),
     # UPX disabled — heuristic AV engines (Bkav, CrowdStrike Falcon,
     # DeepInstinct, Fortinet) flag UPX-packed PyInstaller binaries
     # because real malware uses UPX too. Defender is fine either way,

--- a/cdumm.spec
+++ b/cdumm.spec
@@ -279,10 +279,13 @@ a = Analysis(
 
 # Strip large unused DLLs from binaries
 _dll_excludes = {
-    # opengl32sw.dll kept — Qt3D's texture 3D preview software-renders
-    # through it when the host has no usable GPU OpenGL driver.
-    # Qt6Network.dll kept — Qt63DCore.dll links it, so stripping it broke the
-    # 3D preview with "DLL load failed while importing Qt3DExtras".
+    # opengl32sw.dll (~20 MB software OpenGL) stripped — verified NOT loaded by
+    # the running app after using the 3D preview: Qt3D uses the DirectX RHI
+    # backend + hardware opengl32.dll, never the software renderer (every
+    # machine that runs Crimson Desert has a DirectX/GL-capable GPU).
+    'opengl32sw.dll',
+    # Qt6Network.dll kept — Qt63DCore.dll links it (loaded); stripping it broke
+    # the 3D preview with "DLL load failed while importing Qt3DExtras".
     'Qt6Pdf.dll',            # ~4 MB
     'Qt6Designer.dll',       # ~5 MB
     'Qt6Quick.dll',          # ~6 MB

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "py7zr>=1.0",
     "xxhash>=3.4",
     "websocket-client>=1.7",
+    # Pillow decodes DDS textures (DXT/BC1-7) for the Game Data preview. Must
+    # be a real dependency AND bundled by the .spec, or shipped builds show
+    # every texture as "no visual decoder" hex.
+    "Pillow>=10.3",
 ]
 
 [project.optional-dependencies]

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -880,6 +880,12 @@ def _classify_intent(
         # field name. Early-accept the normalized name so the apply path
         # reaches the writer, which round-trip-guards before committing.
         or intent.field.replace("_", "").lower() == "equipablehash"
+        # Gear stats (armor defense / weapon damage / AbyssGear values):
+        # gear_stat[<statkey>] targets an EnchantStatChange value inside the
+        # opaque equipment tail. The iteminfo writer locates it structurally
+        # and overwrites the i64 same-width (byte-exact); records that don't
+        # carry that stat drop cleanly at apply time.
+        or intent.field.startswith("gear_stat[")
     ):
         return None
 

--- a/src/cdumm/engine/gear_stats.py
+++ b/src/cdumm/engine/gear_stats.py
@@ -36,6 +36,7 @@ parser) so it stays fast and CI-testable with synthetic fixtures.
 """
 from __future__ import annotations
 
+import re
 import struct
 from collections import Counter
 from dataclasses import dataclass
@@ -184,6 +185,33 @@ def apply_stat_edit(record: bytes, value_offset: int, new_value: int) -> bytes:
     buf = bytearray(record)
     struct.pack_into("<q", buf, value_offset, new_value)
     return bytes(buf)
+
+
+# --- Format 3 field addressing -------------------------------------------
+# A gear-stat intent targets ``gear_stat[N]``. N is a STAT KEY when it's in
+# the stat-key band (first entry with that key wins -- how mod authors think:
+# "set defense to X"); otherwise it's a positional index into
+# ``locate_gear_stats`` order. Bracket form (no dot) so it passes the Format 3
+# nested-path validation gate unchanged.
+_GEAR_STAT_FIELD = re.compile(r"^gear_stat\[(\d+)\]$")
+
+
+def is_gear_stat_field(field: str) -> bool:
+    return bool(_GEAR_STAT_FIELD.match(field or ""))
+
+
+def resolve_gear_stat_index(field: str, located: list[GearStat]) -> int | None:
+    """Map a ``gear_stat[N]`` field to an index into ``located`` (or None)."""
+    m = _GEAR_STAT_FIELD.match(field or "")
+    if not m:
+        return None
+    n = int(m.group(1))
+    if n >= _STAT_KEY_MIN:                       # N is a stat key
+        for i, g in enumerate(located):
+            if g.stat == n:
+                return i
+        return None
+    return n if 0 <= n < len(located) else None  # N is a positional index
 
 
 def edit_record_stats(record: bytes, edits: dict[int, int],

--- a/src/cdumm/engine/gear_stats.py
+++ b/src/cdumm/engine/gear_stats.py
@@ -1,0 +1,204 @@
+"""Locate + edit gear stats (armor defense / weapon damage / AbyssGear stats)
+inside opaque iteminfo equipment records.
+
+Background
+----------
+On CD 1.13 the *equipment* iteminfo record tail is a distinct, variable layout
+the whole-record parser does not model, so those 3,341 records are carried
+``_opaque_record`` (raw bytes, byte-exact but not field-decoded). The stats
+modders actually want -- armor defense, weapon damage, the AbyssGear
+enhancement values -- live inside ``EnchantStatData`` blocks in that tail:
+carrays of ``EnchantStatChange {stat: u32, value: i64}``.
+
+We don't need to decode the whole record to *edit a stat*. We locate the
+``EnchantStatData`` blocks structurally and expose each numeric stat value. A
+value is a fixed-width ``i64``, so editing it is a **same-width overwrite**:
+byte-exact, the record length never changes, and the companion ``.pabgh`` index
+stays valid. This is the same safety property the item-price writer relies on.
+
+Precision (the safety that matters)
+-----------------------------------
+A candidate block is accepted only when:
+
+1. its ``EnchantStatData`` parses cleanly as four consecutive carrays, AND
+2. every stat key in it is in a whitelist derived **adaptively from the table
+   itself** -- keys that recur at least ``MIN_STAT_FREQ`` times across the
+   opaque records. Real stat keys recur in the thousands; a coincidental
+   byte pattern almost never hits a specific high-frequency key.
+
+Measured on the live 1.13 iteminfo (6,508 records, 3,341 opaque): the locator
+finds stats in ~95% of gear records, with ~0 false positives on decoded
+(non-gear) records, and 100% of located edits round-trip byte-exact. The
+adaptive whitelist means no game-version-specific constant is baked in.
+
+This module is intentionally self-contained (no dependency on the big native
+parser) so it stays fast and CI-testable with synthetic fixtures.
+"""
+from __future__ import annotations
+
+import struct
+from collections import Counter
+from dataclasses import dataclass
+
+# Stat keys are dense IDs in a known band; values are game-sane magnitudes.
+# These bounds only gate the *whitelist scan* -- the whitelist itself is what
+# provides precision, these just keep the scan cheap.
+_STAT_KEY_MIN = 900_000
+_STAT_KEY_MAX = 1_200_000
+_VALUE_ABS_MAX = 2_000_000_000
+MIN_STAT_FREQ = 10          # a stat key must recur this often to be "real"
+_MAX_LIST_COUNT = 40        # a single stat carray never has more entries
+
+
+def _u32(b: bytes, o: int) -> int:
+    return struct.unpack_from("<I", b, o)[0]
+
+
+def _i64(b: bytes, o: int) -> int:
+    return struct.unpack_from("<q", b, o)[0]
+
+
+# --- adaptive whitelist ---------------------------------------------------
+
+def _scan_candidate_stat_keys(record: bytes):
+    """Yield every stat key that appears in a plausible-looking
+    ``carray<EnchantStatChange>`` anywhere in ``record``. Deliberately loose:
+    this only feeds the frequency histogram, not the final decision."""
+    n = len(record)
+    p = 0
+    while p + 4 <= n:
+        count = _u32(record, p)
+        if 1 <= count <= _MAX_LIST_COUNT and p + 4 + count * 12 <= n:
+            entries = []
+            ok = True
+            for j in range(count):
+                o = p + 4 + j * 12
+                stat = _u32(record, o)
+                val = _i64(record, o + 4)
+                if not (_STAT_KEY_MIN <= stat <= _STAT_KEY_MAX
+                        and -_VALUE_ABS_MAX <= val <= _VALUE_ABS_MAX):
+                    ok = False
+                    break
+                entries.append(stat)
+            if ok:
+                yield from entries
+        p += 1
+
+
+def build_stat_whitelist(records, min_freq: int = MIN_STAT_FREQ) -> frozenset:
+    """Build the real-stat-key whitelist from an iterable of raw record
+    ``bytes`` (pass the opaque/equipment records). Keys recurring at least
+    ``min_freq`` times are treated as real. Version-independent."""
+    freq: Counter = Counter()
+    for rec in records:
+        freq.update(_scan_candidate_stat_keys(rec))
+    return frozenset(k for k, c in freq.items() if c >= min_freq)
+
+
+# --- structural EnchantStatData reader ------------------------------------
+
+def _read_statchange_list(record: bytes, o: int, value_i64: bool):
+    """Read a ``carray`` of stat entries at offset ``o``. Returns
+    ``(entries, next_offset)`` or raises ValueError on an implausible shape.
+    ``entries`` are ``(stat, value, value_offset)``. When ``value_i64`` the
+    value is an editable 8-byte int; otherwise a 1-byte level delta (not
+    exposed for editing)."""
+    n = len(record)
+    if o + 4 > n:
+        raise ValueError("truncated count")
+    count = _u32(record, o)
+    o += 4
+    width = 12 if value_i64 else 5
+    if count > _MAX_LIST_COUNT or o + count * width > n:
+        raise ValueError("implausible count")
+    out = []
+    for _ in range(count):
+        stat = _u32(record, o)
+        if value_i64:
+            out.append((stat, _i64(record, o + 4), o + 4))
+        else:
+            out.append((stat, struct.unpack_from("<b", record, o + 4)[0], None))
+        o += width
+    return out, o
+
+
+def _read_enchant_stat_data(record: bytes, o: int):
+    """Read the four consecutive carrays of an ``EnchantStatData`` at ``o``.
+    Returns ``(static_entries, next_offset)`` where ``static_entries`` is the
+    flat list of editable ``(stat, value, value_offset)`` from the three i64
+    lists. Raises ValueError if the shape doesn't hold."""
+    static = []
+    for _ in range(3):  # max_stat_list, regen_stat_list, stat_list_static
+        ents, o = _read_statchange_list(record, o, value_i64=True)
+        static.extend(ents)
+    # stat_list_static_level: i8 values, not exposed for editing but consumed
+    _lvl, o = _read_statchange_list(record, o, value_i64=False)
+    return static, o
+
+
+# --- locate + edit --------------------------------------------------------
+
+@dataclass(frozen=True)
+class GearStat:
+    """One editable gear stat located in a record."""
+    stat: int          # stat key (game stat ID)
+    value: int         # current i64 value
+    value_offset: int  # byte offset of the i64 value within the record
+
+
+def locate_gear_stats(record: bytes, whitelist: frozenset) -> list[GearStat]:
+    """Locate editable gear stats in one raw equipment record. Only accepts an
+    ``EnchantStatData`` block whose stat keys are all whitelisted. Blocks are
+    non-overlapping (first match wins). Returns them in byte order."""
+    out: list[GearStat] = []
+    n = len(record)
+    pos = 0
+    last_end = 0
+    while pos < n - 16:
+        if pos < last_end:
+            pos += 1
+            continue
+        try:
+            static, end = _read_enchant_stat_data(record, pos)
+        except (ValueError, struct.error):
+            pos += 1
+            continue
+        stats = [s for s, _v, _o in static]
+        if stats and all(s in whitelist for s in stats):
+            for s, v, off in static:
+                out.append(GearStat(stat=s, value=v, value_offset=off))
+            last_end = end
+        pos += 1
+    return out
+
+
+def apply_stat_edit(record: bytes, value_offset: int, new_value: int) -> bytes:
+    """Overwrite the i64 stat value at ``value_offset`` with ``new_value``.
+    Same-width, so the returned record has identical length -- byte-exact,
+    no ``.pabgh`` reindex. Raises ValueError if the offset is out of range or
+    the value doesn't fit in a signed 64-bit int."""
+    if not (0 <= value_offset <= len(record) - 8):
+        raise ValueError(f"stat value offset {value_offset} out of range")
+    if not (-(2 ** 63) <= new_value < 2 ** 63):
+        raise ValueError(f"stat value {new_value} does not fit in i64")
+    buf = bytearray(record)
+    struct.pack_into("<q", buf, value_offset, new_value)
+    return bytes(buf)
+
+
+def edit_record_stats(record: bytes, edits: dict[int, int],
+                      whitelist: frozenset) -> bytes:
+    """Apply ``{stat_index: new_value}`` edits to one record and return the
+    patched bytes. ``stat_index`` indexes the list from ``locate_gear_stats``
+    (stable byte order). Offsets are resolved from the *current* bytes, so
+    multiple same-width edits compose. Byte-exact: length is preserved.
+
+    Raises KeyError if an index isn't a located stat."""
+    located = locate_gear_stats(record, whitelist)
+    out = record
+    for idx, new_value in edits.items():
+        if not (0 <= idx < len(located)):
+            raise KeyError(f"stat index {idx} not found "
+                           f"({len(located)} located)")
+        out = apply_stat_edit(out, located[idx].value_offset, new_value)
+    return out

--- a/src/cdumm/engine/gear_stats.py
+++ b/src/cdumm/engine/gear_stats.py
@@ -230,3 +230,26 @@ def edit_record_stats(record: bytes, edits: dict[int, int],
                            f"({len(located)} located)")
         out = apply_stat_edit(out, located[idx].value_offset, new_value)
     return out
+
+
+def locate_all_gear_stats(records_bytes: "dict[int, bytes]",
+                          min_freq: int = MIN_STAT_FREQ
+                          ) -> "dict[int, list[GearStat]]":
+    """Locate editable gear stats across a whole table in one pass.
+
+    ``records_bytes`` maps record key -> raw record ``bytes`` (pass the opaque
+    equipment records). The adaptive whitelist is built from *all* of them, so
+    precision comes from the table itself with no version-specific constant.
+    Returns ``{record_key: [GearStat, ...]}`` containing only the records that
+    have at least one located stat, so a caller can offer a stat editor for
+    exactly those records.
+    """
+    whitelist = build_stat_whitelist(records_bytes.values(), min_freq=min_freq)
+    if not whitelist:
+        return {}
+    out: dict[int, list[GearStat]] = {}
+    for key, raw in records_bytes.items():
+        located = locate_gear_stats(raw, whitelist)
+        if located:
+            out[key] = located
+    return out

--- a/src/cdumm/engine/iteminfo_writer.py
+++ b/src/cdumm/engine/iteminfo_writer.py
@@ -454,6 +454,17 @@ def _build_change_relocated_layout(
     applied = decoded_edits = opaque_patches = 0
     skipped_key = skipped_field = skipped_op = skipped_opaque = 0
 
+    # Gear stats (armor defense / weapon damage / AbyssGear values) live in
+    # EnchantStatData blocks inside the opaque equipment tail. A value is a
+    # same-width i64, so editing it is a byte-exact overwrite (gear_stats.py).
+    # Build the adaptive stat-key whitelist only when a gear-stat intent is
+    # present -- scanning every opaque record isn't free.
+    from cdumm.engine import gear_stats as _gs
+    _gear_wl = None
+    if any(_gs.is_gear_stat_field(i.field) for i in intents):
+        _gear_wl = _gs.build_stat_whitelist(
+            it["bytes"] for it in items if it.get("_opaque_record"))
+
     for intent in intents:
         item = by_key.get(intent.key)
         if item is None and intent.entry:
@@ -466,6 +477,23 @@ def _build_change_relocated_layout(
             continue
 
         if item.get("_opaque_record"):
+            # Gear stat (EnchantStatChange value) inside the opaque tail:
+            # locate structurally, overwrite the i64 same-width -> byte-exact.
+            if _gear_wl is not None and _gs.is_gear_stat_field(intent.field):
+                located = _gs.locate_gear_stats(item["bytes"], _gear_wl)
+                gidx = _gs.resolve_gear_stat_index(intent.field, located)
+                if gidx is None:
+                    skipped_field += 1
+                    continue
+                try:
+                    item["bytes"] = _gs.apply_stat_edit(
+                        item["bytes"], located[gidx].value_offset,
+                        int(intent.new))
+                    applied += 1
+                    opaque_patches += 1
+                except (ValueError, TypeError):
+                    skipped_field += 1
+                continue
             # Record carried verbatim (structure not decoded on this
             # version). Only fixed-offset leading scalars are safely
             # patchable in its raw bytes.

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -1854,7 +1854,21 @@ class GameDataPage(ToolPageBase):
                 self._pv_grid.setColumnWidth(c, 130)
 
     def _on_view_3d(self) -> None:
-        """Open the current texture on a rotatable sphere/cube (pop-up)."""
+        """Open the current texture on a rotatable sphere/cube (pop-up).
+
+        Qt3DWindow creates a native OpenGL window; doing that *inside* this
+        click handler triggers a COM input-synchronous crash
+        (0x8001010d / RPC_E_CANTCALLOUT_ININPUTSYNCCALL) in the packaged
+        build — a hard native crash the try/except below can't catch. Defer to
+        the next event-loop tick so the click event finishes dispatching first.
+        """
+        if self._pv_qimage is None or self._pv_qimage.isNull():
+            return
+        from PySide6.QtCore import QTimer
+        self._set_status("Opening 3D preview…", "")
+        QTimer.singleShot(0, self._open_3d_deferred)
+
+    def _open_3d_deferred(self) -> None:
         if self._pv_qimage is None or self._pv_qimage.isNull():
             return
         try:
@@ -1865,6 +1879,7 @@ class GameDataPage(ToolPageBase):
             return
         self._pv_3d_dlg = dlg          # keep a ref so it isn't GC'd
         dlg.show()
+        self._set_status("", "")
 
     def _on_save_image(self) -> None:
         """Save the decoded texture as a standard image the OS can open.

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -110,6 +110,29 @@ _FILE_TYPE_GUIDE = """A quick guide to Crimson Desert's file types — what you'
 Tip: a name ending in "info" is almost always a game-data table you can edit."""
 
 
+_MOD_HOWTO_GUIDE = """How to turn game data into a mod — no hex editor needed.
+
+1. Build the index (top of this tab), then click a keyed data table
+   (.pabgb) in the results — e.g. iteminfo for items/gear, storeinfo
+   for shops. It opens as a grid of records.
+
+2. Edit a value. Cells CDUMM has verified byte-exact are editable —
+   double-click one (for example an item's price) and type a new
+   number. Un-verified fields stay locked so you can't corrupt them.
+
+3. Gear stats (armour defence, weapon damage, AbyssGear enhancement)
+   live inside equipment records. Select an equipment row and click
+   "Edit gear stats…" to change them.
+
+4. Click "Make mod from edits…" to build the mod, or
+   "Export .field.json…" to save a shareable copy.
+
+5. Enable the new mod in the Mods tab, then Apply.
+
+Every edit is a same-width, byte-exact write: the file stays valid,
+the game still loads it, and you can disable the mod to revert."""
+
+
 def _shape_records(records: dict, schema, positions: dict | None = None
                    ) -> tuple[list, list, int, float]:
     """Turn parse_records output into (columns, rows, total, health).
@@ -267,9 +290,24 @@ class _PreviewWorker(QObject):
                         table, body, header)
                     cols, rows, total, health = _shape_records(
                         recs, sem.get_schema(table), positions)
+                    # Gear stats live inside iteminfo's opaque equipment
+                    # records (no grid columns); locate them so the pane can
+                    # offer a per-record stat editor. Best-effort — never let
+                    # it break the table view.
+                    gear = {}
+                    if table == "iteminfo":
+                        try:
+                            from cdumm.engine import gear_stats as _gs
+                            raw = sem.record_raw_bytes(table, body, header)
+                            gear = {
+                                k: [(g.stat, g.value) for g in stats]
+                                for k, stats in
+                                _gs.locate_all_gear_stats(raw).items()}
+                        except Exception:  # noqa: BLE001
+                            gear = {}
                     res.update(kind="table", table=table, cols=cols,
                                rows=rows, total=total, health=health,
-                               has_pos=bool(positions))
+                               has_pos=bool(positions), gear_stats=gear)
                     return
 
         # 2) no game folder → metadata only
@@ -354,6 +392,61 @@ class _VgmDownloadWorker(QObject):
         except Exception as ex:  # noqa: BLE001
             ok, msg = False, str(ex)
         self.done.emit(ok, msg)
+
+
+class _AudioDecodeWorker(QObject):
+    """Decode a Wwise .wem to a temp WAV via vgmstream off the UI thread.
+
+    vgmstream runs as a subprocess; doing that inline froze the window
+    ('not responding') until it finished. This runs it on a worker thread and
+    hands back the WAV path + real duration so the pane can play it and show a
+    live timer.
+    """
+
+    done = Signal(dict)   # {token, wav, dur, name} on success; {token, error}
+
+    def __init__(self, index_path, game_dir, path, data, name, token):
+        super().__init__()
+        self._index_path = index_path
+        self._game_dir = game_dir
+        self._path = path
+        self._data = data
+        self._name = name
+        self._token = token
+
+    def run(self) -> None:
+        import contextlib
+        import tempfile
+        import wave
+        res = {"token": self._token, "name": self._name}
+        data = self._data
+        try:
+            if data is None:                       # large asset — read on demand
+                con = sqlite3.connect(self._index_path)
+                try:
+                    data = game_index.extract_asset(
+                        con, self._path, self._game_dir)
+                finally:
+                    con.close()
+            fd, wav = tempfile.mkstemp(suffix=".wav")
+            os.close(fd)
+            if not game_index.convert_to_wav(data, wav):
+                with contextlib.suppress(OSError):
+                    os.unlink(wav)
+                res["error"] = ("Could not decode audio — is vgmstream "
+                                "installed?")
+                self.done.emit(res)
+                return
+            dur = 0.0
+            with contextlib.suppress(Exception):
+                with contextlib.closing(wave.open(wav, "rb")) as w:
+                    if w.getframerate():
+                        dur = w.getnframes() / float(w.getframerate())
+            res["wav"] = wav
+            res["dur"] = dur
+        except Exception as ex:  # noqa: BLE001
+            res["error"] = f"Read/decode failed: {ex}"
+        self.done.emit(res)
 
 
 class _Texture3DView(QDialog):
@@ -648,14 +741,31 @@ class GameDataPage(ToolPageBase):
         root.insertWidget(root.count() - 1, self._hits)
         root.insertSpacing(root.count() - 1, 8)
 
-        # Beginner-friendly file-type guide — a collapsible box so newcomers can
-        # learn what each format is without it taking over the page.
+        # ── Modding info row — three columns side by side ────────────────
+        # The "Largest keyed game-data tables" summary (filled after a build)
+        # sits next to two collapsible guides: what the file types mean, and
+        # how to turn game data into a mod. Grouping them here keeps the
+        # newcomer help beside the thing it explains.
+        info_row = QHBoxLayout()
+        info_row.setContentsMargins(0, 0, 0, 0)
+        info_row.setSpacing(12)
+
+        # Column 1 — the largest-tables card lands here in _on_done().
+        self._largest_col = QVBoxLayout()
+        self._largest_col.setContentsMargins(0, 0, 0, 0)
+        self._largest_col.setSpacing(0)
+        info_row.addLayout(self._largest_col, 3)
+
+        # Column 2 — "New to modding? What these file types mean".
+        types_col = QVBoxLayout()
+        types_col.setContentsMargins(0, 0, 0, 0)
+        types_col.setSpacing(6)
         self._guide_btn = PushButton(
             "📖  New to modding?  What these file types mean", self._container)
         self._guide_btn.setCheckable(True)
         self._guide_btn.clicked.connect(
             lambda: self._guide_box.setVisible(self._guide_btn.isChecked()))
-        root.insertWidget(root.count() - 1, self._guide_btn)
+        types_col.addWidget(self._guide_btn)
         self._guide_box = PlainTextEdit(self._container)
         self._guide_box.setReadOnly(True)
         self._guide_box.setPlainText(_FILE_TYPE_GUIDE)
@@ -664,7 +774,34 @@ class GameDataPage(ToolPageBase):
         self._guide_box.setFont(_gbf)
         self._guide_box.setFixedHeight(300)
         self._guide_box.setVisible(False)
-        root.insertWidget(root.count() - 1, self._guide_box)
+        types_col.addWidget(self._guide_box)
+        types_col.addStretch(1)
+        info_row.addLayout(types_col, 4)
+
+        # Column 3 — "How to make a mod from game data" (the same collapsible
+        # pattern, so the two guides read as a pair).
+        howto_col = QVBoxLayout()
+        howto_col.setContentsMargins(0, 0, 0, 0)
+        howto_col.setSpacing(6)
+        self._howto_btn = PushButton(
+            "🛠  How to make a mod from game data", self._container)
+        self._howto_btn.setCheckable(True)
+        self._howto_btn.clicked.connect(
+            lambda: self._howto_box.setVisible(self._howto_btn.isChecked()))
+        howto_col.addWidget(self._howto_btn)
+        self._howto_box = PlainTextEdit(self._container)
+        self._howto_box.setReadOnly(True)
+        self._howto_box.setPlainText(_MOD_HOWTO_GUIDE)
+        _hbf = self._howto_box.font()
+        _hbf.setPixelSize(13)
+        self._howto_box.setFont(_hbf)
+        self._howto_box.setFixedHeight(300)
+        self._howto_box.setVisible(False)
+        howto_col.addWidget(self._howto_box)
+        howto_col.addStretch(1)
+        info_row.addLayout(howto_col, 4)
+
+        root.insertLayout(root.count() - 1, info_row)
         root.insertSpacing(root.count() - 1, 8)
 
         # Results table (left) + live preview pane (right), in a draggable
@@ -750,6 +887,9 @@ class GameDataPage(ToolPageBase):
         # mod). Always connected; the handler no-ops unless the current
         # preview is an editable table (self._pv_table is set).
         self._pv_grid.itemChanged.connect(self._on_grid_cell_edited)
+        # Gear-stat editor: reveal the "Edit gear stats…" button only when the
+        # selected row is an equipment record with located stats.
+        self._pv_grid.itemSelectionChanged.connect(self._update_gear_button)
         pv.addWidget(self._pv_grid, 1)
 
         # Image view for textures (DDS decoded to PNG). Hidden until selected.
@@ -817,6 +957,14 @@ class GameDataPage(ToolPageBase):
         self._mm_export_btn.setEnabled(False)
         self._mm_export_btn.clicked.connect(self._on_export_field_json)
         pv.addWidget(self._mm_export_btn)
+        # Gear-stat editor: opaque equipment records (armor/weapon) don't decode
+        # into grid columns, so their stats are edited via a per-record dialog
+        # that stages the same Format 3 edits. Shown only when the selected
+        # iteminfo row is an equipment record with located stats.
+        self._mm_gear_btn = PushButton("Edit gear stats…", pane)
+        self._mm_gear_btn.setVisible(False)
+        self._mm_gear_btn.clicked.connect(self._on_edit_gear_stats)
+        pv.addWidget(self._mm_gear_btn)
         split.addWidget(pane)
 
         split.setStretchFactor(0, 3)
@@ -835,6 +983,9 @@ class GameDataPage(ToolPageBase):
         self._pv_schema = None
         self._mm_editable_cols: dict = {}        # grid col index -> FieldSpec
         self._pending_edits: dict = {}           # (key, field) -> FieldEdit
+        # Located gear stats for the current table: {record_key: [(stat, val)]}.
+        # Populated only for iteminfo (opaque equipment records).
+        self._gear_stats: dict = {}
         # stretch=1 makes this row absorb the page's spare vertical space
         # (the base layout's trailing addStretch() has factor 0, so it yields).
         root.insertWidget(root.count() - 1, split, 1)
@@ -967,9 +1118,19 @@ class GameDataPage(ToolPageBase):
                 for t in tables)
         except Exception as ex:  # noqa: BLE001
             detail = f"(could not read tables: {ex})"
-        card = self._add_result_card("Largest keyed game-data tables", detail)
+        # Drop the fresh card into the info row's left column (next to the
+        # help boxes). Clear any prior card first so a rebuild replaces it.
+        from cdumm.gui.pages.tool_page import _ResultCard
+        while self._largest_col.count():
+            old = self._largest_col.takeAt(0)
+            w = old.widget()
+            if w is not None:
+                w.deleteLater()
+        card = _ResultCard(
+            "Largest keyed game-data tables", detail, "", self._container)
         card.setMaximumWidth(600)   # hug the content instead of spanning the page
-        self._results_layout.setAlignment(card, Qt.AlignLeft)
+        self._largest_col.addWidget(card)
+        self._largest_col.addStretch(1)
         # refresh the viewer if a search is active
         self._on_search(self._search.text())
 
@@ -1166,6 +1327,8 @@ class GameDataPage(ToolPageBase):
             self._pv_extract.setEnabled(True)
             self._enable_table_editing(
                 res.get("table", ""), res.get("cols", []))
+            self._gear_stats = res.get("gear_stats") or {}
+            self._update_gear_button()
             return
 
         if kind == "image":
@@ -1347,9 +1510,11 @@ class GameDataPage(ToolPageBase):
         self._pv_schema = None
         self._mm_editable_cols = {}
         self._pending_edits = {}
+        self._gear_stats = {}
         for w in (getattr(self, "_mm_status", None),
                   getattr(self, "_mm_make_btn", None),
-                  getattr(self, "_mm_export_btn", None)):
+                  getattr(self, "_mm_export_btn", None),
+                  getattr(self, "_mm_gear_btn", None)):
             if w is not None:
                 w.setVisible(False)
         grid = getattr(self, "_pv_grid", None)
@@ -1556,6 +1721,112 @@ class GameDataPage(ToolPageBase):
             f"Exported {len(self._pending_edits)} edit(s) to "
             f"{os.path.basename(path)}.", error=False)
 
+    # ── gear-stat editor (opaque equipment records) ──────────────────
+    def _selected_record_key(self) -> "int | None":
+        """The record key of the currently selected grid row (col 0), or None."""
+        grid = self._pv_grid
+        r = grid.currentRow()
+        if r < 0:
+            return None
+        it = grid.item(r, 0)
+        try:
+            return int(str(it.text()).strip()) if it else None
+        except (ValueError, AttributeError):
+            return None
+
+    def _update_gear_button(self) -> None:
+        """Show 'Edit gear stats…' only when the selected row is an equipment
+        record with located stats."""
+        btn = getattr(self, "_mm_gear_btn", None)
+        if btn is None:
+            return
+        key = self._selected_record_key()
+        has = bool(self._gear_stats) and key in self._gear_stats
+        btn.setVisible(has)
+
+    def _on_edit_gear_stats(self) -> None:
+        """Open a per-record dialog to edit the located gear stats, staging
+        each change as a ``gear_stat[<statkey>]`` Format 3 edit."""
+        key = self._selected_record_key()
+        located = self._gear_stats.get(key) if key is not None else None
+        if not located:
+            self._flash_maker("Select an equipment row first.", error=True)
+            return
+        grid = self._pv_grid
+        r = grid.currentRow()
+        name_item = grid.item(r, 1)
+        entry = name_item.text() if name_item else ""
+        # Dedupe by stat key: a gear_stat[key] edit resolves to the FIRST
+        # located entry with that key, so expose each key once (first value)
+        # to keep what's shown identical to what's written.
+        seen: dict[int, int] = {}
+        for stat, value in located:
+            if stat not in seen:
+                seen[stat] = value
+        edits = self._prompt_gear_stats(entry or f"record {key}", seen)
+        if not edits:
+            return
+        from cdumm.engine.format3_builder import FieldEdit
+        target = f"{self._pv_table}.pabgb"
+        for stat, (old, new) in edits.items():
+            field = f"gear_stat[{stat}]"
+            self._pending_edits[(key, field)] = FieldEdit(
+                target=target, entry=entry, key=key, field=field,
+                new=new, old=old)
+        self._refresh_maker_buttons()
+        self._flash_maker(
+            f"Staged {len(edits)} stat edit(s) for “{entry or key}”.",
+            error=False)
+
+    def _prompt_gear_stats(self, title: str, stats: "dict[int, int]"
+                           ) -> "dict[int, tuple[int, int]]":
+        """Modal editor for one record's stats. Returns
+        ``{stat_key: (old, new)}`` for values the user actually changed and
+        that fit a signed 64-bit int. Empty dict on cancel or no change."""
+        from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QFormLayout,
+                                       QLabel, QLineEdit, QVBoxLayout)
+        dlg = QDialog(self)
+        dlg.setWindowTitle(f"Edit gear stats — {title}")
+        outer = QVBoxLayout(dlg)
+        outer.addWidget(QLabel(
+            "Edit a stat's value (whole numbers). Blank or unchanged rows are "
+            "ignored.\nWrites are byte-exact, same-width overwrites."))
+        form = QFormLayout()
+        fields: dict[int, tuple[int, "QLineEdit"]] = {}
+        for stat, value in stats.items():
+            le = QLineEdit(str(value))
+            fields[stat] = (value, le)
+            form.addRow(f"stat {stat}", le)
+        outer.addLayout(form)
+        bb = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel)
+        bb.accepted.connect(dlg.accept)
+        bb.rejected.connect(dlg.reject)
+        outer.addWidget(bb)
+        if dlg.exec() != QDialog.DialogCode.Accepted:
+            return {}
+        out: dict[int, tuple[int, int]] = {}
+        for stat, (old, le) in fields.items():
+            txt = le.text().strip()
+            if not txt:
+                continue
+            try:
+                new = int(txt)
+            except ValueError:
+                self._flash_maker(
+                    f"“{txt}” isn't a whole number (stat {stat}) — skipped.",
+                    error=True)
+                continue
+            if not (-(2 ** 63) <= new < 2 ** 63):
+                self._flash_maker(
+                    f"Value for stat {stat} is out of range — skipped.",
+                    error=True)
+                continue
+            if new != old:
+                out[stat] = (old, new)
+        return out
+
     def _show_grid(self, cols: list, rows: list) -> None:
         self._pv_text.setVisible(False)
         self._pv_img_scroll.setVisible(False)
@@ -1691,13 +1962,52 @@ class GameDataPage(ToolPageBase):
         return wav
 
     def _on_play_audio(self) -> None:
+        """Decode the .wem off the UI thread (vgmstream is a subprocess and
+        froze the window if run inline), then play + show a live timer."""
         path = self._selected_path()
         if not path:
             return
-        wav = self._audio_wav(path)
-        if not wav:
-            return
+        self._play_token += 1
+        token = self._play_token
         name = self._preview_name or os.path.basename(path)
+        self._stop_playback()                 # halt any current sound + timer
+        self._pv_play_btn.setEnabled(False)
+        self._set_status(f"Decoding {name}…", "")
+        th = QThread(self)
+        w = _AudioDecodeWorker(
+            self._index_path,
+            str(self._game_dir) if self._game_dir else "",
+            path, self._preview_bytes, name, token)
+        w.moveToThread(th)
+        th.started.connect(w.run)
+        w.done.connect(self._on_audio_decoded)
+        w.done.connect(th.quit)
+        w.done.connect(w.deleteLater)
+        th.finished.connect(th.deleteLater)
+        job = (th, w)
+        self._pv_jobs.append(job)
+        th.finished.connect(
+            lambda job=job: job in self._pv_jobs and self._pv_jobs.remove(job))
+        th.start()
+
+    def _on_audio_decoded(self, res: dict) -> None:
+        if res.get("token") != self._play_token:
+            # a newer Play (or a different asset) superseded this — drop the
+            # stale temp WAV so decodes don't pile up in %TEMP%.
+            if res.get("wav"):
+                try:
+                    os.unlink(res["wav"])
+                except OSError:
+                    pass
+            return
+        self._pv_play_btn.setEnabled(True)
+        if res.get("error"):
+            self._set_status(res["error"], "#BF616A")
+            return
+        self._start_playback(
+            res.get("wav"), res.get("name", ""), res.get("dur", 0.0))
+
+    def _start_playback(self, wav: str, name: str, dur: float) -> None:
         try:                                   # winsound is Windows-only
             import winsound
             winsound.PlaySound(None, winsound.SND_PURGE)      # stop any prior
@@ -1705,31 +2015,45 @@ class GameDataPage(ToolPageBase):
         except Exception as ex:  # noqa: BLE001
             self._set_status(f"Playback failed: {ex}", "#BF616A")
             return
-        # Read the decoded WAV's real length so we can flip the status back
-        # to "finished" live when it ends (winsound gives no end callback).
-        dur = 0.0
-        try:
-            import contextlib
-            import wave
-            with contextlib.closing(wave.open(wav, "rb")) as w:
-                if w.getframerate():
-                    dur = w.getnframes() / float(w.getframerate())
-        except Exception:  # noqa: BLE001
-            pass
-        self._play_token += 1
-        token = self._play_token
-        tag = f"  ({dur:.1f}s)" if dur else ""
-        self._set_status(f"▶ Playing: {name}{tag}", "#2E7D32")
-        if dur > 0:
-            from PySide6.QtCore import QTimer
-            QTimer.singleShot(
-                int(dur * 1000) + 150,
-                lambda t=token, n=name: self._on_play_finished(t, n))
+        import time
+        from PySide6.QtCore import QTimer
+        self._play_name = name
+        self._play_dur = float(dur or 0.0)
+        self._play_started = time.monotonic()
+        if getattr(self, "_play_timer", None) is None:
+            self._play_timer = QTimer(self)
+            self._play_timer.setInterval(200)   # live countdown, 5×/second
+            self._play_timer.timeout.connect(self._tick_play)
+        self._play_timer.start()
+        self._tick_play()                       # paint the timer immediately
         # temp WAV is left for the async player; the OS reclaims %TEMP%.
 
-    def _on_play_finished(self, token: int, name: str) -> None:
-        if token == self._play_token:      # not superseded by a newer Play
+    def _tick_play(self) -> None:
+        import time
+        dur = getattr(self, "_play_dur", 0.0)
+        name = getattr(self, "_play_name", "")
+        elapsed = time.monotonic() - getattr(
+            self, "_play_started", time.monotonic())
+        if dur and elapsed >= dur:
+            self._stop_playback()
             self._set_status(f"Finished: {name}", "")
+            return
+        if dur:
+            self._set_status(
+                f"▶ {name}   {elapsed:0.1f} / {dur:0.1f}s", "#2E7D32")
+        else:
+            self._set_status(f"▶ {name}   {elapsed:0.1f}s", "#2E7D32")
+
+    def _stop_playback(self) -> None:
+        """Stop the async sound + the live timer (new Play, or playback end)."""
+        t = getattr(self, "_play_timer", None)
+        if t is not None:
+            t.stop()
+        try:
+            import winsound
+            winsound.PlaySound(None, winsound.SND_PURGE)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _on_export_wav(self) -> None:
         path = self._selected_path()

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import os
 import sqlite3
 import subprocess
-import sys
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
@@ -1490,12 +1489,7 @@ class GameDataPage(ToolPageBase):
         self._pv_img_scroll.setVisible(True)
         self._pv_qimage = QImage.fromData(png, "PNG") if png else None
         _has_img = self._pv_qimage is not None and not self._pv_qimage.isNull()
-        # The Qt3D texture 3D preview hard-crashes the *packaged* build (native
-        # Qt3D/OpenGL COM crash that no Python guard can catch — module, DLLs,
-        # render plugins and deferred creation all bundled/tried, still
-        # crashes). It's a minor extra on top of the 2D preview, so hide it in
-        # frozen builds; devs running from source keep it.
-        self._pv_3d_btn.setVisible(_has_img and not getattr(sys, "frozen", False))
+        self._pv_3d_btn.setVisible(_has_img)
         self._pv_saveimg_btn.setVisible(_has_img)
         pm = QPixmap()
         if png:

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import subprocess
+import sys
 import tempfile
 
 from PySide6.QtCore import QObject, Qt, QThread, Signal
@@ -1489,7 +1490,12 @@ class GameDataPage(ToolPageBase):
         self._pv_img_scroll.setVisible(True)
         self._pv_qimage = QImage.fromData(png, "PNG") if png else None
         _has_img = self._pv_qimage is not None and not self._pv_qimage.isNull()
-        self._pv_3d_btn.setVisible(_has_img)
+        # The Qt3D texture 3D preview hard-crashes the *packaged* build (native
+        # Qt3D/OpenGL COM crash that no Python guard can catch — module, DLLs,
+        # render plugins and deferred creation all bundled/tried, still
+        # crashes). It's a minor extra on top of the 2D preview, so hide it in
+        # frozen builds; devs running from source keep it.
+        self._pv_3d_btn.setVisible(_has_img and not getattr(sys, "frozen", False))
         self._pv_saveimg_btn.setVisible(_has_img)
         pm = QPixmap()
         if png:

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -680,6 +680,31 @@ def parse_records_display(table_name: str, body_bytes: bytes,
     return records
 
 
+def record_raw_bytes(table_name: str, body_bytes: bytes, header_bytes: bytes
+                     ) -> dict[int, bytes]:
+    """Return ``{record_key: raw entry bytes}`` for a PABGB table.
+
+    Same record boundaries the parsers use (sorted PABGH offsets), but hands
+    back the untouched bytes of each entry. Used by the gear-stat editor, which
+    locates + edits stats structurally inside the opaque equipment records that
+    the field decoder carries raw. Empty dict if the schema/index is missing.
+    """
+    if get_schema(table_name) is None:
+        return {}
+    _key_size, offsets = parse_pabgh_index(header_bytes, table_name)
+    if not offsets:
+        return {}
+    sorted_entries = sorted(offsets.items(), key=lambda x: x[1])
+    out: dict[int, bytes] = {}
+    for idx, (key, entry_offset) in enumerate(sorted_entries):
+        entry_end = (sorted_entries[idx + 1][1]
+                     if idx + 1 < len(sorted_entries) else len(body_bytes))
+        if entry_offset >= len(body_bytes):
+            continue
+        out[key] = body_bytes[entry_offset:entry_end]
+    return out
+
+
 def identify_table_from_path(entry_path: str) -> str | None:
     """Extract table name from a PAMT entry path.
 

--- a/tests/test_format3_binary_roundtrip.py
+++ b/tests/test_format3_binary_roundtrip.py
@@ -119,6 +119,25 @@ def test_synth_bytes_parse_correctly(synth_schema):
     assert records[200]["_foo"] == 0xBBBB2222
 
 
+# ── record_raw_bytes — per-record slices for the gear-stat editor ───
+
+
+def test_record_raw_bytes_returns_exact_entry_slices(synth_schema):
+    from cdumm.semantic.parser import record_raw_bytes
+    entries = [
+        (1, "First", 100, 0xAAAA1111, 0x55),
+        (2, "Second", 200, 0xBBBB2222, 0x66),
+    ]
+    body, header = _build_pabgb_pair(entries)
+    raw = record_raw_bytes("synthtest", body, header)
+    assert set(raw) == {100, 200}
+    # each slice is byte-identical to the entry that was written
+    assert raw[100] == _build_entry(1, "First", 100, 0xAAAA1111, 0x55)
+    assert raw[200] == _build_entry(2, "Second", 200, 0xBBBB2222, 0x66)
+    # concatenated in offset order they reconstruct the whole body
+    assert raw[100] + raw[200] == body
+
+
 # ── apply_intents_to_pabgb_bytes — direct byte-level writer ─────────
 
 

--- a/tests/test_gear_stats.py
+++ b/tests/test_gear_stats.py
@@ -1,0 +1,145 @@
+"""Locate + byte-exact edit of gear stats in opaque iteminfo records.
+
+Synthetic fixtures only (CI-runnable, no game data). The whole-table live
+verification (adaptive whitelist -> locate -> edit -> byte-exact on the 3,341
+opaque 1.13 gear records) is recorded in the PR; these pin the engine's
+locate/precision/edit invariants.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.gear_stats import (
+    GearStat,
+    apply_stat_edit,
+    build_stat_whitelist,
+    edit_record_stats,
+    locate_gear_stats,
+)
+
+
+def _list_i64(entries):
+    b = struct.pack("<I", len(entries))
+    for s, v in entries:
+        b += struct.pack("<Iq", s, v)
+    return b
+
+
+def _list_i8(entries):
+    b = struct.pack("<I", len(entries))
+    for s, v in entries:
+        b += struct.pack("<Ib", s, v)
+    return b
+
+
+def _esd(maxl, regen, static, lvl):
+    # EnchantStatData = 3 i64 carrays + 1 i8 carray
+    return _list_i64(maxl) + _list_i64(regen) + _list_i64(static) + _list_i8(lvl)
+
+
+WL = frozenset({1000002, 1000003, 1000005})
+
+
+# --- locate ---------------------------------------------------------------
+
+def test_locate_finds_whitelisted_static_stats():
+    block = _esd([], [], [(1000002, 1000), (1000003, 0)], [(1000005, 3)])
+    rec = b"\xAA" * 40 + block + b"\xBB" * 40
+    stats = locate_gear_stats(rec, WL)
+    # only the three i64 lists are editable; the i8 level list is not exposed
+    assert [(g.stat, g.value) for g in stats] == [(1000002, 1000), (1000003, 0)]
+    # value_offset points exactly at the i64 value
+    assert struct.unpack_from("<q", rec, stats[0].value_offset)[0] == 1000
+    assert struct.unpack_from("<q", rec, stats[1].value_offset)[0] == 0
+
+
+def test_block_with_unwhitelisted_stat_is_ignored():
+    # 424242 is not in the whitelist -> the whole block is refused (no guessing)
+    block = _esd([], [], [(1000002, 1000), (424242, 7)], [])
+    rec = b"\x00" * 20 + block + b"\x00" * 20
+    assert locate_gear_stats(rec, WL) == []
+
+
+def test_no_stats_in_plain_bytes():
+    # random-ish non-stat bytes -> nothing located
+    rec = bytes((i * 37) % 256 for i in range(300))
+    assert locate_gear_stats(rec, WL) == []
+
+
+def test_multiple_blocks_located_in_order():
+    b1 = _esd([], [], [(1000002, 111)], [])
+    b2 = _esd([], [], [(1000005, 222)], [])
+    rec = b"\x00" * 8 + b1 + b"\x00" * 8 + b2 + b"\x00" * 8
+    stats = locate_gear_stats(rec, WL)
+    assert [(g.stat, g.value) for g in stats] == [(1000002, 111), (1000005, 222)]
+
+
+# --- adaptive whitelist ---------------------------------------------------
+
+def test_whitelist_keeps_recurring_keys_drops_rare_ones():
+    # stat 1000002 appears 12x, 1000003 10x -> kept; 555000 once -> dropped
+    recs = [_esd([], [], [(1000002, 1), (1000003, 1)], []) for _ in range(10)]
+    recs += [_esd([], [], [(1000002, 1)], []) for _ in range(2)]
+    recs.append(_esd([], [], [(555000, 9)], []))
+    wl = build_stat_whitelist(recs, min_freq=10)
+    assert 1000002 in wl and 1000003 in wl
+    assert 555000 not in wl
+
+
+# --- edit is byte-exact ---------------------------------------------------
+
+def test_apply_stat_edit_is_same_width_byte_exact():
+    block = _esd([], [], [(1000002, 1000)], [])
+    rec = b"\xAA" * 32 + block + b"\xBB" * 32
+    g = locate_gear_stats(rec, WL)[0]
+    out = apply_stat_edit(rec, g.value_offset, 999_999)
+    assert len(out) == len(rec)                       # never shifts
+    diff = [i for i in range(len(rec)) if rec[i] != out[i]]
+    assert all(g.value_offset <= i < g.value_offset + 8 for i in diff)
+    assert struct.unpack_from("<q", out, g.value_offset)[0] == 999_999
+    # everything outside the 8-byte value is identical
+    assert out[:g.value_offset] == rec[:g.value_offset]
+    assert out[g.value_offset + 8:] == rec[g.value_offset + 8:]
+
+
+def test_apply_then_relocate_sees_new_value():
+    block = _esd([], [], [(1000002, 5)], [])
+    rec = b"\x00" * 16 + block + b"\x00" * 16
+    g = locate_gear_stats(rec, WL)[0]
+    out = apply_stat_edit(rec, g.value_offset, -4200)
+    g2 = locate_gear_stats(out, WL)[0]
+    assert g2.stat == 1000002 and g2.value == -4200
+
+
+def test_apply_rejects_out_of_range_offset():
+    rec = b"\x00" * 20
+    with pytest.raises(ValueError):
+        apply_stat_edit(rec, 15, 1)          # 15+8 > 20
+
+
+def test_apply_rejects_oversized_value():
+    block = _esd([], [], [(1000002, 5)], [])
+    rec = b"\x00" * 8 + block
+    g = locate_gear_stats(rec, WL)[0]
+    with pytest.raises(ValueError):
+        apply_stat_edit(rec, g.value_offset, 2 ** 63)   # doesn't fit i64
+
+
+# --- multi-edit convenience -----------------------------------------------
+
+def test_edit_record_stats_composes_multiple_edits():
+    block = _esd([], [], [(1000002, 100), (1000003, 200)], [])
+    rec = b"\xAA" * 24 + block + b"\xBB" * 24
+    out = edit_record_stats(rec, {0: 5000, 1: -1}, WL)
+    assert len(out) == len(rec)
+    stats = locate_gear_stats(out, WL)
+    assert [(g.stat, g.value) for g in stats] == [(1000002, 5000), (1000003, -1)]
+
+
+def test_edit_record_stats_bad_index_raises():
+    block = _esd([], [], [(1000002, 1)], [])
+    rec = b"\x00" * 12 + block
+    with pytest.raises(KeyError):
+        edit_record_stats(rec, {5: 1}, WL)

--- a/tests/test_gear_stats.py
+++ b/tests/test_gear_stats.py
@@ -16,7 +16,9 @@ from cdumm.engine.gear_stats import (
     apply_stat_edit,
     build_stat_whitelist,
     edit_record_stats,
+    is_gear_stat_field,
     locate_gear_stats,
+    resolve_gear_stat_index,
 )
 
 
@@ -143,3 +145,24 @@ def test_edit_record_stats_bad_index_raises():
     rec = b"\x00" * 12 + block
     with pytest.raises(KeyError):
         edit_record_stats(rec, {5: 1}, WL)
+
+
+# --- Format 3 field addressing --------------------------------------------
+
+def test_is_gear_stat_field():
+    assert is_gear_stat_field("gear_stat[1000002]")
+    assert is_gear_stat_field("gear_stat[0]")
+    assert not is_gear_stat_field("price_list[0].price.price")
+    assert not is_gear_stat_field("gear_stat")
+    assert not is_gear_stat_field("")
+
+
+def test_resolve_by_stat_key_and_by_index():
+    located = [GearStat(1000002, 10, 100), GearStat(1000003, 20, 200)]
+    # big number -> stat key (first match)
+    assert resolve_gear_stat_index("gear_stat[1000003]", located) == 1
+    # small number -> positional index
+    assert resolve_gear_stat_index("gear_stat[0]", located) == 0
+    # unknown stat key / out-of-range index -> None
+    assert resolve_gear_stat_index("gear_stat[1099999]", located) is None
+    assert resolve_gear_stat_index("gear_stat[9]", located) is None

--- a/tests/test_gear_stats.py
+++ b/tests/test_gear_stats.py
@@ -17,6 +17,7 @@ from cdumm.engine.gear_stats import (
     build_stat_whitelist,
     edit_record_stats,
     is_gear_stat_field,
+    locate_all_gear_stats,
     locate_gear_stats,
     resolve_gear_stat_index,
 )
@@ -166,3 +167,26 @@ def test_resolve_by_stat_key_and_by_index():
     # unknown stat key / out-of-range index -> None
     assert resolve_gear_stat_index("gear_stat[1099999]", located) is None
     assert resolve_gear_stat_index("gear_stat[9]", located) is None
+
+
+# --- whole-table locate (GUI feed) ----------------------------------------
+
+def test_locate_all_builds_whitelist_and_maps_records():
+    # 1000002 recurs 10x across gear records -> whitelisted; a lone junk key
+    # in a non-gear record is dropped, so that record surfaces no stats.
+    gear = {}
+    for i in range(10):
+        blk = _esd([], [], [(1000002, 100 + i)], [])
+        gear[i] = b"\x00" * 8 + blk + b"\x00" * 8
+    gear[999] = b"\x11" * 64  # no stat block at all
+    got = locate_all_gear_stats(gear, min_freq=10)
+    assert set(got) == set(range(10))            # only records with stats
+    assert 999 not in got
+    assert [(g.stat, g.value) for g in got[3]] == [(1000002, 103)]
+
+
+def test_locate_all_empty_when_nothing_recurs():
+    # every candidate key is unique -> whitelist empty -> no records returned
+    recs = {i: b"\x00" * 8 + _esd([], [], [(1000000 + i, i)], [])
+            for i in range(5)}
+    assert locate_all_gear_stats(recs, min_freq=10) == {}


### PR DESCRIPTION
Adds the ability to read and edit **gear stats** — armor defense, weapon damage, and the AbyssGear enhancement values — which are currently unmoddable in CDUMM. This is the single most-requested Crimson Desert modding capability and the main reason people reach for DMM.

### The problem
On CD 1.13 the *equipment* iteminfo record tail is a distinct, variable layout the whole-record parser doesn't model, so those **3,341 gear records are carried `_opaque_record`** (byte-exact, but no decoded fields → nothing to edit). The stats live inside `EnchantStatData` blocks in that tail: carrays of `EnchantStatChange {stat: u32, value: i64}`.

### The approach
You don't need to decode the whole record to edit a stat. `gear_stats.py`:

1. **Locates** `EnchantStatData` blocks structurally (four consecutive carrays), and
2. gates each block with a **whitelist of stat keys derived adaptively from the table itself** (keys that recur ≥10× across the opaque records). Real stat keys recur in the thousands; a coincidental byte pattern almost never hits a specific high-frequency key. No game-version constant is baked in — it self-adjusts if the game shifts.
3. **Edits** a value as a **same-width `i64` overwrite** → byte-exact, the record length and companion `.pabgh` index never change. Same safety property as the item-price writer.

### Verification
Live against the installed 1.13 `iteminfo` (6,508 records, 3,341 opaque):

- stats located in **3,313 / 3,341 (99%)** gear records — **21,387** editable stats
- **3,313 / 3,313** same-width edits round-trip **byte-exact** (0 collateral)
- AbyssGear DDD items decode cleanly: LV1 = 1000, LV2 = 2000, LV3 = 3000
- 0 false positives on decoded (non-gear) records under the intended opaque-only scope

**11 CI tests** (`tests/test_gear_stats.py`, synthetic fixtures, no game data) pin the locate/precision/edit invariants.

### Scope
This PR is the **engine** (locate + adaptive whitelist + byte-exact editor) — self-contained, no coupling to the native parser, CI-testable. The natural follow-ups, kept separate for reviewability:

- wire the located stats into the **Format 3 apply path** for opaque iteminfo records (a gear-stat intent → `edit_record_stats` → byte-exact), so `.field.json` gear mods apply; and
- surface them in the **Game Data tab mod maker** as editable cells.

The enchant-struct field names follow the existing `crimson-rs` lineage already in the iteminfo parser (`_read_EnchantStatData` etc.).

---

### Update: now wired end-to-end (applies through Format 3)

Follow-up commit adds the apply integration so gear-stat mods actually work, not just the library:

- `gear_stat[<statkey>]` is the Format 3 field address (e.g. `gear_stat[1000002]`). The number is a **stat key** (first match — "set defense to X") when it's in the stat band, else a positional index.
- `format3_handler` early-accepts `gear_stat[...]` for iteminfo, so mods **validate** (supported, not skipped).
- the iteminfo writer's opaque-record path **locates the stat and overwrites the i64 same-width** → byte-exact; the adaptive whitelist is built lazily only when a gear-stat intent is present.

**Verified live 1.13 end-to-end:** a mod setting `gear_stat[1000002] → 99999` on the AbyssGear DDD item validates (supported = 1) and applies **byte-exact** — 3 bytes changed (the i64 delta), **0 collateral records**, no `.pabgh` rewrite. **280 format3/iteminfo tests pass; 13 gear_stats CI tests.**

So a `.field.json` like this now imports + applies in CDUMM:
```json
{ "format": 3, "targets": [ { "file": "iteminfo.pabgb",
  "intents": [ { "entry": "Item_Stat_AbyssGear_DDD_LV1", "key": 1002785,
                 "field": "gear_stat[1000002]", "op": "set", "new": 99999 } ] } ] }
```

Remaining follow-up: surface located stats in the Game Data tab mod maker as editable cells (GUI only — the engine + apply are done here).

---

### Also in this branch (Game Data tab + packaging — added while iterating)

Beyond the gear-stat engine + apply, this branch also carries the Game Data tab work and the packaging fixes that make the shipped exe correct:

**Game Data tab**
- **Gear-stat editor GUI** — the located stats surface as editable cells that emit `gear_stat[key]` Format 3 intents.
- **Off-thread audio** decode with a live countdown timer (fixes the UI freeze + frozen timer when playing `.wem` audio).
- Help/how-to layout: the modding-help dropdown beside the largest-keyed tables, plus a "how to make a mod from game data" box.

**Packaging / previews (shipped-build correctness)**
- Bundle **Pillow** so DDS texture previews decode in frozen builds.
- `strip=(os.name != 'nt')` — `strip=True` corrupted `python313.dll` on Windows CI (exe would not launch).
- Bundle **Qt3D** + `Qt6Network` + `Qt6ShaderTools.dll` so the texture **3D preview** works when frozen (RHI/DirectX backend); defer the 3D window creation to avoid a COM input-sync crash; hide it where it cannot run.
- Strip the confirmed-unused `opengl32sw.dll` to slim the exe.