### PR TITLE
fix(game-data): don't render packed files' random ASCII as a names outline

### DIFF
--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -27,6 +27,13 @@ from typing import Any, Callable, Iterable
 # Data-table blob (.pabgb) + schema/header (.pabgh) extensions.
 TABLE_EXTS = (".pabgb", ".pabgh")
 
+# The game's own verbose reflection-serialized formats — these embed a real
+# field / type / object name schema as text (readable via decode_reflection /
+# extract_strings). Packed value-only formats (.pabgh/.paatt/.paac/…) and
+# third-party binaries (.hkx, .roadsector, …) embed NO name schema, so the
+# flat "names" outline must never be mined from them.
+REFLECTION_EXTS = (".pae", ".paseq", ".prefab", ".meshinfo", ".paproj")
+
 
 def category_of(path: str) -> str:
     """First path segment, e.g. 'gamedata' for 'gamedata/iteminfo.pabgb'."""

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -604,11 +604,34 @@ def convert_to_wav(data: bytes, out_wav: str) -> bool:
             pass
 
 
+_NAME_LIKE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*$")   # engine identifier
+
+
+def _is_name_like(s: str) -> bool:
+    """True only for strings shaped like an engine reflection name — a plain
+    identifier (``Sequence``, ``_isAccessLock``, ``bool``) or an asset-path
+    reference (contains ``/``).
+
+    Packed value-only formats (.paatt / .pabgh / .paac / …) embed no names —
+    their printable-ASCII runs are just random byte noise (``&N$0``, ``;@g#``,
+    ``JJ<sR``). Those must NOT be surfaced as a "names" outline, so anything
+    carrying punctuation or otherwise not identifier/path-shaped is rejected.
+    """
+    if _NAME_LIKE.match(s):
+        return True
+    return "/" in s and any(c.isalpha() for c in s)
+
+
 def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
-    """Printable-ASCII runs of at least ``min_len`` chars — the embedded
-    field / type / object names in the game's reflection-serialized binaries
-    (.paseq, .prefab, .meshinfo, ...). De-duplicated in encounter order and
-    capped to ``limit`` — a readable structure outline instead of raw hex."""
+    """Printable-ASCII runs of at least ``min_len`` chars that look like
+    engine names — the embedded field / type / object names in the game's
+    reflection-serialized binaries (.paseq, .prefab, .meshinfo, ...).
+    De-duplicated in encounter order and capped to ``limit`` — a readable
+    structure outline instead of raw hex.
+
+    Only ``_is_name_like`` runs are kept, so packed value-only files don't
+    masquerade their random ASCII noise as a structure outline.
+    """
     out: list = []
     seen: set = set()
     cur = bytearray()
@@ -618,7 +641,7 @@ def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
         else:
             if len(cur) >= min_len:
                 s = cur.decode("ascii")
-                if s not in seen:
+                if s not in seen and _is_name_like(s):
                     seen.add(s)
                     out.append(s)
                     if len(out) >= limit:
@@ -626,7 +649,7 @@ def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
             cur = bytearray()
     if len(cur) >= min_len and len(out) < limit:
         s = cur.decode("ascii")
-        if s not in seen:
+        if s not in seen and _is_name_like(s):
             out.append(s)
     return out
 

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -32,7 +32,8 @@ TABLE_EXTS = (".pabgb", ".pabgh")
 # extract_strings). Packed value-only formats (.pabgh/.paatt/.paac/…) and
 # third-party binaries (.hkx, .roadsector, …) embed NO name schema, so the
 # flat "names" outline must never be mined from them.
-REFLECTION_EXTS = (".pae", ".paseq", ".prefab", ".meshinfo", ".paproj")
+REFLECTION_EXTS = (".pae", ".paseq", ".prefab", ".meshinfo", ".paproj",
+                   ".pastage")
 
 
 def category_of(path: str) -> str:
@@ -599,8 +600,12 @@ def convert_to_wav(data: bytes, out_wav: str) -> bool:
     try:
         tmp.write(data)
         tmp.close()
+        # CREATE_NO_WINDOW (0x08000000) stops a console window flashing on
+        # screen every time vgmstream runs as a subprocess (e.g. on Play).
+        _flags = 0x08000000 if os.name == "nt" else 0
         subprocess.run([exe, "-o", out_wav, tmp.name],
-                       capture_output=True, timeout=60, check=False)
+                       capture_output=True, timeout=60, check=False,
+                       creationflags=_flags)
         return os.path.exists(out_wav) and os.path.getsize(out_wav) > 44
     except Exception:  # noqa: BLE001
         return False
@@ -662,6 +667,7 @@ def extract_strings(data: bytes, min_len: int = 4, limit: int = 600) -> list:
 
 
 _REFLECT_ID = re.compile(r"[A-Za-z][A-Za-z0-9]*$")   # class / type identifier
