### PR TITLE
feat(about): credit contributors and translators in the Credits card

### DIFF
--- a/src/cdumm/gui/pages/about_page.py
+++ b/src/cdumm/gui/pages/about_page.py
@@ -214,6 +214,8 @@ class AboutPage(SmoothScrollArea):
         self._credits_dev = BodyLabel(tr("about.credits_dev"), credits_card)
         credits_layout.addWidget(self._credits_dev)
         self._credits_detail = CaptionLabel(tr("about.credits_detail"), credits_card)
+        # Contributor list is long; wrap it instead of clipping at the card edge.
+        self._credits_detail.setWordWrap(True)
         credits_layout.addWidget(self._credits_detail)
         self._layout.addWidget(credits_card)
 

--- a/src/cdumm/translations/en.json
+++ b/src/cdumm/translations/en.json
@@ -635,7 +635,7 @@
   "about.license_desc": "This software is free and open source. You may redistribute and/or modify it under the terms of the GPLv3 as published by the Free Software Foundation.",
   "about.credits": "Credits",
   "about.credits_dev": "Developed by kindiboy",
-  "about.credits_detail": "Built with PySide6 and QFluentWidgets. German translation by HaZt.",
+  "about.credits_detail": "Built with PySide6 and QFluentWidgets. Contributors: AgentKush (Game Data browser and in-app mod maker), DarthGigi (macOS support), Andy Hunne (Linux support), Evan Prohaska (iteminfo 1.13 decoding). Translations: German by HaZt, Portuguese by Carlos_G.",
   "nav.activity": "Activity",
   "nav.settings": "Settings",
   "nav.verify_state": "Verify State",


### PR DESCRIPTION
## Summary

The **Credits** card on the About page only named the developer (kindiboy) and the German translator (HaZt). Several merged contributors and a translator were missing. This adds them, with their actual contributions (verified from `git shortlog` / history), and word-wraps the detail label so the longer list doesn't clip at the card edge.

## Credits added

- **AgentKush** — Game Data browser and in-app mod maker
- **DarthGigi** — macOS support
- **Andy Hunne** — Linux support
- **Evan Prohaska** — iteminfo 1.13 decoding
- **Carlos_G** — Portuguese (pt-BR) translation

(HaZt / German translation was already credited and is kept.)

## Implementation

- Expands the existing `about.credits_detail` string in the English base locale (`en.json`) — no **new** translation keys, so the 16-locale key-parity check is unaffected. Other locales keep their existing translated credit line until retranslated.
- `about_page.py`: `setWordWrap(True)` on the credits detail label so the longer contributor list wraps instead of clipping.

## Testing

- `en.json` validated as well-formed JSON (1300 keys) with the new value present.
- `tests/test_i18n_key_parity.py` passes (no key drift across the 16 locales).
- `about_page.py` parses; the page constructs and renders the credits card without error under an offscreen Qt render (confirmed `tr()` resolves both credit strings).