### PR TITLE
fix(crash-report): preserve crash trace across relaunch + surface native faults

### DIFF
--- a/src/cdumm/gui/bug_report.py
+++ b/src/cdumm/gui/bug_report.py
@@ -385,6 +385,132 @@ def _exe_info(exe_path: Path) -> str:
         return f"{exe_path} (error: {e})"
 
 
+# ── Crash-trace parsing / GPU diagnostics ──────────────────────────────
+
+# faulthandler headline prefixes that indicate a *native* fault: the
+# crash is in C/C++ code and the Python frames it prints may be unrelated
+# to the actual fault. Matched case-insensitively against the first
+# non-empty line of the trace.
+_NATIVE_CRASH_MARKERS = (
+    "windows fatal exception",   # access violation, stack overflow, ...
+    "segmentation fault",
+    "bus error",
+    "illegal instruction",
+    "fatal python error: aborted",
+)
+
+
+def _crash_trace_candidates(app_data_dir: Path) -> list[tuple[str, Path]]:
+    """Return (label, path) crash-trace sources in priority order.
+
+    The preserved ``crash_trace.prev.txt`` (moved aside by main.py's
+    ``_preserve_prior_crash_trace`` at the next startup) is the real
+    previous-session trace and comes first. ``crash_trace.txt`` is only
+    non-empty when faulthandler dumped *and* the process survived long
+    enough to report in the same session — a rare fallback.
+    """
+    return [
+        ("previous session", app_data_dir / "crash_trace.prev.txt"),
+        ("this session", app_data_dir / "crash_trace.txt"),
+    ]
+
+
+def _parse_crash_headline(trace_text: str) -> tuple[str, bool]:
+    """Extract the crash headline and whether it is a native fault.
+
+    faulthandler writes the fault class on the first line, e.g.
+    ``Windows fatal exception: access violation`` or
+    ``Fatal Python error: Segmentation fault``. Returns
+    ``(headline, is_native)``; ``headline`` is "" if none could be read.
+    """
+    headline = ""
+    for line in trace_text.splitlines():
+        s = line.strip()
+        if s:
+            headline = s
+            break
+    low = headline.lower()
+    is_native = any(m in low for m in _NATIVE_CRASH_MARKERS)
+    return headline, is_native
+
+
+def _windows_gpu_adapters() -> list[tuple[str, str]]:
+    """Read installed display adapters (name, driver version) from the
+    Windows registry — no GL context, no subprocess.
+
+    Spinning up an OpenGL/D3D context to query the live GPU would risk
+    crashing the crash reporter itself on a machine whose GPU driver is
+    the very thing that just faulted. The registry's Display-adapter
+    class key is a safe, static source. Returns [] on non-Windows or on
+    any failure.
+    """
+    if not IS_WINDOWS:
+        return []
+    adapters: list[tuple[str, str]] = []
+    try:
+        import winreg
+        class_key = (r"SYSTEM\CurrentControlSet\Control\Class"
+                     r"\{4d36e968-e325-11ce-bfc1-08002be10318}")
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, class_key) as root:
+            i = 0
+            while True:
+                try:
+                    sub = winreg.EnumKey(root, i)
+                except OSError:
+                    break
+                i += 1
+                # Adapter instances are 4-digit keys (0000, 0001, ...);
+                # skip 'Properties' and 'Configuration' sibling keys.
+                if not (len(sub) == 4 and sub.isdigit()):
+                    continue
+                try:
+                    with winreg.OpenKey(root, sub) as ak:
+                        name, _ = winreg.QueryValueEx(ak, "DriverDesc")
+                        try:
+                            drv, _ = winreg.QueryValueEx(ak, "DriverVersion")
+                        except OSError:
+                            drv = "?"
+                    adapters.append((str(name), str(drv)))
+                except OSError:
+                    continue
+    except Exception:
+        return adapters
+    return adapters
+
+
+def _renderer_diagnostics() -> list[str]:
+    """Safe GPU / Qt-render diagnostics for the SYSTEM section.
+
+    Captures the Qt version, active QPA platform plugin, the RHI backend
+    override (if the user set one), and the installed GPU adapter(s).
+    Render-stack faults (Qt3D preview, DDS texture decode) are the most
+    common native crashes, so this makes them actionable. Every lookup is
+    read-only and cannot spawn a graphics context.
+    """
+    lines: list[str] = []
+    try:
+        from PySide6.QtCore import qVersion
+        lines.append(f"Qt Version: {qVersion()}")
+    except Exception:
+        pass
+    try:
+        app = QApplication.instance()
+        if app is not None:
+            lines.append(f"Qt Platform Plugin: {app.platformName()}")
+    except Exception:
+        pass
+    rhi = os.environ.get("QSG_RHI_BACKEND")
+    if rhi:
+        lines.append(f"QSG_RHI_BACKEND (env override): {rhi}")
+    adapters = _windows_gpu_adapters()
+    if adapters:
+        for name, drv in adapters:
+            lines.append(f"GPU: {name} (driver {drv})")
+    elif IS_WINDOWS:
+        lines.append("GPU: (not detected)")
+    return lines
+
+
 def generate_bug_report(db: Database | None, game_dir: Path | None,
                         app_data_dir: Path | None) -> str:
     """Build a structured bug report for user-facing diagnostics."""