+_FIELD_ID = re.compile(r"_[A-Za-z][A-Za-z0-9_]*$")   # engine "_field" name
 
 
 def _raw_ascii_runs(data: bytes, min_len: int = 4, cap: int = 12000) -> list:
@@ -703,7 +709,7 @@ def decode_reflection(data: bytes, limit: int = 4000) -> dict | None:
     i, n = 0, len(ss)
     while i < n and len(fields) < limit:
         s = ss[i]
-        if s.startswith("_"):
+        if _FIELD_ID.match(s):
             fields.append((cur, s, ss[i + 1] if i + 1 < n else ""))
             i += 2
         else:

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -314,19 +314,22 @@ class _PreviewWorker(QObject):
             res.update(kind="text", text=text[:self._text_cap],
                        truncated=len(text) >= self._text_cap)
             return
-        # Reflection-serialized binaries (.paseq/.prefab/.meshinfo/...) embed
-        # their field/type/object names as text — surface those as a readable
-        # outline instead of raw hex.
         # Verbose reflection binaries (.pae/.paseq/.prefab/.meshinfo/…) embed a
         # full field→type schema; surface it as a named table.
         refl = game_index.decode_reflection(data)
         if refl:
             res.update(kind="schema", **refl)
             return
-        strings = game_index.extract_strings(data)
-        if len(strings) >= 6:
-            res.update(kind="outline", strings=strings, nstr=len(strings))
-            return
+        # The flat name outline is only meaningful for those same verbose
+        # reflection formats. Packed value-only files (.pabgh/.paatt/…) and
+        # third-party binaries (.hkx, .roadsector, …) embed no name schema, so
+        # mining them yields misleading noise ("navigraphX" repeats, Havok type
+        # tags) — route everything else to the struct/hex view instead.
+        if game_index.ext_of(self._path) in game_index.REFLECTION_EXTS:
+            strings = game_index.extract_strings(data)
+            if len(strings) >= 6:
+                res.update(kind="outline", strings=strings, nstr=len(strings))
+                return
         # No embedded names, but a word-aligned struct (.paatt attribute
         # blocks, .pabgh key indexes) reads far better as a typed word
         # table than a raw hex wall.

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -328,6 +328,17 @@ def test_extract_strings_drops_packed_noise():
     assert got == ["StaticMesh", "_itemId", "/Game/Weapons/Sword"]
 
 
+def test_reflection_exts_gate_membership():
+    # The name outline is only mined from the game's verbose reflection
+    # formats. Packed value-only files and third-party binaries whose noise is
+    # identifier-shaped (.hkx Havok tags, .roadsector 'navigraphX' repeats)
+    # must be excluded so they don't render a misleading outline.
+    for e in (".paseq", ".prefab", ".meshinfo", ".pae", ".paproj"):
+        assert e in gi.REFLECTION_EXTS
+    for e in (".hkx", ".roadsector", ".pabgh", ".paatt", ".paac", ".pabgb"):
+        assert e not in gi.REFLECTION_EXTS
+
+
 def test_decode_struct_typed_words_and_keys():
     import struct as _s
     # version=1, a record key (1,000,040), a negative int, and a float 2.0

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -315,6 +315,19 @@ def test_extract_strings_pulls_field_names():
     assert gi.extract_strings(b"\x00\x01ab\x00", min_len=4) == []  # too short
 
 
+def test_extract_strings_drops_packed_noise():
+    # Packed value-only files (.pabgh/.paatt/...) hold no embedded names —
+    # their printable runs are random punctuation-laden noise. These must be
+    # rejected so packed files fall through to the struct/hex view instead of
+    # rendering a fake "field/type/object names" outline.
+    noise = b"\x00&N$0\x00;@g#\x00JJ<sR\x00WD\":\x00t^#H\x00]YRH\x00r7$P\x00"
+    assert gi.extract_strings(noise, min_len=4) == []
+    # …but genuine identifiers and asset paths still come through.
+    ok = b"\x00StaticMesh\x00_itemId\x00/Game/Weapons/Sword\x00"
+    got = gi.extract_strings(ok, min_len=4)
+    assert got == ["StaticMesh", "_itemId", "/Game/Weapons/Sword"]
+
+
 def test_decode_struct_typed_words_and_keys():
     import struct as _s
     # version=1, a record key (1,000,040), a negative int, and a float 2.0

--- a/tests/test_game_index.py
+++ b/tests/test_game_index.py
@@ -333,10 +333,26 @@ def test_reflection_exts_gate_membership():
     # formats. Packed value-only files and third-party binaries whose noise is
     # identifier-shaped (.hkx Havok tags, .roadsector 'navigraphX' repeats)
     # must be excluded so they don't render a misleading outline.