@@ -459,6 +585,10 @@ def generate_bug_report(db: Database | None, game_dir: Path | None,
         except Exception:
             pass
         body.append(f"App Data Drive Free: {_disk_free(app_data_dir)}")
+    # Renderer / GPU — render-stack faults are the most common native
+    # crashes (Qt3D preview, DDS decode); capture the stack safely.
+    for _rline in _renderer_diagnostics():
+        body.append(_rline)
     body.append("")
 
     # ── Storage ────────────────────────────────────────────────────────
@@ -874,35 +1004,53 @@ def generate_bug_report(db: Database | None, game_dir: Path | None,
             body.append("  (log file not found)")
     body.append("")
 
-    # ── Crash trace (if last session actually recorded a trace) ───────
-    # We only emit this section and flag it in the TL;DR when the trace
-    # file exists AND has non-whitespace content — an empty file left over
-    # from a previous session shouldn't claim there was a crash.
+    # ── Crash trace (if a recent session actually recorded a trace) ────
+    # main.py preserves the previous session's faulthandler dump as
+    # crash_trace.prev.txt at the next startup (the live crash_trace.txt
+    # is truncated on every launch), so a real hard crash survives to be
+    # reported here. We only emit the section — and flag it in the TL;DR —
+    # when a candidate trace exists AND has non-whitespace content. The
+    # preserved previous-session trace takes priority over any same-session
+    # dump; the first candidate with content wins and we stop.
     if app_data_dir:
-        trace_path = app_data_dir / "crash_trace.txt"
-        if trace_path.exists():
+        for _src_label, trace_path in _crash_trace_candidates(app_data_dir):
+            if not trace_path.exists():
+                continue
             try:
                 text = trace_path.read_text(encoding="utf-8", errors="replace")
             except Exception as e:
-                text = ""
-                body.append("--- CRASH TRACE (previous session) ---")
-                body.append(f"  Error reading crash trace: {e}")
+                body.append("--- CRASH TRACE ---")
+                body.append(f"  Error reading {trace_path.name}: {e}")
                 body.append("")
                 tldr_flags.append(
-                    "crash_trace.txt exists but couldn't be read — check "
+                    f"{trace_path.name} exists but couldn't be read — check "
                     "file permissions on the CDUMM app-data folder.")
-            else:
-                if text.strip():
-                    tldr_flags.append(
-                        "Previous session crashed — crash trace is included "
-                        "at the bottom of this report.")
-                    body.append("--- CRASH TRACE (previous session) ---")
-                    if len(text) > 4000:
-                        text = text[-4000:]
-                        body.append("  (truncated — showing last 4000 chars)")
-                    for ll in text.splitlines():
-                        body.append(f"  {ll}")
-                    body.append("")
+                continue
+            if not text.strip():
+                continue
+            headline, is_native = _parse_crash_headline(text)
+            flag = f"Crash detected ({_src_label})"
+            if headline:
+                flag += f": {headline}"
+            if is_native:
+                flag += (" — native fault, so the Python frames in the trace "
+                         "may be unrelated to the real (C/C++) crash site")
+            flag += ". Full trace at the bottom of this report."
+            tldr_flags.append(flag)
+            body.append(f"--- CRASH TRACE ({_src_label}) ---")
+            if is_native:
+                body.append(
+                    "  NOTE: native fault — faulthandler can only print Python "
+                    "frames, which may be unrelated to the actual crash in "
+                    "C/C++ code. Treat the fault type on the first line as the "
+                    "primary signal (e.g. a GPU/driver fault in a render call).")
+            if len(text) > 4000:
+                text = text[-4000:]
+                body.append("  (truncated — showing last 4000 chars)")
+            for ll in text.splitlines():
+                body.append(f"  {ll}")
+            body.append("")
+            break
 
     # ── Assemble header + TL;DR + body ────────────────────────────────
     out: list[str] = []

--- a/src/cdumm/main.py
+++ b/src/cdumm/main.py
@@ -11,6 +11,31 @@ from cdumm.platform import IS_LINUX, IS_WINDOWS, app_data_dir
 
 APP_DATA_DIR = app_data_dir()
 
+
+def _preserve_prior_crash_trace(trace_path: Path) -> None:
+    """Move a previous session's crash trace aside before it is truncated.
+
+    faulthandler keeps ``trace_path`` open for the whole session and
+    rewrites it at fault time, so opening it ``"w"`` at startup wipes
+    whatever the PREVIOUS session's fatal fault recorded. Without this
+    rename the "CRASH TRACE (previous session)" bug-report section could
+    never fire for a real hard crash: the relaunch destroyed the evidence
+    before the user could generate a report. Move any non-empty prior
+    trace to ``<name>.prev<suffix>`` so it survives into the next session,
+    where the user actually clicks "generate bug report".
+
+    Best-effort: never raises, so a locked or unwritable file can't block
+    boot. ``os.replace`` overwrites an older ``.prev`` copy, so we always
+    keep the most recent previous session's trace.
+    """
+    try:
+        if trace_path.is_file() and trace_path.stat().st_size > 0:
+            os.replace(trace_path, trace_path.with_name(
+                trace_path.stem + ".prev" + trace_path.suffix))
+    except Exception:
+        pass
+
+
 # Enable faulthandler to dump C-level stack trace on segfault.
 # Defensive: if AppData is read-only / permissions fail (domolinixd1000
 # report: CDUMM.exe closes in 2-3s, can't even produce a bug report),
@@ -20,6 +45,7 @@ APP_DATA_DIR = app_data_dir()
 _fault_log = None
 try:
     APP_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    _preserve_prior_crash_trace(APP_DATA_DIR / "crash_trace.txt")
     _fault_log = open(APP_DATA_DIR / "crash_trace.txt", "w")
     faulthandler.enable(file=_fault_log)
 except Exception:
@@ -28,8 +54,9 @@ except Exception:
     # breaks Python's stdlib open on some Windows configs.
     try:
         import tempfile as _tempfile
-        _fault_log = open(
-            Path(_tempfile.gettempdir()) / "cdumm_crash_trace.txt", "w")
+        _tmp_trace = Path(_tempfile.gettempdir()) / "cdumm_crash_trace.txt"
+        _preserve_prior_crash_trace(_tmp_trace)
+        _fault_log = open(_tmp_trace, "w")
         faulthandler.enable(file=_fault_log)
     except Exception:
         try:

--- a/tests/test_crash_report.py
+++ b/tests/test_crash_report.py
@@ -1,0 +1,199 @@
+"""Crash-report generator hardening.
+
+Covers the four improvements to the crash/bug-report path:
+
+  1. Trace survival — main.py preserves the previous session's
+     faulthandler dump (``crash_trace.txt`` -> ``crash_trace.prev.txt``)
+     BEFORE truncating it on the next launch. Without this the whole
+     "CRASH TRACE (previous session)" section was dead for real hard
+     crashes: the relaunch wiped the evidence before the user could ever
+     generate a report.
+  2. Crash-type headline — the faulthandler fault class (e.g. "Windows
+     fatal exception: access violation") is surfaced in the TL;DR.
+  3. Native-vs-Python flag — native faults are labelled so triagers know
+     the Python frames may be unrelated to the real C/C++ crash site
+     (the misleading ``splash.py`` trace on the Qt3D crash).
+  4. GPU / Qt render diagnostics — safe, registry-only adapter capture.
+"""
+from __future__ import annotations
+
+
+# faulthandler dump samples (exact first-line formats CPython emits).
+WIN_AV = (
+    "Windows fatal exception: access violation\n"
+    "\n"
+    "Current thread 0x00001234 (most recent call first):\n"
+    '  File "splash.py", line 76 in show_splash\n'
+)
+SEGFAULT = (
+    "Fatal Python error: Segmentation fault\n"
+    "\n"
+    "Current thread 0x00007f00 (most recent call first):\n"
+    '  File "viewer.py", line 12 in render\n'
+)
+PY_TRACEBACK = (
+    "\n\n"
+    "Traceback (most recent call last):\n"
+    '  File "engine.py", line 40 in apply\n'
+    "ValueError: boom\n"
+)
+
+
+# ── 1. Trace survival (cdumm.main._preserve_prior_crash_trace) ──────────
+
+
+def test_preserve_prior_crash_trace_moves_nonempty(tmp_path):
+    from cdumm import main as cdumm_main
+
+    trace = tmp_path / "crash_trace.txt"
+    trace.write_text(WIN_AV, encoding="utf-8")
+
+    cdumm_main._preserve_prior_crash_trace(trace)
+
+    prev = tmp_path / "crash_trace.prev.txt"
+    assert prev.exists(), "non-empty trace must be preserved for the next session"
+    assert "access violation" in prev.read_text(encoding="utf-8")
+    assert not trace.exists(), "trace must be MOVED (renamed), not copied"
+
+
+def test_preserve_prior_crash_trace_skips_empty(tmp_path):
+    """An empty file left over from a clean run isn't a crash — don't
+    preserve it (it must not later claim a crash happened)."""
+    from cdumm import main as cdumm_main
+
+    trace = tmp_path / "crash_trace.txt"
+    trace.write_text("", encoding="utf-8")
+
+    cdumm_main._preserve_prior_crash_trace(trace)
+
+    assert not (tmp_path / "crash_trace.prev.txt").exists()
+    assert trace.exists(), "empty trace is left in place, not moved"
+
+
+def test_preserve_prior_crash_trace_missing_is_noop(tmp_path):
+    from cdumm import main as cdumm_main
+
+    trace = tmp_path / "crash_trace.txt"
+    cdumm_main._preserve_prior_crash_trace(trace)  # must not raise
+
+    assert not (tmp_path / "crash_trace.prev.txt").exists()
+
+
+def test_preserve_prior_crash_trace_keeps_most_recent(tmp_path):
+    """A second crash before the report is read overwrites the older
+    preserved copy — we keep the most recent previous session."""
+    from cdumm import main as cdumm_main
+
+    prev = tmp_path / "crash_trace.prev.txt"
+    prev.write_text("OLD trace from two sessions ago", encoding="utf-8")
+    trace = tmp_path / "crash_trace.txt"
+    trace.write_text("NEW trace from last session", encoding="utf-8")
+
+    cdumm_main._preserve_prior_crash_trace(trace)
+
+    assert prev.read_text(encoding="utf-8") == "NEW trace from last session"
+
+
+# ── 2 + 3. Headline extraction / native-fault detection ─────────────────
+
+
+def test_parse_headline_windows_access_violation():
+    from cdumm.gui.bug_report import _parse_crash_headline
+
+    headline, native = _parse_crash_headline(WIN_AV)
+    assert headline == "Windows fatal exception: access violation"
+    assert native is True
+
+
+def test_parse_headline_segfault_is_native():
+    from cdumm.gui.bug_report import _parse_crash_headline
+
+    headline, native = _parse_crash_headline(SEGFAULT)
+    assert "Segmentation fault" in headline
+    assert native is True
+
+
+def test_parse_headline_python_traceback_not_native():
+    """A plain Python traceback (leading blank lines) yields the first
+    non-empty line and is NOT flagged native."""
+    from cdumm.gui.bug_report import _parse_crash_headline
+
+    headline, native = _parse_crash_headline(PY_TRACEBACK)
+    assert headline == "Traceback (most recent call last):"
+    assert native is False
+
+
+def test_parse_headline_empty():
+    from cdumm.gui.bug_report import _parse_crash_headline
+
+    assert _parse_crash_headline("   \n\n  ") == ("", False)
+
+
+# ── 1 (reader). Candidate ordering: preserved trace first ───────────────
+
+
+def test_crash_trace_candidates_prev_first(tmp_path):
+    from cdumm.gui.bug_report import _crash_trace_candidates
+
+    cands = _crash_trace_candidates(tmp_path)
+    assert [p.name for _, p in cands] == [
+        "crash_trace.prev.txt", "crash_trace.txt"]
+    assert cands[0][0] == "previous session"
+    assert cands[1][0] == "this session"
+
+
+# ── 4. GPU / renderer diagnostics — safe, never raises ──────────────────
+
+
+def test_windows_gpu_adapters_never_raises_and_shape():
+    from cdumm.gui.bug_report import _windows_gpu_adapters
+
+    out = _windows_gpu_adapters()
+    assert isinstance(out, list)
+    for item in out:
+        assert isinstance(item, tuple) and len(item) == 2
+        assert isinstance(item[0], str) and isinstance(item[1], str)
+
+
+def test_renderer_diagnostics_returns_str_lines():
+    from cdumm.gui.bug_report import _renderer_diagnostics
+
+    out = _renderer_diagnostics()
+    assert isinstance(out, list)
+    assert all(isinstance(x, str) for x in out)
+
+
+# ── Integration: the report wires it all together ───────────────────────
+
+
+def test_report_includes_preserved_native_crash(tmp_path):
+    """A preserved native crash surfaces with headline + native note, and
+    the preserved (previous-session) trace wins over any same-session
+    dump."""
+    from cdumm.gui.bug_report import generate_bug_report
+
+    (tmp_path / "crash_trace.prev.txt").write_text(WIN_AV, encoding="utf-8")
+    # A same-session dump also exists; the preserved one must take priority.
+    (tmp_path / "crash_trace.txt").write_text(
+        "Fatal Python error: Segmentation fault\n(this-session dump)\n",
+        encoding="utf-8")
+
+    report = generate_bug_report(None, None, tmp_path)
+
+    assert "--- CRASH TRACE (previous session) ---" in report
+    assert "--- CRASH TRACE (this session) ---" not in report
+    # Headline reaches the TL;DR (and the body first line).
+    assert "Windows fatal exception: access violation" in report
+    # Native-fault note is present.
+    assert "native fault" in report
+    # The lower-priority same-session content must not leak in.
+    assert "this-session dump" not in report
+
+
+def test_report_no_trace_no_crash_section(tmp_path):
+    """With no trace files, the report must not claim a crash."""
+    from cdumm.gui.bug_report import generate_bug_report
+
+    report = generate_bug_report(None, None, tmp_path)
+    assert "CRASH TRACE" not in report
+    assert "Crash detected" not in report


### PR DESCRIPTION
## Summary

The **CRASH TRACE (previous session)** section of the bug report was effectively dead for real crashes and could show a misleading trace. Root cause: `main.py` opens `crash_trace.txt` with `"w"` (truncate) on **every** startup with no preservation, so a hard crash's faulthandler dump is wiped by the very next launch — before the user can generate a report. For native faults (e.g. the Qt3D preview crash) the only trace that ever showed was unrelated Python frames (`splash.py`).

This makes the crash trace actually survive, and readable at a glance.

## Changes

**1. Trace survives relaunch** (`main.py`) — `_preserve_prior_crash_trace()` renames `crash_trace.txt` → `crash_trace.prev.txt` **before** faulthandler truncates it, at startup (AppData + temp fallback). Best-effort, wrapped so it can never block boot. `os.replace` keeps the most recent previous session.

**2. Read the survivor** (`bug_report.py`) — the report reads `crash_trace.prev.txt` first (the real previous session), falling back to the live `crash_trace.txt` for a rare same-session dump. First candidate with content wins.

**3. Headline the crash type + flag native faults** (`bug_report.py`) — faulthandler writes the fault class on line 1 (`Windows fatal exception: access violation`, `Fatal Python error: Segmentation fault`). That headline is surfaced in the **TL;DR** instead of buried. Native faults are labelled so triagers know the Python frames may be unrelated to the real C/C++ crash site.

**4. GPU / Qt render diagnostics** (`bug_report.py`) — the SYSTEM section reports Qt version, QPA platform plugin, `QSG_RHI_BACKEND` override, and GPU adapter name + driver version. Render-stack faults (3D preview, DDS decode) are the most common native crashes. All lookups are read-only — GPU comes from the Windows registry, **no GL context and no subprocess** — so the crash reporter can't crash itself on a bad GPU driver.

## Testing

`tests/test_crash_report.py` — 13 new tests: preservation (move / skip-empty / no-op / keep-most-recent), headline + native detection on real faulthandler samples, candidate ordering (prev before live), safe GPU probe shape, and end-to-end report wiring (a preserved native crash surfaces with headline + note and beats the same-session dump; no trace ⇒ no false "crash detected"). 34 related tests pass locally (new + existing crash / bug-report / i18n-parity). No behavioural change to any non-crash path.