-    for e in (".paseq", ".prefab", ".meshinfo", ".pae", ".paproj"):
+    for e in (".paseq", ".prefab", ".meshinfo", ".pae", ".paproj", ".pastage"):
         assert e in gi.REFLECTION_EXTS
     for e in (".hkx", ".roadsector", ".pabgh", ".paatt", ".paac", ".pabgb"):
         assert e not in gi.REFLECTION_EXTS
+
+
+def test_decode_reflection_rejects_punctuation_field_noise():
+    # A binary/video blob whose _-runs are punctuation garbage must NOT be
+    # mis-parsed as a reflection schema (the .mp4 false-positive: fields like
+    # "_.<yL", "_aKv(", "_6T5" are not real engine field names).
+    noise = (b"\x00Obj\x00_.<yL\x00Type\x00_aKv(\x00X\x00_/l!\x00"
+             b"Y\x00_6T5\x00Z\x00_[CC\x00W\x00")
+    assert gi.decode_reflection(noise) is None
+    # …but a clean object + _field/type stream still parses as a schema.
+    # (type names are >=4 chars so the ascii-run filter keeps them and the
+    # field/type alternation stays intact.)
+    good = (b"\x00Sequence\x00_isCameraJumped\x00bool\x00"
+            b"_raceIndex\x00Int4\x00_raceWin\x00Int4\x00_raceLose\x00Int4\x00")
+    r = gi.decode_reflection(good)
+    assert r is not None and r["nfields"] >= 3
 
 
 def test_decode_struct_typed_words_and_keys():


### PR DESCRIPTION
## Problem
On the Game Data tab, packed / binary assets were rendered with fake, misleading "structure," in four distinct ways:

1. **Fake "names" outline on packed value-only files.** Previewing e.g. `gamedata/iteminfo.pabgh` showed *"Structure outline — the field / type / object names embedded in this reflection-serialized binary"* full of random junk (`&N$0`, `_nZnl1`, `;@g#`, `JJ<sR`, `WD":` …). Packed formats (`.pabgh` / `.paatt` / `.paac` / …) store **values only** — they embed no names — but `extract_strings` surfaced *any* printable-ASCII run of >= 4 chars as an "embedded name."
2. **The same fake outline on other packed / third-party formats** — `.hkx` (Havok type tags + FourCC markers), `.roadsector` (`navigraphX` repeats), `.pat`, `.uianiminit`, `.pbd`, `.paac`, `.pam`, `.padxil` — whose incidental ASCII was identifier-shaped enough to slip a pure content filter.
3. **`.mp4` mis-parsed as a "reflection schema."** `decode_reflection` false-positived on video binaries and rendered ~130 garbage "fields" (`_.<yL`, `_aKv(`, `_G"~IA/`), because it accepted any run starting with `_` as a field.
4. **Audio Play flashed a console window** each time `vgmstream` ran as a subprocess.

## Fix
Layered so both the flat *outline* and the rich *schema* views only fire for the game's genuine reflection formats:

- **`extract_strings` name filter** — a run is kept only if it's an engine identifier (`Sequence`, `_isAccessLock`, `bool`) or an asset path (contains `/`). Punctuation-laden noise is dropped.
- **`REFLECTION_EXTS` allow-list gate** (`game_data_page._on_preview_ready` routing) — the flat "names" outline now renders **only** for the verbose reflection formats (`.pae` / `.paseq` / `.prefab` / `.meshinfo` / `.paproj` / `.pastage`). Every other binary routes to the honest typed-word struct / hex view. One rule fixes `.pabgh`, `.hkx`, `.roadsector`, `.pat`, `.uianiminit`, `.pbd`, `.paac`, `.pam`, `.padxil`.
- **`decode_reflection` field validation** — `_field` names must be real identifiers (`_[A-Za-z][A-Za-z0-9_]*`), so `.mp4` and other binaries with punctuation `_`-runs no longer parse as a fake schema.
- **`.pastage`** added to `REFLECTION_EXTS` — it *is* a genuine reflection / quest-stage format (opens as a real field/type table).
- **`convert_to_wav`** now passes `CREATE_NO_WINDOW` on Windows — no more console flash on audio Play / Export.

## Tests (39 pass)
- `test_extract_strings_drops_packed_noise` — punctuation noise -> `[]`; real identifiers + an asset path still pass.
- `test_reflection_exts_gate_membership` — verbose formats IN; packed / third-party (`.hkx` / `.roadsector` / `.pabgh` / `.paatt` / `.paac` / `.pabgb`) OUT.
- `test_decode_reflection_rejects_punctuation_field_noise` — mp4-style `_`-punctuation noise -> `None`; a clean object + `_field`/type stream still parses (>= 3 fields).
- Existing `test_extract_strings_pulls_field_names` stays green.

Verified in a packaged onefile build: every packed / binary format above now shows an honest struct or hex view instead of fake "names," and `.mp4` no longer shows a garbage schema.