### PR TITLE
feat(format3): full patch-op parity , match + clone/delete/new_record/array_append

### DIFF
--- a/docs/FORMAT3_OPS.md
+++ b/docs/FORMAT3_OPS.md
@@ -63,7 +63,22 @@ gear variant.
 - `new_key` must be unused and fit the table's key width; a collision is
   refused.
 - The copy is byte-identical to the source except your patches.
-- Patches target **verified scalar fields** (same rule as `set`).
+- Patches target **verified scalar fields** (same rule as `set`), and on
+  `iteminfo` also **`gear_stat[...]`** — so you can clone a weapon or piece
+  of armour and change its damage/defense on the copy:
+
+```json
+{
+  "op": "clone_record",
+  "source_key": 50003,
+  "new_key": 50003001,
+  "new_name": "Sharpened Blade",
+  "patches": [ { "field": "gear_stat[1000000]", "new": 999999 } ]
+}
+```
+
+  A `gear_stat[...]` edit is a byte-exact same-width overwrite of the stat
+  in the copy; editing a stat the item doesn't carry is a clean no-op.
 
 ---
 

--- a/docs/FORMAT3_OPS.md
+++ b/docs/FORMAT3_OPS.md
@@ -1,0 +1,143 @@
+# Format 3 (`.field.json`) operations — mod author reference
+
+CDUMM applies Format 3 mods by name (entry + field), not raw byte offsets.
+A mod declares a `target` (the `.pabgb` table it edits) and a list of
+`intents`. This document covers every operation CDUMM supports and its
+exact JSON shape.
+
+Every reshaping operation is **safe by construction**: it is append-only or
+a full rebuild, and CDUMM re-decodes the result and verifies it before
+committing. If an operation can't be applied safely it is **skipped with a
+reason** (shown after apply) — it never corrupts the table.
+
+Fields you edit must be **verified** for that table (CDUMM proves a field's
+byte offset against real record data before allowing writes). Unverified
+fields render as `(unverified)` in the Game Data tab and are refused.
+
+---
+
+## `set` — change a field
+
+The default. Change one field on one record, located by `entry` name (and
+optionally numeric `key`).
+
+```json
+{ "entry": "Hwando", "key": 1000080, "field": "_itemTier", "new": 5 }
+```
+
+`op` may be omitted — `set` is implied.
+
+---
+
+## `match` — batch edit
+
+Apply one edit to **every record whose fields all equal the given values**
+(AND across conditions), instead of naming a single record.
+
+```json
+{ "match": { "_storeType": 3 }, "field": "_buyPriceRate", "new": 50 }
+```
+
+- Match on any **verified** field, or on the metadata `_name` / `_key`.
+- Internally each match becomes one ordinary `set` per matched record, so
+  it composes with everything else.
+
+---
+
+## `clone_record` — copy a record (make a variant)
+
+Deep-copy an existing record to a **new key** (and optional new name), then
+patch a few fields on the copy. This is the standard way to make an item or
+gear variant.
+
+```json
+{
+  "op": "clone_record",
+  "source_key": 1000080,
+  "new_key": 1000090,
+  "new_name": "Hwando+",
+  "patches": [ { "field": "_itemTier", "new": 5 } ]
+}
+```
+
+- `new_key` must be unused and fit the table's key width; a collision is
+  refused.
+- The copy is byte-identical to the source except your patches.
+- Patches target **verified scalar fields** (same rule as `set`).
+
+---
+
+## `new_record` — build from a template
+
+Create a record based on an existing one. Provide a `source_key` (or
+`template_key`) to copy from, plus `new_key`, an optional `new_name`, and
+`patches`. This routes through the same engine as `clone_record`.
+
+```json
+{
+  "op": "new_record",
+  "template_key": 1000080,
+  "new_key": 1000091,
+  "new_name": "Custom Blade",
+  "patches": [ { "field": "_itemTier", "new": 3 } ]
+}
+```
+
+Building a record from a bare field list (no template) is **not supported** —
+it needs a per-table serializer CDUMM doesn't have for most tables, and the
+community-recommended path is to clone a record that already works.
+
+---
+
+## `delete_record` — remove a record
+
+Remove a record by key. CDUMM rebuilds the table body from the survivors and
+reindexes the companion `.pabgh`.
+
+```json
+{ "op": "delete_record", "key": 1000090 }
+```
+
+> Byte-safety only: CDUMM guarantees the table stays well-formed, **not**
+> that the game is happy with a record other tables still reference. Delete
+> records you added, or ones nothing else points at.
+
+---
+
+## `array_append` — add one element to a list
+
+Append a single element to a list field without rewriting the whole list.
+
+```json
+{
+  "op": "array_append",
+  "entry": "DropSet_Faction_Graymane",
+  "key": 175001,
+  "field": "drops",
+  "new": { "flag": 1, "item_key": 1000080, "rates": 5000 }
+}
+```
+
+Supported today for list fields whose format CDUMM can round-trip
+byte-exact, so existing elements are never disturbed:
+
+| Table          | Field   |
+|----------------|---------|
+| `dropsetinfo`  | `drops` |
+
+For any other list field, `array_append` is skipped with a note to use a
+`set` intent whose value is the **full new list** (the current items plus
+your addition) — CDUMM's list writers replace the whole list.
+
+---
+
+## Multiple targets
+
+A single mod file may edit several tables via a `targets` array; each entry
+has its own `target` + `intents` and follows all the rules above.
+
+## What happens on apply
+
+CDUMM reports, per mod, how many intents applied and how many were skipped
+and why (in the post-apply message and the log). A skipped intent is never a
+partial write — it's all-or-nothing per operation.

--- a/docs/FORMAT3_OP_GAPS.md
+++ b/docs/FORMAT3_OP_GAPS.md
@@ -1,5 +1,11 @@
 # Format 3 op coverage — what CDUMM doesn't support yet
 
+> **STATUS (resolved in PR #271):** the gaps below are closed. `match`,
+> `clone_record`, `delete_record` and `new_record` (template) now apply;
+> `array_append` applies for `dropsetinfo.drops` and gives an actionable
+> skip elsewhere. User-facing reference: `docs/FORMAT3_OPS.md`. This note is
+> kept for the history of how the gap was derived.
+
 Internal tracking note, not user-facing. Records a verified gap between what
 Format 3 (`.field.json`) mods *can* express and what CDUMM's apply pipeline
 currently accepts, so it isn't re-derived from scratch later.

--- a/src/cdumm/engine/dropset_writer.py
+++ b/src/cdumm/engine/dropset_writer.py
@@ -379,6 +379,86 @@ def build_drops_replacement_change(
     }
 
 
+def build_drop_append_change(
+    record_bytes: bytes,
+    intent_key: int,
+    intent_entry: str,
+    element_json: dict,
+) -> Optional[dict]:
+    """Append ONE drop (``element_json``) to a DropSet's drops list,
+    leaving every existing drop byte-for-byte intact.
+
+    Returns a v2-style change dict (same shape as
+    ``build_drops_replacement_change``), or ``None`` when it can't be done
+    safely. Safety is guaranteed two ways: (1) the record must round-trip
+    byte-exact (``serialize(parse(record)) == record``) before we touch
+    it, and (2) after appending, removing the new drop must re-serialize
+    back to the exact original bytes — proving the existing drops (and any
+    trailer) are preserved. Verified: dropset round-trips byte-exact on
+    all 14,575 vanilla records.
+    """
+    try:
+        ds = parse_dropset_record(record_bytes)
+    except Exception:
+        return None
+    if ds.key != intent_key:
+        return None
+    if not isinstance(element_json, dict):
+        return None
+    # (1) this record must round-trip byte-exact, else re-serializing the
+    # existing drops could drift them.
+    try:
+        if serialize_dropset_record(ds) != record_bytes:
+            return None
+    except Exception:
+        return None
+
+    template = ds.drops[0] if ds.drops else None
+    try:
+        new_drop = _drop_dict_to_item_drop(element_json, template)
+    except (ValueError, KeyError, TypeError) as e:
+        import logging
+        logging.getLogger(__name__).warning(
+            "dropset writer: build_drop_append_change bad element for "
+            "entry=%r key=%d: %s", intent_entry, intent_key, e)
+        return None
+
+    ds.drops.append(new_drop)
+    try:
+        new_record = serialize_dropset_record(ds)
+    except (ValueError, KeyError, TypeError):
+        return None
+
+    name_bytes = ds.name.encode("latin-1", errors="replace")
+    header_len = 4 + 4 + len(name_bytes)
+    if record_bytes[:header_len] != new_record[:header_len]:
+        return None
+
+    # (2) self-check: dropping the appended drop must reproduce the exact
+    # original bytes -> existing drops + trailer are byte-preserved.
+    ds.drops.pop()
+    try:
+        if serialize_dropset_record(ds) != record_bytes:
+            return None
+    except Exception:
+        return None
+    # and the new record must decode to exactly one more drop.
+    try:
+        back = parse_dropset_record(new_record)
+    except Exception:
+        return None
+    if len(back.drops) != len(ds.drops) + 1:
+        return None
+
+    return {
+        "entry": ds.name or intent_entry,
+        "rel_offset": 0,
+        "original": record_bytes[header_len:].hex(),
+        "patched": new_record[header_len:].hex(),
+        "label": f"{ds.name or intent_entry}.drops[+append]",
+    }
+
+
 def serialize_dropset_record(ds: DropSet) -> bytes:
     """Encode a DropSet back to its on-disk bytes."""
     buf = bytearray()

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -207,7 +207,7 @@ def _expand_match_intents(
 # safely returns None and is skipped here, never applied.
 
 
-_RECORD_OPS = ("clone_record", "delete_record")
+_RECORD_OPS = ("clone_record", "delete_record", "new_record")
 
 
 def _build_record_ops_change_for_target(
@@ -236,16 +236,16 @@ def _build_record_ops_change_for_target(
     n_applied = 0
     for intent in supported:
         op = getattr(intent, "op", "")
-        if op == "clone_record":
+        if op in ("clone_record", "new_record"):
             spec = getattr(intent, "clone", None)
             if not spec:
-                continue
+                continue  # new_record without a template; skipped upstream
             res = apply_clone_to_pabgb_bytes(tn, body, header, spec)
             if res is None:
                 logger.warning(
-                    "Format 3 clone_record on %s refused (source_key=%s, "
+                    "Format 3 %s on %s refused (source_key=%s, "
                     "new_key=%s); skipped, no bytes changed.",
-                    target, spec.get("source_key"), spec.get("new_key"))
+                    op, target, spec.get("source_key"), spec.get("new_key"))
                 continue
             body, header = res
             n_applied += 1

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -1846,6 +1846,18 @@ def _build_list_writer_change(
     """
     record_bytes = vanilla_body[entry_off:entry_end]
     if table_name == "dropsetinfo" and intent.field == "drops":
+        # array_append: add one drop, existing drops byte-preserved.
+        if getattr(intent, "op", "set") == "array_append":
+            from cdumm.engine.dropset_writer import build_drop_append_change
+            if not isinstance(intent.new, dict):
+                return None
+            return build_drop_append_change(
+                record_bytes,
+                intent_key=intent.key,
+                intent_entry=entry_name or intent.entry,
+                element_json=intent.new,
+            )
+        # op=set: replace the whole drops list.
         from cdumm.engine.dropset_writer import (
             build_drops_replacement_change,
         )

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -106,9 +106,22 @@ def _lookup_record_field(rec: dict, field: str):
 def _match_value_equals(got, want) -> bool:
     """Type-tolerant equality between a decoded record value ``got`` and
     a mod-authored JSON value ``want`` (e.g. JSON ``5`` vs decoded int,
-    or JSON ``"5"`` vs decoded ``5``)."""
+    or JSON ``"5"`` vs decoded ``5``).
+
+    A list/tuple on the mod side means **any-of** (SQL ``IN``): the record
+    matches when its value equals any one candidate. That lets a single
+    intent target a whole family of records — pinapana's Crazy ExtraSockets
+    (GitHub #272) selects 63 ``equip_type_info`` values in one intent
+    instead of 63 separate intents.
+
+    When the record's own value is *itself* a list, a list on the mod side
+    keeps exact-equality semantics instead, so a genuinely list-valued
+    field can still be matched whole and the two meanings never collide.
+    """
     if got is None:
         return False
+    if isinstance(want, (list, tuple)) and not isinstance(got, (list, tuple)):
+        return any(_match_value_equals(got, w) for w in want)
     if got == want:
         return True
     # numeric tolerance (int vs float), excluding bool surprises.

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -196,6 +196,77 @@ def _expand_match_intents(
     return out
 
 
+# ── clone_record: record creation ───────────────────────────────────
+#
+# ``clone_record`` copies an existing record to a new key + optional name
+# and patches a few fields on the copy. Unlike ``set``/``match`` it grows
+# the table, so it emits a whole-table (body + .pabgh companion) change in
+# the same offset=0 shape the iteminfo/skill writers use. The record
+# creation itself lives in ``format3_handler.apply_clone_to_pabgb_bytes``,
+# which is append-only and parse-back self-checked — a clone it can't do
+# safely returns None and is skipped here, never applied.
+
+
+def _build_clone_change_for_target(
+    target: str,
+    vanilla_body: bytes,
+    vanilla_header: bytes,
+    supported: list[Format3Intent],
+) -> tuple[dict | None, dict | None, int]:
+    """Build one whole-table change for a target whose supported intents
+    include ``clone_record`` ops.
+
+    Applies each clone sequentially (a refused clone is skipped with a
+    warning, never aborting the rest), then applies any non-clone ``set``
+    intents on top of the cloned bytes. Returns ``(body_change,
+    companion_change | None, n_clones_applied)``, or ``(None, None, 0)``
+    when nothing applied.
+    """
+    from cdumm.engine.format3_handler import (
+        apply_clone_to_pabgb_bytes,
+        apply_intents_to_pabgb_bytes,
+    )
+    tn = _table_name_from_target(target)
+    body, header = bytes(vanilla_body), bytes(vanilla_header)
+    n_applied = 0
+    for intent in supported:
+        if getattr(intent, "op", "") != "clone_record":
+            continue
+        spec = getattr(intent, "clone", None)
+        if not spec:
+            continue
+        res = apply_clone_to_pabgb_bytes(tn, body, header, spec)
+        if res is None:
+            logger.warning(
+                "Format 3 clone_record on %s refused (source_key=%s, "
+                "new_key=%s); skipped, no bytes changed.",
+                target, spec.get("source_key"), spec.get("new_key"))
+            continue
+        body, header = res
+        n_applied += 1
+    if n_applied == 0:
+        return None, None, 0
+    # Apply non-clone set intents (incl. match-expanded ones) on top of
+    # the cloned bytes so a mixed mod composes into one change.
+    rest = [i for i in supported if getattr(i, "op", "") != "clone_record"]
+    if rest:
+        body = apply_intents_to_pabgb_bytes(tn, body, header, rest)
+    body_change = {
+        "offset": 0,
+        "original": bytes(vanilla_body).hex(),
+        "patched": bytes(body).hex(),
+        "label": f"clone_record x{n_applied} ({tn})",
+    }
+    companion = None
+    if bytes(header) != bytes(vanilla_header):
+        companion = {
+            "offset": 0,
+            "original": bytes(vanilla_header).hex(),
+            "patched": bytes(header).hex(),
+        }
+    return body_change, companion, n_applied
+
+
 def expand_format3_into_aggregated(
     aggregated: dict[str, list[dict]],
     signatures: dict[str, str],
@@ -359,6 +430,46 @@ def expand_format3_into_aggregated(
                         "Format 3 mod '%s' (id=%d): match selector(s) for "
                         "%s matched 0 records; 0 byte changes.",
                         mod_name, mod_id, target)
+                    continue
+
+                # clone_record: creates records (grows the table), so it
+                # emits one whole-table body + .pabgh companion change,
+                # routed like the iteminfo/skill whole-table writers. Each
+                # clone is append-only + parse-back self-checked in the
+                # engine, so a clone it can't do safely is skipped, never
+                # applied. Isolated to clone-bearing mods; every other
+                # Format 3 flow below is unchanged.
+                if any(getattr(i, "op", "") == "clone_record"
+                       for i in supported):
+                    body_change, companion, n_applied = (
+                        _build_clone_change_for_target(
+                            target, vanilla_body, vanilla_header, supported))
+                    if body_change is None:
+                        n_mods_skipped += 1
+                        logger.warning(
+                            "Format 3 mod '%s' (id=%d): clone_record "
+                            "produced 0 changes for %s (all clones "
+                            "refused).", mod_name, mod_id, target)
+                        continue
+                    body_change["_target_file"] = target
+                    body_change["_source_mod_ids"] = [mod_id]
+                    aggregated.setdefault(target, []).append(body_change)
+                    if companion is not None:
+                        comp_target = target.replace(".pabgb", ".pabgh")
+                        companion["_target_file"] = comp_target
+                        companion["_source_mod_ids"] = [mod_id]
+                        aggregated.setdefault(
+                            comp_target, []).append(companion)
+                    n_mods_changed += 1
+                    files_touched.add(target)
+                    n_bytes_changed += len(body_change["patched"]) // 2
+                    if participating_mod_ids is not None:
+                        participating_mod_ids.add(mod_id)
+                    logger.info(
+                        "Format 3 clone_record: applied %d clone(s) from "
+                        "mod '%s' (id=%d) to %s%s",
+                        n_applied, mod_name, mod_id, target,
+                        " + .pabgh companion" if companion else "")
                     continue
 
                 # Whole-table writer targets: defer dispatch to the

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -46,6 +46,8 @@ from cdumm.engine.field_schema import (
 )
 from cdumm.engine.format3_handler import (
     Format3Intent,
+    _snake_to_camel,
+    _table_name_from_target,
     parse_format3_mod,
     parse_format3_mod_targets,
     validate_intents,
@@ -55,6 +57,7 @@ from cdumm.semantic.parser import (
     has_schema,
     identify_table_from_path,
     parse_pabgh_index,
+    parse_records,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,6 +68,132 @@ VanillaExtractor = Callable[[str], "tuple[bytes, bytes] | None"]
 bytes for the vanilla version of that file, or None if the file
 can't be extracted. apply_engine wires this to its existing
 ``_get_vanilla_entry_content`` + ``_extract_sibling_entry`` helpers."""
+
+
+# ── 'match' selector expansion ───────────────────────────────────────
+#
+# A Format 3 intent may carry a ``match`` selector instead of a single
+# ``entry``/``key``: ``{"match": {field: value, ...}, "field": F,
+# "new": N}`` targets *every* record whose fields all equal the given
+# values (AND across conditions). We resolve that here, at apply time,
+# once the table's vanilla bytes are in hand: decode the table with the
+# same ``parse_records`` the diff/apply pipeline already uses, find the
+# matching record keys, and emit one ordinary per-record ``set`` intent
+# for each. Those flow through the existing, already-trusted writer path
+# (and its verified-field write gate) — so ``match`` adds no new
+# byte-writing code and cannot introduce a new corruption path. Matching
+# is gated in ``validate_intents`` to verified (or metadata) fields, so
+# we only ever compare against trustworthy decoded values.
+
+
+def _lookup_record_field(rec: dict, field: str):
+    """Return ``rec``'s value for ``field``, trying the same four name
+    shapes the writer uses (exact / +underscore / snake→camel /
+    snake→camel +underscore). Returns ``None`` if no shape is present."""
+    if field in rec:
+        return rec[field]
+    cand = [field, f"_{field}"]
+    if "_" in field:
+        camel = _snake_to_camel(field)
+        if camel != field:
+            cand += [camel, f"_{camel}"]
+    for n in cand:
+        if n in rec:
+            return rec[n]
+    return None
+
+
+def _match_value_equals(got, want) -> bool:
+    """Type-tolerant equality between a decoded record value ``got`` and
+    a mod-authored JSON value ``want`` (e.g. JSON ``5`` vs decoded int,
+    or JSON ``"5"`` vs decoded ``5``)."""
+    if got is None:
+        return False
+    if got == want:
+        return True
+    # numeric tolerance (int vs float), excluding bool surprises.
+    if (isinstance(got, (int, float)) and not isinstance(got, bool)
+            and isinstance(want, (int, float)) and not isinstance(want, bool)):
+        try:
+            return float(got) == float(want)
+        except (TypeError, ValueError, OverflowError):
+            return False
+    # string-form tolerance ("5" == 5).
+    if isinstance(want, str) and not isinstance(got, str):
+        return str(got) == want
+    return False
+
+
+def _match_record_keys(records: dict, match: dict) -> list:
+    """Keys of every record in ``records`` whose fields all satisfy the
+    ``match`` conditions (AND). Preserves ``records`` iteration order."""
+    out = []
+    for key, rec in records.items():
+        if all(
+            _match_value_equals(
+                rec.get(mf) if mf in ("_name", "_key", "_entry_id")
+                else _lookup_record_field(rec, mf),
+                mv,
+            )
+            for mf, mv in match.items()
+        ):
+            out.append(key)
+    return out
+
+
+def _expand_match_intents(
+    target: str,
+    vanilla_body: bytes,
+    vanilla_header: bytes,
+    intents: list[Format3Intent],
+) -> list[Format3Intent]:
+    """Replace each ``match`` intent in ``intents`` with concrete
+    per-record ``set`` intents; pass non-match intents through unchanged.
+
+    Decodes the target table once via ``parse_records`` and, for each
+    ``match`` intent, emits one ``Format3Intent`` per matched record
+    carrying that record's real ``_name``/``_key`` so the existing writer
+    resolves it exactly like a hand-authored single-record intent.
+    """
+    # ``getattr`` guard: some intent stand-ins (and any future
+    # lightweight intent type) may not carry a ``match`` attribute at
+    # all — those are, by definition, not match selectors.
+    if not any(getattr(i, "match", None) is not None for i in intents):
+        return list(intents)
+
+    table_name = _table_name_from_target(target)
+    try:
+        records = parse_records(table_name, vanilla_body, vanilla_header)
+    except Exception:  # noqa: BLE001 - decode must never break apply
+        logger.warning(
+            "Format 3 match: could not decode %s to resolve a match "
+            "selector; those intents produce 0 changes.", target,
+            exc_info=True)
+        records = {}
+
+    out: list[Format3Intent] = []
+    for intent in intents:
+        match = getattr(intent, "match", None)
+        if match is None:
+            out.append(intent)
+            continue
+        matched = _match_record_keys(records, match) if records else []
+        for key in matched:
+            rec = records[key]
+            out.append(Format3Intent(
+                entry=str(rec.get("_name", "")),
+                key=int(rec.get("_key", key)),
+                field=intent.field,
+                op="set",
+                new=intent.new,
+                old=getattr(intent, "old", None),
+                match=None,
+            ))
+        logger.info(
+            "Format 3 match on %s (%s == …) expanded to %d record(s) "
+            "for field %r.", target, ",".join(match), len(matched),
+            intent.field)
+    return out
 
 
 def expand_format3_into_aggregated(
@@ -213,14 +342,33 @@ def expand_format3_into_aggregated(
                     continue
                 vanilla_body, vanilla_header = vanilla
 
+                # Expand any 'match' selector intents into concrete
+                # per-record 'set' intents now that the table bytes are
+                # available to decode. Non-match intents pass through
+                # untouched, so this is a no-op for the common case.
+                supported = _expand_match_intents(
+                    target, vanilla_body, vanilla_header,
+                    validation.supported)
+                if not supported:
+                    # Every intent was a match selector that resolved to
+                    # zero records (or the table wouldn't decode). Nothing
+                    # to write, but not an error , report like other
+                    # zero-change cases.
+                    n_mods_skipped += 1
+                    logger.debug(
+                        "Format 3 mod '%s' (id=%d): match selector(s) for "
+                        "%s matched 0 records; 0 byte changes.",
+                        mod_name, mod_id, target)
+                    continue
+
                 # Whole-table writer targets: defer dispatch to the
                 # post-loop phase so all mods' intents land in a single
                 # parse+serialize.
                 if target in _WHOLE_TABLE_TARGETS:
                     whole_table_intents.setdefault(target, []).extend(
-                        validation.supported)
+                        supported)
                     whole_table_intent_mods.setdefault(target, []).extend(
-                        [mod_name] * len(validation.supported))
+                        [mod_name] * len(supported))
                     whole_table_mod_names.setdefault(target, []).append(mod_name)
                     whole_table_mod_ids.setdefault(target, []).append(mod_id)
                     n_mods_changed += 1  # provisional; recounted below if no bytes
@@ -235,13 +383,13 @@ def expand_format3_into_aggregated(
                         "Format 3 batched %d supported intent(s) from mod "
                         "'%s' (id=%d) into whole-table writer queue for %s "
                         "(queue depth now %d)",
-                        len(validation.supported), mod_name, mod_id,
+                        len(supported), mod_name, mod_id,
                         target, len(whole_table_intents[target]))
                     continue
 
                 # Convert each supported intent into a v2-style change dict
                 changes = _intents_to_v2_changes(
-                    target, vanilla_body, vanilla_header, validation.supported)
+                    target, vanilla_body, vanilla_header, supported)
                 if not changes:
                     n_mods_skipped += 1
                     # Don't pollute aggregated with empty lists.
@@ -249,7 +397,7 @@ def expand_format3_into_aggregated(
                         "Format 3 mod '%s' (id=%d): all %d supported intents "
                         "resolved to zero changes (probably TID-not-found "
                         "or value out of range).",
-                        mod_name, mod_id, len(validation.supported))
+                        mod_name, mod_id, len(supported))
                     if warnings_out is not None:
                         warnings_out.append(
                             f"Format 3 mod '{mod_name}' produced 0 byte "

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -207,55 +207,71 @@ def _expand_match_intents(
 # safely returns None and is skipped here, never applied.
 
 
-def _build_clone_change_for_target(
+_RECORD_OPS = ("clone_record", "delete_record")
+
+
+def _build_record_ops_change_for_target(
     target: str,
     vanilla_body: bytes,
     vanilla_header: bytes,
     supported: list[Format3Intent],
 ) -> tuple[dict | None, dict | None, int]:
     """Build one whole-table change for a target whose supported intents
-    include ``clone_record`` ops.
+    include record-creation/deletion ops (``clone_record`` /
+    ``delete_record``).
 
-    Applies each clone sequentially (a refused clone is skipped with a
-    warning, never aborting the rest), then applies any non-clone ``set``
-    intents on top of the cloned bytes. Returns ``(body_change,
-    companion_change | None, n_clones_applied)``, or ``(None, None, 0)``
-    when nothing applied.
+    Applies each record op sequentially in mod order (a refused op is
+    skipped with a warning, never aborting the rest), then applies any
+    remaining ``set`` intents on top. Returns ``(body_change,
+    companion_change | None, n_ops_applied)``, or ``(None, None, 0)`` when
+    nothing applied.
     """
     from cdumm.engine.format3_handler import (
         apply_clone_to_pabgb_bytes,
+        apply_delete_to_pabgb_bytes,
         apply_intents_to_pabgb_bytes,
     )
     tn = _table_name_from_target(target)
     body, header = bytes(vanilla_body), bytes(vanilla_header)
     n_applied = 0
     for intent in supported:
-        if getattr(intent, "op", "") != "clone_record":
-            continue
-        spec = getattr(intent, "clone", None)
-        if not spec:
-            continue
-        res = apply_clone_to_pabgb_bytes(tn, body, header, spec)
-        if res is None:
-            logger.warning(
-                "Format 3 clone_record on %s refused (source_key=%s, "
-                "new_key=%s); skipped, no bytes changed.",
-                target, spec.get("source_key"), spec.get("new_key"))
-            continue
-        body, header = res
-        n_applied += 1
+        op = getattr(intent, "op", "")
+        if op == "clone_record":
+            spec = getattr(intent, "clone", None)
+            if not spec:
+                continue
+            res = apply_clone_to_pabgb_bytes(tn, body, header, spec)
+            if res is None:
+                logger.warning(
+                    "Format 3 clone_record on %s refused (source_key=%s, "
+                    "new_key=%s); skipped, no bytes changed.",
+                    target, spec.get("source_key"), spec.get("new_key"))
+                continue
+            body, header = res
+            n_applied += 1
+        elif op == "delete_record":
+            res = apply_delete_to_pabgb_bytes(
+                tn, body, header, getattr(intent, "key", None))
+            if res is None:
+                logger.warning(
+                    "Format 3 delete_record on %s refused (key=%s not "
+                    "found / unsafe); skipped, no bytes changed.",
+                    target, getattr(intent, "key", None))
+                continue
+            body, header = res
+            n_applied += 1
     if n_applied == 0:
         return None, None, 0
-    # Apply non-clone set intents (incl. match-expanded ones) on top of
-    # the cloned bytes so a mixed mod composes into one change.
-    rest = [i for i in supported if getattr(i, "op", "") != "clone_record"]
+    # Apply remaining set intents (incl. match-expanded ones) on top of
+    # the reshaped bytes so a mixed mod composes into one change.
+    rest = [i for i in supported if getattr(i, "op", "") not in _RECORD_OPS]
     if rest:
         body = apply_intents_to_pabgb_bytes(tn, body, header, rest)
     body_change = {
         "offset": 0,
         "original": bytes(vanilla_body).hex(),
         "patched": bytes(body).hex(),
-        "label": f"clone_record x{n_applied} ({tn})",
+        "label": f"record ops x{n_applied} ({tn})",
     }
     companion = None
     if bytes(header) != bytes(vanilla_header):
@@ -432,24 +448,24 @@ def expand_format3_into_aggregated(
                         mod_name, mod_id, target)
                     continue
 
-                # clone_record: creates records (grows the table), so it
-                # emits one whole-table body + .pabgh companion change,
-                # routed like the iteminfo/skill whole-table writers. Each
-                # clone is append-only + parse-back self-checked in the
-                # engine, so a clone it can't do safely is skipped, never
-                # applied. Isolated to clone-bearing mods; every other
-                # Format 3 flow below is unchanged.
-                if any(getattr(i, "op", "") == "clone_record"
+                # Record ops (clone_record / delete_record) reshape the
+                # table, so they emit one whole-table body + .pabgh
+                # companion change, routed like the iteminfo/skill
+                # whole-table writers. Each op is parse-back self-checked
+                # in the engine, so one it can't do safely is skipped,
+                # never applied. Isolated to record-op-bearing mods; every
+                # other Format 3 flow below is unchanged.
+                if any(getattr(i, "op", "") in _RECORD_OPS
                        for i in supported):
                     body_change, companion, n_applied = (
-                        _build_clone_change_for_target(
+                        _build_record_ops_change_for_target(
                             target, vanilla_body, vanilla_header, supported))
                     if body_change is None:
                         n_mods_skipped += 1
                         logger.warning(
-                            "Format 3 mod '%s' (id=%d): clone_record "
-                            "produced 0 changes for %s (all clones "
-                            "refused).", mod_name, mod_id, target)
+                            "Format 3 mod '%s' (id=%d): record op(s) "
+                            "produced 0 changes for %s (all refused).",
+                            mod_name, mod_id, target)
                         continue
                     body_change["_target_file"] = target
                     body_change["_source_mod_ids"] = [mod_id]
@@ -466,7 +482,7 @@ def expand_format3_into_aggregated(
                     if participating_mod_ids is not None:
                         participating_mod_ids.add(mod_id)
                     logger.info(
-                        "Format 3 clone_record: applied %d clone(s) from "
+                        "Format 3 record ops: applied %d op(s) from "
                         "mod '%s' (id=%d) to %s%s",
                         n_applied, mod_name, mod_id, target,
                         " + .pabgh companion" if companion else "")

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -245,6 +245,54 @@ def _parse_delete_intent(raw: dict, i: int, label: str) -> Format3Intent:
     )
 
 
+def _parse_new_record_intent(raw: dict, i: int, label: str) -> Format3Intent:
+    """Parse a ``new_record`` intent.
+
+    A new record has to be built from a known-good layout, so CDUMM's safe
+    form bases it on an existing record: supply ``source_key`` (or
+    ``template_key``) to copy, plus ``new_key``, an optional ``new_name``,
+    and ``patches``. That routes through the same append-only, self-checked
+    clone engine. Without a template key the intent still parses but is
+    skipped in validation with an actionable message (building a valid
+    record from a bare field list needs a per-table serializer CDUMM does
+    not have for most tables — cloning one that already works is the
+    community-recommended path anyway).
+    """
+    src = raw.get("source_key", raw.get("template_key"))
+    new_key = raw.get("new_key")
+    if isinstance(new_key, bool) or not isinstance(new_key, int):
+        raise ValueError(
+            f"{label} intent #{i} new_record needs an integer 'new_key'"
+        )
+    new_name = raw.get("new_name")
+    if new_name is not None and not isinstance(new_name, str):
+        raise ValueError(
+            f"{label} intent #{i} new_record 'new_name' must be a string"
+        )
+    raw_patches = raw.get("patches", [])
+    if not isinstance(raw_patches, list):
+        raise ValueError(
+            f"{label} intent #{i} new_record 'patches' must be a list"
+        )
+    patches: list[dict] = []
+    for j, p in enumerate(raw_patches):
+        if not isinstance(p, dict) or "field" not in p or "new" not in p:
+            raise ValueError(
+                f"{label} intent #{i} new_record patch #{j} must be an "
+                f"object with 'field' and 'new'"
+            )
+        patches.append({"field": str(p["field"]), "new": p["new"]})
+    clone: dict | None = None
+    if isinstance(src, int) and not isinstance(src, bool):
+        clone = {"source_key": src, "new_key": new_key, "patches": patches}
+        if new_name is not None:
+            clone["new_name"] = new_name
+    return Format3Intent(
+        entry="", key=new_key, field="", op="new_record",
+        new=None, old=None, match=None, clone=clone,
+    )
+
+
 def _parse_intents_block(
     raw_intents, label: str = "intents",
 ) -> list[Format3Intent]:
@@ -274,6 +322,9 @@ def _parse_intents_block(
             continue
         if raw.get("op") == "delete_record":
             intents.append(_parse_delete_intent(raw, i, label))
+            continue
+        if raw.get("op") == "new_record":
+            intents.append(_parse_new_record_intent(raw, i, label))
             continue
         # The newer skill .field.json variant drops 'op' since 'set'
         # is implicit. We default to 'set' when absent. GitHub #66.
@@ -590,6 +641,13 @@ def _partition_unsupported_op(
     """
     if intent.op in _SUPPORTED_OPS:
         return None
+    if intent.op == "array_append":
+        return (
+            "op 'array_append' (append one element to a list) isn't "
+            "supported yet: CDUMM's list writers replace the whole list, "
+            "so use a 'set' intent whose value is the full new list (the "
+            "record's current items plus your addition)."
+        )
     if intent.op in _V32_RESERVED_OPS:
         return (
             f"intent uses op {intent.op!r} which is reserved for "
@@ -758,6 +816,11 @@ def validate_intents(
                     mi,
                     f"delete_record needs a decoded schema for table "
                     f"'{table_name}', which CDUMM doesn't have yet"))
+            elif mi.op == "new_record":
+                result.skipped.append((
+                    mi,
+                    f"new_record needs a decoded schema for table "
+                    f"'{table_name}', which CDUMM doesn't have yet"))
             else:
                 kept.append(mi)
         intents = kept
@@ -810,6 +873,23 @@ def validate_intents(
         # clone_record is a record-creation op with its own validator; it
         # must be routed before the set-oriented op partition (which would
         # otherwise reject it as an unknown op).
+        if intent.op == "new_record":
+            if intent.clone is not None:
+                # Template-based new record -> validate like a clone.
+                reason = _classify_clone(
+                    intent, schema, field_specs, fs_entries, table_name)
+            else:
+                reason = (
+                    "new_record needs a 'source_key' (or 'template_key') "
+                    "to base the record on an existing one; building a "
+                    "record from a bare field template isn't supported "
+                    "yet. Use clone_record on a similar record instead."
+                )
+            if reason is None:
+                result.supported.append(intent)
+            else:
+                result.skipped.append((intent, reason))
+            continue
         if intent.op == "clone_record" or intent.clone is not None:
             reason = _classify_clone(
                 intent, schema, field_specs, fs_entries, table_name)

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -641,13 +641,6 @@ def _partition_unsupported_op(
     """
     if intent.op in _SUPPORTED_OPS:
         return None
-    if intent.op == "array_append":
-        return (
-            "op 'array_append' (append one element to a list) isn't "
-            "supported yet: CDUMM's list writers replace the whole list, "
-            "so use a 'set' intent whose value is the full new list (the "
-            "record's current items plus your addition)."
-        )
     if intent.op in _V32_RESERVED_OPS:
         return (
             f"intent uses op {intent.op!r} which is reserved for "
@@ -772,6 +765,37 @@ def _classify_delete(intent: Format3Intent) -> str | None:
     return None
 
 
+# List fields whose parse->serialize round-trips byte-exact, so an
+# ``array_append`` can add one element while preserving every existing
+# element's bytes. dropsetinfo.drops is verified byte-exact on all 14,575
+# vanilla records. Add a (table, field) here only after proving the same.
+APPENDABLE_LIST_FIELDS = frozenset({("dropsetinfo", "drops")})
+
+
+def _classify_array_append(
+    intent: Format3Intent, table_name: str
+) -> str | None:
+    """Validate an ``array_append`` intent. Supported only for fields in
+    ``APPENDABLE_LIST_FIELDS`` (proven byte-exact list round-trip); every
+    other field gets an actionable skip pointing at ``set``."""
+    if (table_name, intent.field) not in APPENDABLE_LIST_FIELDS:
+        appendable = ", ".join(
+            f"{t}.{f}" for t, f in sorted(APPENDABLE_LIST_FIELDS))
+        return (
+            f"op 'array_append' isn't supported for field {intent.field!r} "
+            f"on '{table_name}' yet: CDUMM's list writers replace the whole "
+            f"list, so use a 'set' intent whose value is the full new list "
+            f"(the record's current items plus your addition). Appendable "
+            f"list fields so far: {appendable}."
+        )
+    if not isinstance(intent.new, dict):
+        return (
+            "array_append 'new' must be the element object to append "
+            "(a single drop object for dropsetinfo.drops)"
+        )
+    return None
+
+
 def validate_intents(
     target: str, intents: list[Format3Intent]
 ) -> Format3Validation:
@@ -780,6 +804,23 @@ def validate_intents(
     """
     result = Format3Validation()
     table_name = _table_name_from_target(target)
+
+    # array_append is classified up front so it works whether or not the
+    # table has a PABGB schema (dropsetinfo's drops list is writer-handled,
+    # not schema-driven). Supported only for proven-byte-exact list fields;
+    # everything else gets an actionable skip.
+    if any(i.op == "array_append" for i in intents):
+        kept_aa: list[Format3Intent] = []
+        for i in intents:
+            if i.op == "array_append":
+                reason = _classify_array_append(i, table_name)
+                if reason is None:
+                    result.supported.append(i)
+                else:
+                    result.skipped.append((i, reason))
+            else:
+                kept_aa.append(i)
+        intents = kept_aa
 
     if not has_schema(table_name):
         # Three routes accept intents on a no-PABGB-schema table:

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -54,7 +54,12 @@ from cdumm.engine.field_schema import (
     load_field_schema,
     locate_field,
 )
-from cdumm.semantic.parser import get_schema, has_schema, parse_pabgh_index
+from cdumm.semantic.parser import (
+    get_schema,
+    has_schema,
+    parse_pabgh_index,
+    parse_records,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +144,7 @@ class Format3Intent:
     new: Any
     old: str | None = None
     match: dict | None = None
+    clone: dict | None = None
 
 
 @dataclass
@@ -178,6 +184,52 @@ class Format3Validation:
 # ── Parsing ─────────────────────────────────────────────────────────
 
 
+def _parse_clone_intent(raw: dict, i: int, label: str) -> Format3Intent:
+    """Parse a ``clone_record`` intent.
+
+    Shape: ``{"op":"clone_record","source_key":N,"new_key":M,
+    "new_name":"...","patches":[{"field":..,"new":..}, ...]}``. Copies the
+    record at ``source_key`` to a brand-new record keyed ``new_key`` (with
+    an optional new name), then applies ``patches`` (field sets) to the
+    copy. Raises ValueError with a located message on malformed input.
+    """
+    src = raw.get("source_key")
+    new_key = raw.get("new_key")
+    for name, val in (("source_key", src), ("new_key", new_key)):
+        if isinstance(val, bool) or not isinstance(val, int):
+            raise ValueError(
+                f"{label} intent #{i} clone_record needs an integer "
+                f"'{name}' (a record id); got {val!r}"
+            )
+    new_name = raw.get("new_name")
+    if new_name is not None and not isinstance(new_name, str):
+        raise ValueError(
+            f"{label} intent #{i} clone_record 'new_name' must be a string"
+        )
+    raw_patches = raw.get("patches", [])
+    if not isinstance(raw_patches, list):
+        raise ValueError(
+            f"{label} intent #{i} clone_record 'patches' must be a list"
+        )
+    patches: list[dict] = []
+    for j, p in enumerate(raw_patches):
+        if not isinstance(p, dict) or "field" not in p or "new" not in p:
+            raise ValueError(
+                f"{label} intent #{i} clone_record patch #{j} must be an "
+                f"object with 'field' and 'new'"
+            )
+        patches.append({"field": str(p["field"]), "new": p["new"]})
+    clone: dict = {
+        "source_key": src, "new_key": new_key, "patches": patches,
+    }
+    if new_name is not None:
+        clone["new_name"] = new_name
+    return Format3Intent(
+        entry="", key=0, field="", op="clone_record",
+        new=None, old=None, match=None, clone=clone,
+    )
+
+
 def _parse_intents_block(
     raw_intents, label: str = "intents",
 ) -> list[Format3Intent]:
@@ -199,6 +251,12 @@ def _parse_intents_block(
             raise ValueError(
                 f"{label} intent #{i} is not a JSON object"
             )
+        # clone_record is a record-creation op with its own shape
+        # (source_key / new_key / new_name / patches) and doesn't use the
+        # entry/field/new triple, so parse it here and move on.
+        if raw.get("op") == "clone_record":
+            intents.append(_parse_clone_intent(raw, i, label))
+            continue
         # The newer skill .field.json variant drops 'op' since 'set'
         # is implicit. We default to 'set' when absent. GitHub #66.
         # GitHub #125 AgentRatchet: DMM v3.1 mods (e.g. Refinement Cost
@@ -582,6 +640,53 @@ def _classify_match_selector(
     return None
 
 
+def _classify_clone(
+    intent: Format3Intent, schema, field_specs: dict,
+    fs_entries: dict, table_name: str
+) -> str | None:
+    """Validate a ``clone_record`` intent. Returns None when supported,
+    else a skip reason.
+
+    A clone is supported when source_key/new_key are integers and every
+    patch targets a plain schema field that is writable (reachable by the
+    set writer) and verified. Collision of ``new_key`` and existence of
+    ``source_key`` can only be known against the real table bytes, so
+    those are enforced at apply time (the clone writer refuses + logs);
+    here we validate structure and the patch fields.
+    """
+    clone = intent.clone or {}
+    src = clone.get("source_key")
+    new_key = clone.get("new_key")
+    if isinstance(src, bool) or not isinstance(src, int):
+        return "clone_record needs an integer source_key"
+    if isinstance(new_key, bool) or not isinstance(new_key, int):
+        return "clone_record needs an integer new_key"
+    vf = getattr(schema, "verified_fields", None)
+    for p in clone.get("patches") or []:
+        pf = str(p.get("field", "")) if isinstance(p, dict) else ""
+        if not pf:
+            return "clone_record patch is missing a 'field'"
+        resolved = _resolve_schema_field_name(pf, field_specs)
+        if resolved is None:
+            return (
+                f"clone patch field {pf!r} isn't a plain schema field; "
+                f"clone patches currently support verified scalar fields "
+                f"only"
+            )
+        if vf is not None and resolved not in vf:
+            return (
+                f"clone patch field {pf!r} is not a verified field of "
+                f"this table; patching it is unsafe"
+            )
+        temp = Format3Intent(entry="", key=new_key, field=pf,
+                             op="set", new=p.get("new"))
+        reason = _classify_intent(
+            temp, schema, field_specs, fs_entries, table_name)
+        if reason is not None:
+            return f"clone patch field {pf!r}: {reason}"
+    return None
+
+
 def validate_intents(
     target: str, intents: list[Format3Intent]
 ) -> Format3Validation:
@@ -615,6 +720,11 @@ def validate_intents(
                 result.skipped.append((
                     mi,
                     f"match selector needs a decoded schema for table "
+                    f"'{table_name}', which CDUMM doesn't have yet"))
+            elif mi.clone is not None or mi.op == "clone_record":
+                result.skipped.append((
+                    mi,
+                    f"clone_record needs a decoded schema for table "
                     f"'{table_name}', which CDUMM doesn't have yet"))
             else:
                 kept.append(mi)
@@ -665,6 +775,17 @@ def validate_intents(
     fs_entries = load_field_schema(table_name)
 
     for intent in intents:
+        # clone_record is a record-creation op with its own validator; it
+        # must be routed before the set-oriented op partition (which would
+        # otherwise reject it as an unknown op).
+        if intent.op == "clone_record" or intent.clone is not None:
+            reason = _classify_clone(
+                intent, schema, field_specs, fs_entries, table_name)
+            if reason is None:
+                result.supported.append(intent)
+            else:
+                result.skipped.append((intent, reason))
+            continue
         # Unsupported op is checked first; the schema/field walker
         # below assumes op == 'set' and would silently do a set-style
         # write for e.g. op='append' otherwise.
@@ -1269,6 +1390,179 @@ def _pack_value(value, spec) -> bytes | None:
         # Out-of-range, wrong type, etc. Caller's job to refuse
         # rather than corrupting bytes.
         return None
+
+
+def _raw_entries(table_name: str, body: bytes, header: bytes
+                 ) -> dict[int, bytes]:
+    """``{record_key: raw entry bytes}`` using the sorted PABGH offsets.
+
+    A small local copy of the record-slicing logic so the clone writer
+    stays self-contained (doesn't depend on a parser helper that isn't
+    present on every branch).
+    """
+    _ks, offsets = parse_pabgh_index(header, table_name)
+    if not offsets:
+        return {}
+    ordered = sorted(offsets.items(), key=lambda kv: kv[1])
+    out: dict[int, bytes] = {}
+    for i, (k, off) in enumerate(ordered):
+        end = ordered[i + 1][1] if i + 1 < len(ordered) else len(body)
+        if off < len(body):
+            out[k] = bytes(body)[off:end]
+    return out
+
+
+def apply_clone_to_pabgb_bytes(
+    table_name: str,
+    body: bytes,
+    header: bytes,
+    clone: dict,
+) -> tuple[bytes, bytes] | None:
+    """Clone one record to a new key + name and apply field patches.
+
+    Community-standard ``clone_record``: deep-copy the source record's raw
+    bytes, give the copy ``new_key`` (rewriting the entry-header id and the
+    ``.pabgh`` index key) and an optional ``new_name``, append it to the
+    end of the table, then apply ``patches`` (a list of ``{field, new}``
+    sets) to the copy.
+
+    Returns ``(new_body, new_header)`` or ``None`` when the clone can't be
+    done safely. Corruption is impossible by construction + a mandatory
+    parse-back self-check:
+
+      * append-only — every existing record's bytes and ``.pabgh`` offset
+        are preserved untouched (verified: ``new_body`` starts with ``body``
+        and the rebuilt index equals the old one plus the new entry);
+      * the rebuilt table is re-decoded and the new record verified to be a
+        faithful copy of the source (equal on every non-patched field).
+
+    Any failure — bad key, key collision, unhandled ``.pabgh`` width, a
+    self-check miss — returns ``None`` so the caller emits no change.
+    """
+    tn = _table_name_from_target(table_name)
+    schema = get_schema(tn)
+    if schema is None:
+        return None
+
+    source_key = clone.get("source_key")
+    new_key = clone.get("new_key")
+    if isinstance(source_key, bool) or not isinstance(source_key, int):
+        return None
+    if isinstance(new_key, bool) or not isinstance(new_key, int):
+        return None
+
+    key_size, offsets = parse_pabgh_index(header, tn)
+    if not offsets or key_size not in (2, 4):
+        return None
+    if source_key not in offsets:
+        return None
+    if new_key in offsets:
+        return None  # collision — refuse rather than overwrite
+    if new_key < 0 or new_key >= (1 << (key_size * 8)):
+        return None  # doesn't fit the index key width
+
+    count = len(offsets)
+    count_size = len(header) - count * (key_size + 4)
+    if count_size not in (2, 4):
+        return None  # .pabgh isn't the plain [count][key,offset]* shape
+
+    src = _raw_entries(tn, body, header).get(source_key)
+    if not src:
+        return None
+
+    # Entry layout: [entry_id(eid_size)][name_len u32][name][0x00][payload]
+    eid_size = 2 if key_size == 2 else 4
+    if len(src) < eid_size + 4:
+        return None
+    name_len = struct.unpack_from("<I", src, eid_size)[0]
+    name_start = eid_size + 4
+    name_end = name_start + name_len
+    if name_end >= len(src) or src[name_end] != 0:
+        return None  # malformed / no null terminator where expected
+    payload = src[name_end + 1:]
+
+    new_name = clone.get("new_name")
+    if new_name is None:
+        name_bytes = src[name_start:name_end]
+    elif isinstance(new_name, str):
+        name_bytes = new_name.encode("utf-8")
+    else:
+        return None
+
+    new_entry = (
+        new_key.to_bytes(eid_size, "little")
+        + struct.pack("<I", len(name_bytes))
+        + name_bytes + b"\x00" + payload
+    )
+    new_offset = len(body)
+    new_body = bytes(body) + new_entry
+
+    # Append (new_key, new_offset) to the index; existing bytes preserved.
+    count_fmt = "<I" if count_size == 4 else "<H"
+    new_header = (
+        struct.pack(count_fmt, count + 1)
+        + bytes(header)[count_size:]
+        + new_key.to_bytes(key_size, "little")
+        + struct.pack("<I", new_offset)
+    )
+
+    # Apply patches to the fresh record via the trusted set writer.
+    patches = clone.get("patches") or []
+    try:
+        entry_name = name_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        entry_name = ""
+    patch_intents = [
+        Format3Intent(entry=entry_name, key=new_key,
+                      field=str(p["field"]), op="set", new=p["new"])
+        for p in patches
+        if isinstance(p, dict) and "field" in p and "new" in p
+    ]
+    if patch_intents:
+        new_body = apply_intents_to_pabgb_bytes(
+            tn, new_body, new_header, patch_intents)
+
+    # ── Self-check: corruption-proof gate ──────────────────────────
+    # 1. Append-only: original body prefix untouched.
+    if new_body[:len(body)] != body:
+        return None
+    # 2. Index integrity: rebuilt index == old index + the new entry.
+    ks2, offs2 = parse_pabgh_index(new_header, tn)
+    if ks2 != key_size:
+        return None
+    expected = dict(offsets)
+    expected[new_key] = new_offset
+    if offs2 != expected:
+        return None
+    # 3. Faithful copy: decode both and compare the new record to the
+    #    source on every non-metadata, non-patched field.
+    field_specs = {f.name: f for f in schema.fields}
+    patched_names = set()
+    for p in patches:
+        if isinstance(p, dict) and "field" in p:
+            r = _resolve_schema_field_name(str(p["field"]), field_specs)
+            if r:
+                patched_names.add(r)
+    old_records = parse_records(tn, body, header)
+    new_records = parse_records(tn, new_body, new_header)
+    if new_key not in new_records or source_key not in old_records:
+        return None
+    src_rec = old_records[source_key]
+    new_rec = new_records[new_key]
+    _meta = {"_key", "_entry_id", "_name"}
+    for fname, val in src_rec.items():
+        if fname in _meta or fname in patched_names:
+            continue
+        if new_rec.get(fname) != val:
+            return None
+    # 4. Every original record still decodes byte-identically.
+    old_raw = _raw_entries(tn, body, header)
+    new_raw = _raw_entries(tn, new_body, new_header)
+    for k, rb in old_raw.items():
+        if new_raw.get(k) != rb:
+            return None
+
+    return new_body, new_header
 
 
 def apply_intents_to_pabgb_bytes(

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -735,12 +735,23 @@ def _classify_clone(
         pf = str(p.get("field", "")) if isinstance(p, dict) else ""
         if not pf:
             return "clone_record patch is missing a 'field'"
+        # gear_stat[...] on iteminfo is a byte-exact same-width i64 stat
+        # overwrite located structurally in the record's opaque tail ,
+        # allowed the same as a gear_stat SET on an existing item. Editing
+        # a stat the clone doesn't carry is a clean no-op at apply time.
+        if pf.startswith("gear_stat[") and table_name == "iteminfo":
+            if _gear_stats_available():
+                continue
+            return (
+                f"clone patch field {pf!r} targets a gear stat, but "
+                f"gear-stat editing isn't available in this build"
+            )
         resolved = _resolve_schema_field_name(pf, field_specs)
         if resolved is None:
             return (
                 f"clone patch field {pf!r} isn't a plain schema field; "
-                f"clone patches currently support verified scalar fields "
-                f"only"
+                f"clone patches support verified scalar fields and "
+                f"gear_stat[...] on iteminfo"
             )
         if vf is not None and resolved not in vf:
             return (
@@ -1572,6 +1583,60 @@ def _raw_entries(table_name: str, body: bytes, header: bytes
     return out
 
 
+def _gear_stats_available() -> bool:
+    """Whether the gear-stat editing module is present in this build. It
+    ships with the gear-stats feature; guarding on it keeps clone's
+    gear_stat support from breaking builds where that feature isn't
+    merged yet (so this file stays independent of it)."""
+    try:
+        import cdumm.engine.gear_stats  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _apply_gear_patches_to_new_record(
+    table_name: str, new_body: bytes, new_header: bytes,
+    new_offset: int, gear_patches: list[dict],
+) -> bytes | None:
+    """Apply ``gear_stat[...]`` patches to the freshly-cloned record (the
+    last record, at ``new_offset``).
+
+    Each patch is a byte-exact **same-width** i64 overwrite located
+    structurally in the record's opaque equipment tail — the same
+    mechanism as a gear_stat SET on an existing item, verified byte-exact
+    on the live iteminfo table. A stat the clone doesn't carry is a clean
+    no-op. Returns the new body, or ``None`` if an edit somehow changed
+    the record length (a same-width overwrite never should)."""
+    try:
+        from cdumm.engine import gear_stats as _gs
+    except Exception:
+        # gear-stat editing not in this build -> leave the clone as-is
+        # (validate already gates gear_stat patches on availability).
+        return bytes(new_body)
+    all_recs = _raw_entries(table_name, new_body, new_header)
+    if not all_recs:
+        return None
+    whitelist = _gs.build_stat_whitelist(list(all_recs.values()))
+    rec = bytes(new_body)[new_offset:]   # the appended clone
+    located = _gs.locate_gear_stats(rec, whitelist)
+    edited = rec
+    for p in gear_patches:
+        idx = _gs.resolve_gear_stat_index(str(p["field"]), located)
+        if idx is None:
+            continue   # clone doesn't carry this stat -> clean no-op
+        try:
+            nv = int(p["new"])
+        except (TypeError, ValueError):
+            continue
+        edited = _gs.apply_stat_edit(
+            edited, located[idx].value_offset, nv)
+        located = _gs.locate_gear_stats(edited, whitelist)
+    if len(edited) != len(rec):
+        return None   # same-width overwrite must not change length
+    return bytes(new_body)[:new_offset] + edited
+
+
 def apply_clone_to_pabgb_bytes(
     table_name: str,
     body: bytes,
@@ -1666,21 +1731,36 @@ def apply_clone_to_pabgb_bytes(
         + struct.pack("<I", new_offset)
     )
 
-    # Apply patches to the fresh record via the trusted set writer.
-    patches = clone.get("patches") or []
+    # Apply patches to the fresh record. Scalar fields go through the
+    # trusted set writer; gear_stat[...] fields are byte-exact same-width
+    # i64 overwrites located structurally in the record's opaque tail
+    # (only the freshly-appended clone is touched — it's the last record).
+    patches = [p for p in (clone.get("patches") or [])
+               if isinstance(p, dict) and "field" in p and "new" in p]
     try:
         entry_name = name_bytes.decode("utf-8")
     except UnicodeDecodeError:
         entry_name = ""
-    patch_intents = [
-        Format3Intent(entry=entry_name, key=new_key,
-                      field=str(p["field"]), op="set", new=p["new"])
-        for p in patches
-        if isinstance(p, dict) and "field" in p and "new" in p
-    ]
-    if patch_intents:
+    scalar_patches = [
+        p for p in patches
+        if not str(p["field"]).startswith("gear_stat[")]
+    gear_patches = [
+        p for p in patches
+        if str(p["field"]).startswith("gear_stat[")]
+    if scalar_patches:
+        patch_intents = [
+            Format3Intent(entry=entry_name, key=new_key,
+                          field=str(p["field"]), op="set", new=p["new"])
+            for p in scalar_patches
+        ]
         new_body = apply_intents_to_pabgb_bytes(
             tn, new_body, new_header, patch_intents)
+    if gear_patches:
+        edited = _apply_gear_patches_to_new_record(
+            tn, new_body, new_header, new_offset, gear_patches)
+        if edited is None:
+            return None
+        new_body = edited
 
     # ── Self-check: corruption-proof gate ──────────────────────────
     # 1. Append-only: original body prefix untouched.

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -123,6 +123,14 @@ class Format3Intent:
     for ``old`` bytes and replaces them with ``new``. For regular
     primitive / list intents ``old`` stays None and ``new`` is the
     typed value to set.
+
+    ``match`` is an optional selector: when set to a ``{field: value}``
+    mapping, the intent targets *every* record in the table whose
+    fields all equal the given values (AND across conditions) instead
+    of a single ``entry``/``key``. The apply path decodes the table and
+    expands one such intent into N concrete per-record ``set`` intents
+    before writing, so no new byte-writing path is introduced. When
+    ``match`` is set, ``entry`` is empty and ``key`` is 0 (both unused).
     """
     entry: str
     key: int
@@ -130,6 +138,7 @@ class Format3Intent:
     op: str
     new: Any
     old: str | None = None
+    match: dict | None = None
 
 
 @dataclass
@@ -201,7 +210,24 @@ def _parse_intents_block(
         # mod author may not have populated. Accept missing key when an
         # entry name is present, default it to 0 (apply path looks up by
         # entry name and only falls back to key if the name miss).
-        for required in ("entry", "field"):
+        # A ``match`` selector replaces the single-record ``entry``/``key``
+        # locator: it targets every record whose fields all equal the
+        # given values (AND). When present, ``entry`` is not required ,
+        # the apply path resolves records by decoding the table. ``field``
+        # and ``new`` are always required.
+        raw_match = raw.get("match")
+        if raw_match is not None and (
+            not isinstance(raw_match, dict) or not raw_match
+        ):
+            raise ValueError(
+                f"{label} intent #{i} has an invalid 'match' selector; "
+                f"'match' must be a non-empty object of field:value "
+                f"conditions"
+            )
+        required_keys = (
+            ("field",) if raw_match is not None else ("entry", "field")
+        )
+        for required in required_keys:
             if required not in raw:
                 raise ValueError(
                     f"{label} intent #{i} is missing required key "
@@ -245,12 +271,13 @@ def _parse_intents_block(
         # one unsupported intent shows up in the per-mod skipped summary
         # instead of taking the whole import down.
         intents.append(Format3Intent(
-            entry=str(raw["entry"]),
+            entry=str(raw.get("entry", "")),
             key=raw_key,
             field=str(raw["field"]),
             op=str(raw.get("op", "set")),
             new=raw["new"],
             old=raw_old,
+            match=raw_match,
         ))
     return intents
 
@@ -501,6 +528,60 @@ def _partition_unsupported_op(
     )
 
 
+def _resolve_schema_field_name(
+    name: str, field_specs: dict
+) -> str | None:
+    """Resolve a mod-authored field name to its canonical schema field
+    name, trying the same four shapes the writer uses (exact /
+    +underscore / snake→camel / snake→camel +underscore). Returns None
+    if no shape is present in ``field_specs``."""
+    cand = [name, f"_{name}"]
+    if "_" in name:
+        camel = _snake_to_camel(name)
+        if camel != name:
+            cand += [camel, f"_{camel}"]
+    for n in cand:
+        if n in field_specs:
+            return n
+    return None
+
+
+# Metadata keys ``parse_records`` always attaches, decoded from the
+# entry header (not the payload) so they're trustworthy to match on
+# regardless of a table's ``verified_fields`` coverage.
+_MATCH_META_FIELDS = frozenset({"_name", "_key", "_entry_id"})
+
+
+def _classify_match_selector(
+    intent: Format3Intent, schema, field_specs: dict
+) -> str | None:
+    """Validate a ``match`` intent's selector fields. Returns None when
+    every match-field is safe to compare against — a hand-verified field
+    (present in the table's ``verified_fields``) or the always-safe
+    ``_name``/``_key``/``_entry_id`` metadata — otherwise a skip reason.
+
+    Matching on an unverified field would compare against a garbage
+    decode (its byte offset is unproven), so we refuse it, mirroring the
+    write-time gate in ``format3_apply._resolve_write_pos``.
+    """
+    match = intent.match or {}
+    vf = getattr(schema, "verified_fields", None)
+    for mf in match:
+        if mf in _MATCH_META_FIELDS:
+            continue
+        resolved = _resolve_schema_field_name(mf, field_specs)
+        if resolved is None:
+            return (
+                f"match field {mf!r} is not a known field of this table"
+            )
+        if vf is not None and resolved not in vf:
+            return (
+                f"match field {mf!r} is not a verified field of this "
+                f"table; matching on an unverified field is unsafe"
+            )
+    return None
+
+
 def validate_intents(
     target: str, intents: list[Format3Intent]
 ) -> Format3Validation:
@@ -523,6 +604,22 @@ def validate_intents(
         #      ``old`` inside the entry's payload bounds. Used by
         #      _buff_data_raw style intents on skill.pabgb where the
         #      mod author ships the full vanilla + modded bytes.
+        #
+        # A ``match`` selector needs a decoded PABGB schema (parse_records)
+        # to resolve which records it applies to; a table with no schema
+        # can't support it. Skip those here with a precise reason so they
+        # never slip through to the writer unexpanded.
+        kept: list[Format3Intent] = []
+        for mi in intents:
+            if mi.match is not None:
+                result.skipped.append((
+                    mi,
+                    f"match selector needs a decoded schema for table "
+                    f"'{table_name}', which CDUMM doesn't have yet"))
+            else:
+                kept.append(mi)
+        intents = kept
+
         fs_entries = load_field_schema(table_name)
 
         def _routable(i: Format3Intent) -> bool:
@@ -577,6 +674,11 @@ def validate_intents(
             continue
         reason = _classify_intent(
             intent, schema, field_specs, fs_entries, table_name)
+        # A match selector additionally requires every match-field to be
+        # safe to compare against (verified or metadata). The target
+        # field itself was already vetted by _classify_intent above.
+        if reason is None and intent.match is not None:
+            reason = _classify_match_selector(intent, schema, field_specs)
         if reason is None:
             result.supported.append(intent)
         else:

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -230,6 +230,21 @@ def _parse_clone_intent(raw: dict, i: int, label: str) -> Format3Intent:
     )
 
 
+def _parse_delete_intent(raw: dict, i: int, label: str) -> Format3Intent:
+    """Parse a ``delete_record`` intent: ``{"op":"delete_record",
+    "key":N}`` (optional ``entry`` for a friendlier log label)."""
+    key = raw.get("key")
+    if isinstance(key, bool) or not isinstance(key, int):
+        raise ValueError(
+            f"{label} intent #{i} delete_record needs an integer 'key' "
+            f"(the record to remove); got {key!r}"
+        )
+    return Format3Intent(
+        entry=str(raw.get("entry", "")), key=key, field="",
+        op="delete_record", new=None,
+    )
+
+
 def _parse_intents_block(
     raw_intents, label: str = "intents",
 ) -> list[Format3Intent]:
@@ -256,6 +271,9 @@ def _parse_intents_block(
         # entry/field/new triple, so parse it here and move on.
         if raw.get("op") == "clone_record":
             intents.append(_parse_clone_intent(raw, i, label))
+            continue
+        if raw.get("op") == "delete_record":
+            intents.append(_parse_delete_intent(raw, i, label))
             continue
         # The newer skill .field.json variant drops 'op' since 'set'
         # is implicit. We default to 'set' when absent. GitHub #66.
@@ -687,6 +705,15 @@ def _classify_clone(
     return None
 
 
+def _classify_delete(intent: Format3Intent) -> str | None:
+    """Validate a ``delete_record`` intent. Structural only — whether the
+    key exists is checked against the real bytes at apply time (the
+    delete writer refuses + logs a miss)."""
+    if isinstance(intent.key, bool) or not isinstance(intent.key, int):
+        return "delete_record needs an integer 'key' (the record to remove)"
+    return None
+
+
 def validate_intents(
     target: str, intents: list[Format3Intent]
 ) -> Format3Validation:
@@ -725,6 +752,11 @@ def validate_intents(
                 result.skipped.append((
                     mi,
                     f"clone_record needs a decoded schema for table "
+                    f"'{table_name}', which CDUMM doesn't have yet"))
+            elif mi.op == "delete_record":
+                result.skipped.append((
+                    mi,
+                    f"delete_record needs a decoded schema for table "
                     f"'{table_name}', which CDUMM doesn't have yet"))
             else:
                 kept.append(mi)
@@ -781,6 +813,13 @@ def validate_intents(
         if intent.op == "clone_record" or intent.clone is not None:
             reason = _classify_clone(
                 intent, schema, field_specs, fs_entries, table_name)
+            if reason is None:
+                result.supported.append(intent)
+            else:
+                result.skipped.append((intent, reason))
+            continue
+        if intent.op == "delete_record":
+            reason = _classify_delete(intent)
             if reason is None:
                 result.supported.append(intent)
             else:
@@ -1562,6 +1601,86 @@ def apply_clone_to_pabgb_bytes(
         if new_raw.get(k) != rb:
             return None
 
+    return new_body, new_header
+
+
+def apply_delete_to_pabgb_bytes(
+    table_name: str,
+    body: bytes,
+    header: bytes,
+    key: int,
+) -> tuple[bytes, bytes] | None:
+    """Delete record ``key`` from a table -> ``(new_body, new_header)``
+    or ``None`` when it can't be done safely.
+
+    Rebuilds the body from the surviving entries (in body order) and the
+    ``.pabgh`` index in its original file order with remapped offsets.
+    Parse-back self-checked: the deleted key is gone, every surviving
+    record decodes byte-identically, the index key set matches, and the
+    body shrank by exactly the removed entry's size. Any failure returns
+    ``None`` so the caller emits no change.
+
+    (Byte-safety only: removing a record other tables reference is the
+    modder's concern, same as any mod — this guarantees the table stays
+    well-formed, not that the game likes it.)
+    """
+    tn = _table_name_from_target(table_name)
+    if get_schema(tn) is None:
+        return None
+    if isinstance(key, bool) or not isinstance(key, int):
+        return None
+    key_size, offsets = parse_pabgh_index(header, tn)
+    if not offsets or key_size not in (2, 4):
+        return None
+    if key not in offsets:
+        return None
+    count = len(offsets)
+    count_size = len(header) - count * (key_size + 4)
+    if count_size not in (2, 4):
+        return None
+    raws = _raw_entries(tn, body, header)
+    if key not in raws:
+        return None
+
+    ordered = sorted(offsets.items(), key=lambda kv: kv[1])
+    new_body = bytearray()
+    oldoff_to_newoff: dict[int, int] = {}
+    for k, off in ordered:
+        if k == key:
+            continue
+        oldoff_to_newoff[off] = len(new_body)
+        new_body += raws[k]
+
+    count_fmt = "<I" if count_size == 4 else "<H"
+    idx = bytearray(struct.pack(count_fmt, count - 1))
+    for k, off in offsets.items():  # preserve original index file order
+        if k == key:
+            continue
+        idx += k.to_bytes(key_size, "little")
+        idx += struct.pack("<I", oldoff_to_newoff[off])
+    new_body = bytes(new_body)
+    new_header = bytes(idx)
+
+    # ── Self-check ──
+    ks2, offs2 = parse_pabgh_index(new_header, tn)
+    if ks2 != key_size:
+        return None
+    survivors = {k for k in offsets if k != key}
+    if set(offs2) != survivors:
+        return None
+    old_records = parse_records(tn, body, header)
+    new_records = parse_records(tn, new_body, new_header)
+    if key in new_records:
+        return None
+    for k in survivors:
+        if new_records.get(k) != old_records.get(k):
+            return None
+    new_raw = _raw_entries(tn, new_body, new_header)
+    for k in survivors:
+        if new_raw.get(k) != raws.get(k):
+            return None
+    if len(new_body) != len(body) - len(raws[key]):
+        return None
     return new_body, new_header
 
 

--- a/tests/test_format3_clone_record.py
+++ b/tests/test_format3_clone_record.py
@@ -243,6 +243,31 @@ def test_validate_clone_no_schema_skipped():
     assert "needs a decoded schema" in v.skipped[0][1]
 
 
+def test_validate_clone_gear_stat_patch_on_iteminfo():
+    # gear_stat[...] on iteminfo is a byte-exact structural stat overwrite,
+    # so clone patches may target it (real: clone a weapon, buff its damage)
+    # — but only when the gear-stat feature is present in the build.
+    from cdumm.engine.format3_handler import _gear_stats_available
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 1000080, "new_key": 1000090,
+        "patches": [{"field": "gear_stat[1000000]", "new": 500}]}])[0]
+    v = validate_intents("iteminfo.pabgb", [i])
+    if _gear_stats_available():
+        assert i in v.supported, v.skipped
+    else:
+        assert not v.supported
+        assert "gear-stat editing isn't available" in v.skipped[0][1]
+
+
+def test_validate_clone_rejects_gear_stat_on_non_iteminfo(monkeypatch):
+    _inject(monkeypatch, verified_fields=frozenset({"_foo", "_bar"}))
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "gear_stat[5]", "new": 1}]}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert not v.supported   # gear_stat is only allowed on iteminfo
+
+
 # ── Apply-pipeline wiring ───────────────────────────────────────────
 
 

--- a/tests/test_format3_clone_record.py
+++ b/tests/test_format3_clone_record.py
@@ -1,0 +1,300 @@
+"""Format 3 ``clone_record`` — parse, engine-core byte-exactness, the
+parse-back self-check gate, validation, and apply-pipeline wiring.
+
+``clone_record`` deep-copies a source record to a new key + optional name
+and applies field patches to the copy. It is append-only (existing records
+are never touched) and every clone is parse-back self-checked before it is
+committed, so corruption is impossible: a clone the engine can't do safely
+returns None and is skipped.
+
+Uses the same synthetic all-flat table the binary-roundtrip test uses.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.format3_apply import _build_clone_change_for_target
+from cdumm.engine.format3_handler import (
+    Format3Intent,
+    _parse_intents_block,
+    apply_clone_to_pabgb_bytes,
+    validate_intents,
+)
+from cdumm.semantic import parser as parser_mod
+from cdumm.semantic.parser import FieldSpec, TableSchema, parse_records
+
+
+def _inject(monkeypatch, verified_fields=None):
+    fields = [
+        FieldSpec(name="_key", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_foo", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_bar", stream_size=2,
+                  field_type="direct_u16", struct_fmt="H"),
+    ]
+    schema = TableSchema(table_name="synthtest", fields=fields,
+                         verified_fields=verified_fields)
+    original = parser_mod._loaded_schemas
+    if original is None:
+        parser_mod._load_schemas()
+        original = parser_mod._loaded_schemas
+    new_cache = dict(original or {})
+    new_cache["synthtest"] = schema
+    monkeypatch.setattr(parser_mod, "_loaded_schemas", new_cache)
+    return schema
+
+
+def _build_entry(entry_id, name, key_value, foo, bar):
+    name_bytes = name.encode("utf-8")
+    head = struct.pack("<II", entry_id, len(name_bytes))
+    payload = struct.pack("<IIH", key_value, foo, bar)
+    return head + name_bytes + b"\x00" + payload
+
+
+def _build_pabgb_pair(entries):
+    body = bytearray()
+    keys_offsets = []
+    for entry_id, name, key, foo, bar in entries:
+        offset = len(body)
+        body.extend(_build_entry(entry_id, name, key, foo, bar))
+        keys_offsets.append((key, offset))
+    header = bytearray(struct.pack("<H", len(entries)))
+    for k, o in keys_offsets:
+        header.extend(struct.pack("<II", k, o))
+    return bytes(body), bytes(header)
+
+
+# ── Parsing ─────────────────────────────────────────────────────────
+
+
+def test_parse_accepts_clone_record():
+    intents = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "new_name": "Copy", "patches": [{"field": "_bar", "new": 9}],
+    }])
+    assert len(intents) == 1
+    i = intents[0]
+    assert i.op == "clone_record"
+    assert i.clone == {
+        "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_bar", "new": 9}], "new_name": "Copy",
+    }
+    assert i.entry == "" and i.field == "" and i.new is None
+
+
+def test_parse_clone_defaults_empty_patches_and_no_name():
+    i = _parse_intents_block(
+        [{"op": "clone_record", "source_key": 1, "new_key": 2}])[0]
+    assert i.clone["patches"] == []
+    assert "new_name" not in i.clone
+
+
+@pytest.mark.parametrize("bad", [
+    {"op": "clone_record", "new_key": 2},                       # no source
+    {"op": "clone_record", "source_key": 1},                    # no new_key
+    {"op": "clone_record", "source_key": "x", "new_key": 2},    # non-int
+    {"op": "clone_record", "source_key": 1, "new_key": 2,
+     "patches": "nope"},                                        # patches not list
+    {"op": "clone_record", "source_key": 1, "new_key": 2,
+     "patches": [{"field": "_bar"}]},                           # patch no new
+    {"op": "clone_record", "source_key": 1, "new_key": 2,
+     "new_name": 7},                                            # non-str name
+])
+def test_parse_rejects_bad_clone(bad):
+    with pytest.raises(ValueError):
+        _parse_intents_block([bad])
+
+
+# ── Engine core: byte-exact + self-check ────────────────────────────
+
+
+def test_clone_no_patch_is_faithful_copy(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "First", 100, 0xAAAA1111, 0x55),
+        (2, "Second", 200, 0xBBBB2222, 0x66),
+    ])
+    res = apply_clone_to_pabgb_bytes(
+        "synthtest", body, header, {"source_key": 100, "new_key": 500})
+    assert res is not None
+    new_body, new_header = res
+    # append-only: original body prefix untouched
+    assert new_body[:len(body)] == body
+    recs = parse_records("synthtest", new_body, new_header)
+    assert set(recs) == {100, 200, 500}
+    # the clone equals the source on every data field
+    assert recs[500]["_foo"] == recs[100]["_foo"] == 0xAAAA1111
+    assert recs[500]["_bar"] == recs[100]["_bar"] == 0x55
+    # originals unchanged
+    assert recs[200]["_foo"] == 0xBBBB2222
+
+
+def test_clone_with_patch_applies_only_to_copy(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "First", 100, 0xAAAA1111, 0x55),
+    ])
+    res = apply_clone_to_pabgb_bytes(
+        "synthtest", body, header,
+        {"source_key": 100, "new_key": 500,
+         "patches": [{"field": "_bar", "new": 0x99}]})
+    assert res is not None
+    new_body, new_header = res
+    recs = parse_records("synthtest", new_body, new_header)
+    assert recs[500]["_bar"] == 0x99          # patched on the copy
+    assert recs[500]["_foo"] == 0xAAAA1111     # copied unchanged
+    assert recs[100]["_bar"] == 0x55           # source untouched
+
+
+def test_clone_new_name(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "First", 100, 7, 0x55)])
+    res = apply_clone_to_pabgb_bytes(
+        "synthtest", body, header,
+        {"source_key": 100, "new_key": 500, "new_name": "Cloned"})
+    assert res is not None
+    new_body, new_header = res
+    recs = parse_records("synthtest", new_body, new_header)
+    assert recs[500]["_name"] == "Cloned"
+    assert recs[100]["_name"] == "First"
+
+
+def test_clone_key_collision_refused(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "First", 100, 7, 0x55),
+        (2, "Second", 200, 8, 0x66),
+    ])
+    # new_key 200 already exists -> refuse (return None), never overwrite
+    assert apply_clone_to_pabgb_bytes(
+        "synthtest", body, header,
+        {"source_key": 100, "new_key": 200}) is None
+
+
+def test_clone_missing_source_refused(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "First", 100, 7, 0x55)])
+    assert apply_clone_to_pabgb_bytes(
+        "synthtest", body, header,
+        {"source_key": 999, "new_key": 500}) is None
+
+
+def test_clone_index_grows_by_one_entry(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "First", 100, 7, 0x55)])
+    res = apply_clone_to_pabgb_bytes(
+        "synthtest", body, header, {"source_key": 100, "new_key": 500})
+    assert res is not None
+    _new_body, new_header = res
+    ks, offs = parser_mod.parse_pabgh_index(new_header, "synthtest")
+    assert ks == 4
+    assert set(offs) == {100, 500}
+    assert offs[100] == 0                 # original offset preserved
+    assert offs[500] == len(body)         # clone appended at the end
+
+
+def test_clone_unknown_table_refused():
+    body, header = _build_pabgb_pair([(1, "First", 100, 7, 0x55)])
+    assert apply_clone_to_pabgb_bytes(
+        "notarealtable", body, header,
+        {"source_key": 100, "new_key": 500}) is None
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+
+def test_validate_clone_supported_with_verified_patch(monkeypatch):
+    _inject(monkeypatch, verified_fields=frozenset({"_foo", "_bar"}))
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_bar", "new": 9}]}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert i in v.supported, v.skipped
+
+
+def test_validate_clone_unverified_patch_skipped(monkeypatch):
+    _inject(monkeypatch, verified_fields=frozenset({"_bar"}))  # _foo unverified
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_foo", "new": 9}]}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert not v.supported
+    assert "not a verified field" in v.skipped[0][1]
+
+
+def test_validate_clone_unknown_patch_skipped(monkeypatch):
+    _inject(monkeypatch, verified_fields=frozenset({"_foo", "_bar"}))
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_nope", "new": 9}]}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert not v.supported
+    assert "plain schema field" in v.skipped[0][1]
+
+
+def test_validate_clone_no_schema_skipped():
+    i = _parse_intents_block([{
+        "op": "clone_record", "source_key": 1, "new_key": 2}])[0]
+    v = validate_intents("definitelynotatable.pabgb", [i])
+    assert not v.supported
+    assert "needs a decoded schema" in v.skipped[0][1]
+
+
+# ── Apply-pipeline wiring ───────────────────────────────────────────
+
+
+def test_build_clone_change_emits_whole_table_change(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "First", 100, 0xAAAA1111, 0x55)])
+    intent = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_bar", "new": 0x99}]}])[0]
+    body_change, companion, n = _build_clone_change_for_target(
+        "synthtest.pabgb", body, header, [intent])
+    assert n == 1
+    assert body_change is not None and companion is not None
+    assert body_change["offset"] == 0
+    assert body_change["original"] == body.hex()
+    assert body_change["patched"] != body.hex()
+    # the emitted body parses back with the clone present + patched
+    new_body = bytes.fromhex(body_change["patched"])
+    new_header = bytes.fromhex(companion["patched"])
+    recs = parse_records("synthtest", new_body, new_header)
+    assert recs[500]["_bar"] == 0x99
+    assert recs[500]["_foo"] == 0xAAAA1111
+    assert recs[100]["_bar"] == 0x55
+
+
+def test_build_clone_change_all_refused_returns_none(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "First", 100, 7, 0x55),
+        (2, "Second", 200, 8, 0x66),
+    ])
+    # collision on the only clone -> nothing applied
+    intent = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 200}])[0]
+    body_change, companion, n = _build_clone_change_for_target(
+        "synthtest.pabgb", body, header, [intent])
+    assert (body_change, companion, n) == (None, None, 0)
+
+
+def test_build_clone_change_composes_with_set(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "First", 100, 0xAAAA1111, 0x55)])
+    clone = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500}])[0]
+    # a plain set on the ORIGINAL record, alongside the clone
+    plain = Format3Intent(entry="First", key=100, field="_bar",
+                          op="set", new=0x77)
+    body_change, companion, n = _build_clone_change_for_target(
+        "synthtest.pabgb", body, header, [clone, plain])
+    assert n == 1
+    new_body = bytes.fromhex(body_change["patched"])
+    new_header = bytes.fromhex(companion["patched"])
+    recs = parse_records("synthtest", new_body, new_header)
+    assert recs[100]["_bar"] == 0x77      # set applied to original
+    assert recs[500]["_bar"] == 0x55      # clone kept source value

--- a/tests/test_format3_clone_record.py
+++ b/tests/test_format3_clone_record.py
@@ -15,7 +15,7 @@ import struct
 
 import pytest
 
-from cdumm.engine.format3_apply import _build_clone_change_for_target
+from cdumm.engine.format3_apply import _build_record_ops_change_for_target
 from cdumm.engine.format3_handler import (
     Format3Intent,
     _parse_intents_block,
@@ -252,7 +252,7 @@ def test_build_clone_change_emits_whole_table_change(monkeypatch):
     intent = _parse_intents_block([{
         "op": "clone_record", "source_key": 100, "new_key": 500,
         "patches": [{"field": "_bar", "new": 0x99}]}])[0]
-    body_change, companion, n = _build_clone_change_for_target(
+    body_change, companion, n = _build_record_ops_change_for_target(
         "synthtest.pabgb", body, header, [intent])
     assert n == 1
     assert body_change is not None and companion is not None
@@ -277,7 +277,7 @@ def test_build_clone_change_all_refused_returns_none(monkeypatch):
     # collision on the only clone -> nothing applied
     intent = _parse_intents_block([{
         "op": "clone_record", "source_key": 100, "new_key": 200}])[0]
-    body_change, companion, n = _build_clone_change_for_target(
+    body_change, companion, n = _build_record_ops_change_for_target(
         "synthtest.pabgb", body, header, [intent])
     assert (body_change, companion, n) == (None, None, 0)
 
@@ -290,7 +290,7 @@ def test_build_clone_change_composes_with_set(monkeypatch):
     # a plain set on the ORIGINAL record, alongside the clone
     plain = Format3Intent(entry="First", key=100, field="_bar",
                           op="set", new=0x77)
-    body_change, companion, n = _build_clone_change_for_target(
+    body_change, companion, n = _build_record_ops_change_for_target(
         "synthtest.pabgb", body, header, [clone, plain])
     assert n == 1
     new_body = bytes.fromhex(body_change["patched"])

--- a/tests/test_format3_delete_record.py
+++ b/tests/test_format3_delete_record.py
@@ -1,0 +1,210 @@
+"""Format 3 ``delete_record`` — parse, byte-exact engine core with the
+parse-back self-check, validation, and apply-pipeline wiring.
+
+Deleting a record rebuilds the body from the survivors and reindexes the
+``.pabgh`` (offsets after the removed record shift). Every survivor must
+decode byte-identically and the deleted key must be gone — verified before
+anything is committed; else the delete is refused.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.format3_apply import _build_record_ops_change_for_target
+from cdumm.engine.format3_handler import (
+    Format3Intent,
+    _parse_intents_block,
+    apply_delete_to_pabgb_bytes,
+    validate_intents,
+)
+from cdumm.semantic import parser as parser_mod
+from cdumm.semantic.parser import FieldSpec, TableSchema, parse_records
+
+
+def _inject(monkeypatch, verified_fields=None):
+    fields = [
+        FieldSpec(name="_key", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_foo", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_bar", stream_size=2,
+                  field_type="direct_u16", struct_fmt="H"),
+    ]
+    schema = TableSchema(table_name="synthtest", fields=fields,
+                         verified_fields=verified_fields)
+    original = parser_mod._loaded_schemas
+    if original is None:
+        parser_mod._load_schemas()
+        original = parser_mod._loaded_schemas
+    new_cache = dict(original or {})
+    new_cache["synthtest"] = schema
+    monkeypatch.setattr(parser_mod, "_loaded_schemas", new_cache)
+    return schema
+
+
+def _entry(entry_id, name, key, foo, bar):
+    nb = name.encode("utf-8")
+    return struct.pack("<II", entry_id, len(nb)) + nb + b"\x00" + \
+        struct.pack("<IIH", key, foo, bar)
+
+
+def _pair(entries):
+    body = bytearray()
+    ko = []
+    for eid, name, key, foo, bar in entries:
+        ko.append((key, len(body)))
+        body += _entry(eid, name, key, foo, bar)
+    header = bytearray(struct.pack("<H", len(entries)))
+    for k, o in ko:
+        header += struct.pack("<II", k, o)
+    return bytes(body), bytes(header)
+
+
+# ── Parsing ─────────────────────────────────────────────────────────
+
+
+def test_parse_accepts_delete_record():
+    i = _parse_intents_block(
+        [{"op": "delete_record", "key": 200, "entry": "Second"}])[0]
+    assert i.op == "delete_record" and i.key == 200
+
+
+@pytest.mark.parametrize("bad", [
+    {"op": "delete_record"},                     # no key
+    {"op": "delete_record", "key": "x"},         # non-int
+    {"op": "delete_record", "key": True},        # bool
+])
+def test_parse_rejects_bad_delete(bad):
+    with pytest.raises(ValueError):
+        _parse_intents_block([bad])
+
+
+# ── Engine core ─────────────────────────────────────────────────────
+
+
+def test_delete_middle_record(monkeypatch):
+    _inject(monkeypatch)
+    entries = [
+        (1, "First", 100, 0xAAAA1111, 0x55),
+        (2, "Second", 200, 0xBBBB2222, 0x66),
+        (3, "Third", 300, 0xCCCC3333, 0x77),
+    ]
+    body, header = _pair(entries)
+    removed = _entry(*entries[1])
+    res = apply_delete_to_pabgb_bytes("synthtest", body, header, 200)
+    assert res is not None
+    nb, nh = res
+    recs = parse_records("synthtest", nb, nh)
+    assert set(recs) == {100, 300}
+    assert recs[100]["_foo"] == 0xAAAA1111 and recs[100]["_bar"] == 0x55
+    assert recs[300]["_foo"] == 0xCCCC3333 and recs[300]["_bar"] == 0x77
+    assert len(nb) == len(body) - len(removed)
+
+
+def test_delete_first_and_last(monkeypatch):
+    _inject(monkeypatch)
+    entries = [
+        (1, "First", 100, 1, 0x11),
+        (2, "Second", 200, 2, 0x22),
+        (3, "Third", 300, 3, 0x33),
+    ]
+    body, header = _pair(entries)
+    nb, nh = apply_delete_to_pabgb_bytes("synthtest", body, header, 100)
+    assert set(parse_records("synthtest", nb, nh)) == {200, 300}
+    nb2, nh2 = apply_delete_to_pabgb_bytes("synthtest", body, header, 300)
+    assert set(parse_records("synthtest", nb2, nh2)) == {100, 200}
+
+
+def test_delete_missing_key_refused(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([(1, "First", 100, 1, 0x11)])
+    assert apply_delete_to_pabgb_bytes(
+        "synthtest", body, header, 999) is None
+
+
+def test_delete_non_int_refused(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([(1, "First", 100, 1, 0x11)])
+    assert apply_delete_to_pabgb_bytes(
+        "synthtest", body, header, "x") is None
+
+
+def test_delete_unknown_table_refused():
+    body, header = _pair([(1, "First", 100, 1, 0x11)])
+    assert apply_delete_to_pabgb_bytes(
+        "notarealtable", body, header, 100) is None
+
+
+def test_delete_survivors_byte_identical(monkeypatch):
+    _inject(monkeypatch)
+    entries = [
+        (1, "First", 100, 0x11111111, 0x55),
+        (2, "Second", 200, 0x22222222, 0x66),
+        (3, "Third", 300, 0x33333333, 0x77),
+    ]
+    body, header = _pair(entries)
+    nb, nh = apply_delete_to_pabgb_bytes("synthtest", body, header, 200)
+    # concatenating the two surviving raw entries reproduces the new body
+    assert nb == _entry(*entries[0]) + _entry(*entries[2])
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+
+def test_validate_delete_supported(monkeypatch):
+    _inject(monkeypatch)
+    i = _parse_intents_block([{"op": "delete_record", "key": 100}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert i in v.supported
+
+
+def test_validate_delete_no_schema_skipped():
+    i = _parse_intents_block([{"op": "delete_record", "key": 100}])[0]
+    v = validate_intents("definitelynotatable.pabgb", [i])
+    assert not v.supported and "needs a decoded schema" in v.skipped[0][1]
+
+
+# ── Apply-pipeline wiring ───────────────────────────────────────────
+
+
+def test_build_change_deletes(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([
+        (1, "First", 100, 1, 0x55),
+        (2, "Second", 200, 2, 0x66),
+    ])
+    intent = _parse_intents_block([{"op": "delete_record", "key": 200}])[0]
+    bc, comp, n = _build_record_ops_change_for_target(
+        "synthtest.pabgb", body, header, [intent])
+    assert n == 1 and bc is not None and comp is not None
+    r = parse_records("synthtest", bytes.fromhex(bc["patched"]),
+                      bytes.fromhex(comp["patched"]))
+    assert set(r) == {100}
+
+
+def test_build_change_missing_delete_returns_none(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([(1, "First", 100, 1, 0x55)])
+    intent = _parse_intents_block([{"op": "delete_record", "key": 999}])[0]
+    assert _build_record_ops_change_for_target(
+        "synthtest.pabgb", body, header, [intent]) == (None, None, 0)
+
+
+def test_clone_then_delete_compose(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([
+        (1, "First", 100, 0xAAAA1111, 0x55),
+        (2, "Second", 200, 0xBBBB2222, 0x66),
+    ])
+    clone = _parse_intents_block([{
+        "op": "clone_record", "source_key": 100, "new_key": 500}])[0]
+    delete = _parse_intents_block([{"op": "delete_record", "key": 200}])[0]
+    bc, comp, n = _build_record_ops_change_for_target(
+        "synthtest.pabgb", body, header, [clone, delete])
+    assert n == 2
+    r = parse_records("synthtest", bytes.fromhex(bc["patched"]),
+                      bytes.fromhex(comp["patched"]))
+    assert set(r) == {100, 500}          # 200 deleted, 500 cloned in
+    assert r[500]["_foo"] == 0xAAAA1111

--- a/tests/test_format3_match_selector.py
+++ b/tests/test_format3_match_selector.py
@@ -1,0 +1,333 @@
+"""Format 3 ``match`` selector — parse, validate gate, expansion, and a
+byte-exact equivalence proof against hand-authored per-record intents.
+
+A ``match`` intent targets every record whose fields all equal the given
+values (AND). At apply time it is expanded into ordinary per-record
+``set`` intents, which flow through the same trusted writer path — so the
+central correctness claim is: *expanding a match selector produces
+byte-for-byte the same table as hand-authoring one ``set`` intent per
+matched record.* That is what ``test_expand_is_byte_exact_*`` pins.
+
+Uses the same synthetic all-flat table the binary-roundtrip test uses so
+no game files are needed and exact offsets are checkable.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.format3_apply import (
+    _expand_match_intents,
+    _lookup_record_field,
+    _match_record_keys,
+    _match_value_equals,
+)
+from cdumm.engine.format3_handler import (
+    Format3Intent,
+    _classify_match_selector,
+    _parse_intents_block,
+    apply_intents_to_pabgb_bytes,
+    validate_intents,
+)
+from cdumm.semantic import parser as parser_mod
+from cdumm.semantic.parser import FieldSpec, TableSchema, parse_records
+
+
+# ── Synthetic table injection (optionally with verified_fields) ──────
+
+
+def _inject(monkeypatch, verified_fields=None):
+    fields = [
+        FieldSpec(name="_key", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_foo", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_bar", stream_size=2,
+                  field_type="direct_u16", struct_fmt="H"),
+    ]
+    schema = TableSchema(table_name="synthtest", fields=fields,
+                         verified_fields=verified_fields)
+    original = parser_mod._loaded_schemas
+    if original is None:
+        parser_mod._load_schemas()
+        original = parser_mod._loaded_schemas
+    new_cache = dict(original or {})
+    new_cache["synthtest"] = schema
+    monkeypatch.setattr(parser_mod, "_loaded_schemas", new_cache)
+    return schema
+
+
+def _build_entry(entry_id: int, name: str,
+                 key_value: int, foo: int, bar: int) -> bytes:
+    name_bytes = name.encode("utf-8")
+    head = struct.pack("<II", entry_id, len(name_bytes))
+    payload = struct.pack("<IIH", key_value, foo, bar)
+    return head + name_bytes + b"\x00" + payload
+
+
+def _build_pabgb_pair(entries):
+    body = bytearray()
+    keys_offsets = []
+    for entry_id, name, key, foo, bar in entries:
+        offset = len(body)
+        body.extend(_build_entry(entry_id, name, key, foo, bar))
+        keys_offsets.append((key, offset))
+    header = bytearray(struct.pack("<H", len(entries)))
+    for k, o in keys_offsets:
+        header.extend(struct.pack("<II", k, o))
+    return bytes(body), bytes(header)
+
+
+# ── Parsing ─────────────────────────────────────────────────────────
+
+
+def test_parse_accepts_match_selector():
+    intents = _parse_intents_block(
+        [{"match": {"_foo": 7}, "field": "_bar", "new": 9}])
+    assert len(intents) == 1
+    i = intents[0]
+    assert i.match == {"_foo": 7}
+    assert i.entry == ""       # unused when match present
+    assert i.key == 0
+    assert i.field == "_bar"
+    assert i.new == 9
+    assert i.op == "set"
+
+
+def test_parse_match_allows_missing_entry():
+    # entry omitted is fine when a match selector is present
+    out = _parse_intents_block(
+        [{"match": {"_foo": 1}, "field": "_bar", "new": 2}])
+    assert out[0].match == {"_foo": 1}
+
+
+def test_parse_still_requires_entry_without_match():
+    with pytest.raises(ValueError):
+        _parse_intents_block([{"field": "_bar", "new": 2}])
+
+
+def test_parse_rejects_empty_match():
+    with pytest.raises(ValueError):
+        _parse_intents_block(
+            [{"match": {}, "field": "_bar", "new": 2}])
+
+
+def test_parse_rejects_non_dict_match():
+    with pytest.raises(ValueError):
+        _parse_intents_block(
+            [{"match": [1, 2], "field": "_bar", "new": 2}])
+
+
+def test_parse_match_still_requires_new():
+    with pytest.raises(ValueError):
+        _parse_intents_block([{"match": {"_foo": 1}, "field": "_bar"}])
+
+
+# ── Value equality / field lookup helpers ───────────────────────────
+
+
+def test_match_value_equals_type_tolerance():
+    assert _match_value_equals(5, 5)
+    assert _match_value_equals(5, "5")       # decoded int vs JSON string
+    assert _match_value_equals(5.0, 5)       # float vs int
+    assert not _match_value_equals(5, 6)
+    assert not _match_value_equals(None, 5)  # missing field never matches
+    # bool is not treated as numeric 1/0 for the float path
+    assert not _match_value_equals(2, True)
+
+
+def test_lookup_record_field_name_shapes():
+    rec = {"_itemType": 3}
+    # snake_case without prefix resolves to the schema's _camelCase name
+    assert _lookup_record_field(rec, "item_type") == 3
+    assert _lookup_record_field(rec, "_itemType") == 3
+    assert _lookup_record_field(rec, "nope") is None
+
+
+# ── Expansion ───────────────────────────────────────────────────────
+
+
+def test_expand_targets_all_matching_records(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "A", 100, 7, 0x11),
+        (2, "B", 200, 7, 0x22),
+        (3, "C", 300, 9, 0x33),
+    ])
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x99, match={"_foo": 7})
+    out = _expand_match_intents("synthtest.pabgb", body, header, [mi])
+    assert len(out) == 2
+    assert {i.key for i in out} == {100, 200}
+    assert {i.entry for i in out} == {"A", "B"}
+    assert all(i.match is None and i.op == "set"
+               and i.field == "_bar" and i.new == 0x99 for i in out)
+
+
+def test_expand_matches_on_name_metadata(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "Sword", 100, 7, 0x11),
+        (2, "Shield", 200, 7, 0x22),
+    ])
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x9, match={"_name": "Sword"})
+    out = _expand_match_intents("synthtest.pabgb", body, header, [mi])
+    assert [i.key for i in out] == [100]
+
+
+def test_expand_multi_condition_is_and(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([
+        (1, "A", 100, 7, 0x11),   # foo=7 bar=0x11
+        (2, "B", 200, 7, 0x22),   # foo=7 bar=0x22
+    ])
+    mi = Format3Intent(entry="", key=0, field="_bar", op="set", new=0x5,
+                       match={"_foo": 7, "_bar": 0x22})
+    out = _expand_match_intents("synthtest.pabgb", body, header, [mi])
+    assert [i.key for i in out] == [200]   # only the AND match
+
+
+def test_non_match_intents_pass_through_unchanged(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "A", 100, 7, 0x11)])
+    plain = Format3Intent(entry="A", key=100, field="_bar",
+                          op="set", new=0x5)
+    out = _expand_match_intents("synthtest.pabgb", body, header, [plain])
+    assert out == [plain]
+
+
+def test_zero_match_expands_to_nothing(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "A", 100, 7, 0x11)])
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x9, match={"_foo": 999})
+    out = _expand_match_intents("synthtest.pabgb", body, header, [mi])
+    assert out == []
+
+
+def test_expand_undecodable_table_is_safe_noop(monkeypatch):
+    _inject(monkeypatch)
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x9, match={"_foo": 7})
+    # Garbage bytes -> parse yields no records -> no expansion, no raise.
+    out = _expand_match_intents("synthtest.pabgb", b"\x00\x01", b"", [mi])
+    assert out == []
+
+
+# ── The byte-exact equivalence proof ────────────────────────────────
+
+
+def test_expand_is_byte_exact_vs_hand_authored(monkeypatch):
+    _inject(monkeypatch)
+    entries = [
+        (1, "A", 100, 7, 0x11),
+        (2, "B", 200, 7, 0x22),
+        (3, "C", 300, 9, 0x33),
+    ]
+    body, header = _build_pabgb_pair(entries)
+
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x99, match={"_foo": 7})
+    expanded = _expand_match_intents(
+        "synthtest.pabgb", body, header, [mi])
+
+    hand = [
+        Format3Intent(entry="A", key=100, field="_bar",
+                      op="set", new=0x99),
+        Format3Intent(entry="B", key=200, field="_bar",
+                      op="set", new=0x99),
+    ]
+
+    from_match = apply_intents_to_pabgb_bytes(
+        "synthtest", body, header, expanded)
+    from_hand = apply_intents_to_pabgb_bytes(
+        "synthtest", body, header, hand)
+
+    # Central claim: identical bytes.
+    assert from_match == from_hand
+    # And correctness: matched records changed, others preserved.
+    recs = parse_records("synthtest", from_match, header)
+    assert recs[100]["_bar"] == 0x99
+    assert recs[200]["_bar"] == 0x99
+    assert recs[300]["_bar"] == 0x33          # untouched
+    assert recs[300]["_foo"] == 9             # untouched
+    assert len(from_match) == len(body)        # size-preserving
+
+
+def test_expand_no_hit_leaves_table_byte_identical(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _build_pabgb_pair([(1, "A", 100, 7, 0x11)])
+    mi = Format3Intent(entry="", key=0, field="_bar",
+                       op="set", new=0x9, match={"_foo": 999})
+    expanded = _expand_match_intents(
+        "synthtest.pabgb", body, header, [mi])
+    out = apply_intents_to_pabgb_bytes(
+        "synthtest", body, header, expanded)
+    assert out == body
+
+
+# ── Validation gate (match-fields must be safe to compare) ──────────
+
+
+def _specs():
+    fields = [
+        FieldSpec(name="_key", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_foo", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_bar", stream_size=2,
+                  field_type="direct_u16", struct_fmt="H"),
+    ]
+    return fields, {f.name: f for f in fields}
+
+
+def test_classify_match_selector_allows_verified_field():
+    fields, fs = _specs()
+    schema = TableSchema(table_name="t", fields=fields,
+                         verified_fields=frozenset({"_foo", "_bar"}))
+    ok = Format3Intent(entry="", key=0, field="_bar", op="set",
+                       new=1, match={"_foo": 7})
+    assert _classify_match_selector(ok, schema, fs) is None
+
+
+def test_classify_match_selector_rejects_unverified_field():
+    fields, fs = _specs()
+    schema = TableSchema(table_name="t", fields=fields,
+                         verified_fields=frozenset({"_bar"}))
+    bad = Format3Intent(entry="", key=0, field="_bar", op="set",
+                        new=1, match={"_foo": 7})
+    reason = _classify_match_selector(bad, schema, fs)
+    assert reason and "not a verified field" in reason
+
+
+def test_classify_match_selector_rejects_unknown_field():
+    fields, fs = _specs()
+    schema = TableSchema(table_name="t", fields=fields,
+                         verified_fields=frozenset({"_foo", "_bar"}))
+    unk = Format3Intent(entry="", key=0, field="_bar", op="set",
+                        new=1, match={"_nope": 7})
+    reason = _classify_match_selector(unk, schema, fs)
+    assert reason and "not a known field" in reason
+
+
+def test_classify_match_selector_metadata_always_safe():
+    fields, fs = _specs()
+    # _name is safe even though it isn't in verified_fields.
+    schema = TableSchema(table_name="t", fields=fields,
+                         verified_fields=frozenset({"_bar"}))
+    meta = Format3Intent(entry="", key=0, field="_bar", op="set",
+                         new=1, match={"_name": "x"})
+    assert _classify_match_selector(meta, schema, fs) is None
+
+
+def test_validate_match_skipped_on_no_schema_table():
+    # No schema for this table -> match can't be resolved -> skipped
+    # with a precise reason, never silently applied.
+    mi = Format3Intent(entry="", key=0, field="whatever", op="set",
+                       new=1, match={"x": 1})
+    v = validate_intents("definitelynotatable.pabgb", [mi])
+    assert not v.supported
+    assert v.skipped
+    assert "needs a decoded schema" in v.skipped[0][1]

--- a/tests/test_format3_match_selector.py
+++ b/tests/test_format3_match_selector.py
@@ -331,3 +331,44 @@ def test_validate_match_skipped_on_no_schema_table():
     assert not v.supported
     assert v.skipped
     assert "needs a decoded schema" in v.skipped[0][1]
+
+
+# ── list / any-of match (GitHub #272, pinapana's Crazy ExtraSockets) ────
+# A list on the mod side means "any of" (SQL IN), so one intent can target
+# a whole family of records instead of one intent per value.
+
+def test_match_value_list_is_any_of():
+    assert _match_value_equals(5, [1, 5, 9]) is True
+    assert _match_value_equals(7, [1, 5, 9]) is False
+
+
+def test_match_value_list_keeps_numeric_and_string_tolerance():
+    assert _match_value_equals(5, ["5", 9]) is True
+    assert _match_value_equals(5.0, [1, 5]) is True
+
+
+def test_match_value_empty_list_matches_nothing():
+    assert _match_value_equals(5, []) is False
+
+
+def test_match_value_list_vs_list_field_stays_exact_equality():
+    # When the record's own value is a list, a list on the mod side must
+    # keep exact-equality semantics so a genuinely list-valued field can
+    # still be matched whole (and never becomes an accidental any-of).
+    assert _match_value_equals([1, 2], [1, 2]) is True
+    assert _match_value_equals([1, 2], [1, 2, 3]) is False
+    assert _match_value_equals([3], [1, 2, 3]) is False
+
+
+def test_match_record_keys_selects_every_record_in_the_list():
+    records = {
+        1: {"_name": "a", "_key": 1, "kind": 10},
+        2: {"_name": "b", "_key": 2, "kind": 20},
+        3: {"_name": "c", "_key": 3, "kind": 30},
+        4: {"_name": "d", "_key": 4, "kind": 20},
+    }
+    # any-of picks up both kind==20 records plus kind==10
+    got = _match_record_keys(records, {"kind": [10, 20]})
+    assert got == [1, 2, 4]
+    # a single scalar still behaves exactly as before
+    assert _match_record_keys(records, {"kind": 30}) == [3]

--- a/tests/test_format3_new_record_and_append.py
+++ b/tests/test_format3_new_record_and_append.py
@@ -1,0 +1,147 @@
+"""Format 3 ``new_record`` (template-based, via the clone engine) and the
+``array_append`` recognition + actionable skip.
+
+new_record with a ``source_key``/``template_key`` bases the new record on an
+existing one and routes through the append-only, self-checked clone engine.
+Without a template it parses but is skipped with guidance (building a valid
+record from a bare field list needs a per-table serializer). ``array_append``
+is recognized and skipped with a "use a set with the full list" message.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cdumm.engine.format3_apply import _build_record_ops_change_for_target
+from cdumm.engine.format3_handler import (
+    _parse_intents_block,
+    validate_intents,
+)
+from cdumm.semantic import parser as parser_mod
+from cdumm.semantic.parser import FieldSpec, TableSchema, parse_records
+
+
+def _inject(monkeypatch, verified_fields=None):
+    fields = [
+        FieldSpec(name="_key", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_foo", stream_size=4,
+                  field_type="direct_u32", struct_fmt="I"),
+        FieldSpec(name="_bar", stream_size=2,
+                  field_type="direct_u16", struct_fmt="H"),
+    ]
+    schema = TableSchema(table_name="synthtest", fields=fields,
+                         verified_fields=verified_fields)
+    original = parser_mod._loaded_schemas
+    if original is None:
+        parser_mod._load_schemas()
+        original = parser_mod._loaded_schemas
+    new_cache = dict(original or {})
+    new_cache["synthtest"] = schema
+    monkeypatch.setattr(parser_mod, "_loaded_schemas", new_cache)
+    return schema
+
+
+def _pair(entries):
+    body = bytearray()
+    ko = []
+    for eid, name, key, foo, bar in entries:
+        ko.append((key, len(body)))
+        nb = name.encode("utf-8")
+        body += struct.pack("<II", eid, len(nb)) + nb + b"\x00" + \
+            struct.pack("<IIH", key, foo, bar)
+    header = bytearray(struct.pack("<H", len(entries)))
+    for k, o in ko:
+        header += struct.pack("<II", k, o)
+    return bytes(body), bytes(header)
+
+
+# ── new_record parsing ──────────────────────────────────────────────
+
+
+def test_parse_new_record_with_template():
+    i = _parse_intents_block([{
+        "op": "new_record", "source_key": 100, "new_key": 500,
+        "new_name": "Fresh", "patches": [{"field": "_bar", "new": 9}]}])[0]
+    assert i.op == "new_record"
+    assert i.clone == {"source_key": 100, "new_key": 500,
+                       "patches": [{"field": "_bar", "new": 9}],
+                       "new_name": "Fresh"}
+
+
+def test_parse_new_record_template_key_alias():
+    i = _parse_intents_block(
+        [{"op": "new_record", "template_key": 100, "new_key": 500}])[0]
+    assert i.clone is not None and i.clone["source_key"] == 100
+
+
+def test_parse_new_record_without_template_has_no_clone():
+    i = _parse_intents_block(
+        [{"op": "new_record", "new_key": 500}])[0]
+    assert i.op == "new_record" and i.clone is None
+
+
+def test_parse_new_record_requires_new_key():
+    with pytest.raises(ValueError):
+        _parse_intents_block([{"op": "new_record", "source_key": 1}])
+
+
+# ── new_record apply (template routes through the clone engine) ──────
+
+
+def test_new_record_creates_from_template(monkeypatch):
+    _inject(monkeypatch)
+    body, header = _pair([(1, "Base", 100, 0xAAAA1111, 0x55)])
+    intent = _parse_intents_block([{
+        "op": "new_record", "source_key": 100, "new_key": 500,
+        "new_name": "Made", "patches": [{"field": "_bar", "new": 0x99}]}])[0]
+    bc, comp, n = _build_record_ops_change_for_target(
+        "synthtest.pabgb", body, header, [intent])
+    assert n == 1 and bc is not None and comp is not None
+    r = parse_records("synthtest", bytes.fromhex(bc["patched"]),
+                      bytes.fromhex(comp["patched"]))
+    assert set(r) == {100, 500}
+    assert r[500]["_name"] == "Made"
+    assert r[500]["_foo"] == 0xAAAA1111        # copied from template
+    assert r[500]["_bar"] == 0x99               # patched
+
+
+# ── new_record validation ───────────────────────────────────────────
+
+
+def test_validate_new_record_with_template_supported(monkeypatch):
+    _inject(monkeypatch, verified_fields=frozenset({"_foo", "_bar"}))
+    i = _parse_intents_block([{
+        "op": "new_record", "source_key": 100, "new_key": 500,
+        "patches": [{"field": "_bar", "new": 9}]}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert i in v.supported, v.skipped
+
+
+def test_validate_new_record_without_template_skipped(monkeypatch):
+    _inject(monkeypatch)
+    i = _parse_intents_block([{"op": "new_record", "new_key": 500}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert not v.supported
+    assert "source_key" in v.skipped[0][1]
+
+
+def test_validate_new_record_no_schema_skipped():
+    i = _parse_intents_block(
+        [{"op": "new_record", "source_key": 1, "new_key": 2}])[0]
+    v = validate_intents("definitelynotatable.pabgb", [i])
+    assert not v.supported and "needs a decoded schema" in v.skipped[0][1]
+
+
+# ── array_append recognition + actionable skip ──────────────────────
+
+
+def test_array_append_skipped_with_guidance(monkeypatch):
+    _inject(monkeypatch)
+    i = _parse_intents_block(
+        [{"op": "array_append", "entry": "x", "field": "_bar", "new": 1}])[0]
+    v = validate_intents("synthtest.pabgb", [i])
+    assert not v.supported
+    reason = v.skipped[0][1]
+    assert "array_append" in reason and "set" in reason

--- a/tests/test_format3_new_record_and_append.py
+++ b/tests/test_format3_new_record_and_append.py
@@ -137,7 +137,7 @@ def test_validate_new_record_no_schema_skipped():
 # ── array_append recognition + actionable skip ──────────────────────
 
 
-def test_array_append_skipped_with_guidance(monkeypatch):
+def test_array_append_unsupported_field_skipped_with_guidance(monkeypatch):
     _inject(monkeypatch)
     i = _parse_intents_block(
         [{"op": "array_append", "entry": "x", "field": "_bar", "new": 1}])[0]
@@ -145,3 +145,21 @@ def test_array_append_skipped_with_guidance(monkeypatch):
     assert not v.supported
     reason = v.skipped[0][1]
     assert "array_append" in reason and "set" in reason
+
+
+def test_array_append_supported_on_dropset_drops():
+    # dropsetinfo.drops is the one proven byte-exact appendable list field.
+    i = _parse_intents_block([{
+        "op": "array_append", "entry": "DropSet_X", "key": 175001,
+        "field": "drops", "new": {"flag": 1, "item_key": 42, "rates": 1000}}])[0]
+    v = validate_intents("dropsetinfo.pabgb", [i])
+    assert i in v.supported, v.skipped
+
+
+def test_array_append_dropset_new_must_be_object():
+    i = _parse_intents_block([{
+        "op": "array_append", "entry": "DropSet_X", "key": 175001,
+        "field": "drops", "new": [1, 2, 3]}])[0]   # list, not a single obj
+    v = validate_intents("dropsetinfo.pabgb", [i])
+    assert not v.supported
+    assert "element object" in v.skipped[0][1]


### PR DESCRIPTION
> **Requested in #272** (@pinapana 鈥?*Crazy ExtraSockets*). Part of a 3-PR stack that makes that mod work end to end; **#275** is the one that closes it.
>
> `#271` (this) implements the `match` selector 路 **#274** makes CD 1.13 equipment decode at all 路 **#275** routes `match` through the native decoder so it actually selects those records.
>
> Verified against pinapana's real mod once all three are applied: its 3 `match` intents expand to **9,051 concrete edits** and change **3,017 items**, all via `drop_default_data`, with **zero** collateral edits. Before: 0.

---

Brings CDUMM's Format 3 (`.field.json`) engine to full patch-op parity with the wider mod ecosystem 鈥?a `match` selector plus the four record ops (`clone_record`, `delete_record`, `new_record`, `array_append`) 鈥?all built from CDUMM's own engine (no third-party parser/schema) and verified byte-exact against a real vanilla game table.

Every op is safe by construction: the reshaping ops are **append-only or full-rebuild + a mandatory parse-back self-check** (the result is re-decoded and verified before anything is committed; any failure returns `None` and the op is skipped, never applied). All are isolated to the mods that use them 鈥?every existing Format 3 flow is unchanged.

## Ops

**`match` selector** 鈥?one intent edits every record whose fields all equal given values (AND). Expand-to-set: decoded via the existing `parse_records`, each match becomes an ordinary per-record `set` through the trusted writer + verified-field gate.
```json
{ "match": { "_storeType": 3 }, "field": "_buyPriceRate", "new": 50 }
```

**`clone_record`** 鈥?deep-copy a record to a new key/name + patch the copy (the standard item/gear-variant workflow). Append-only + self-checked. Patches target verified scalar fields, and on `iteminfo` also **`gear_stat[...]`** (armor defense / weapon damage) 鈥?so you can clone a weapon and buff its damage on the copy, byte-exact (a real clone-a-weapon round-trip on the live iteminfo table leaves the source + all other records identical). The gear-stat support degrades gracefully (skips with a reason) in a build where the gear-stat feature isn't present, so this PR stays independent of it.
```json
{ "op": "clone_record", "source_key": 1000080, "new_key": 1000090, "new_name": "Hwando+", "patches": [{ "field": "_itemTier", "new": 5 }] }
```

**`delete_record`** 鈥?remove a record by key. Rebuilds the body from the survivors and reindexes the `.pabgh`; self-checked (deleted key gone, every survivor byte-identical, body shrank by exactly the removed entry).
```json
{ "op": "delete_record", "key": 1000090 }
```

**`new_record`** 鈥?build a record from an existing template (`source_key`/`template_key` + `new_key` + `new_name` + `patches`), routed through the same self-checked clone engine. Without a template it's skipped with guidance (a bare field-list build needs a per-table serializer; cloning a working record is the recommended path).

**`array_append`** 鈥?appends one element to a list field, leaving existing elements byte-identical. Live for `dropsetinfo.drops` ("add a loot drop"); gated to fields with a **proven byte-exact list round-trip** (dropset verified on all 14,575 vanilla records). Other list fields get an actionable skip pointing at a full-list `set` until their round-trip is proven.

```json
{ "op": "array_append", "entry": "DropSet_Faction_Graymane", "key": 175001,
  "field": "drops", "new": { "flag": 1, "item_key": 1000080, "rates": 5000 } }
```

The upshot: every DMM-style patch op is handled 鈥?the implementable ops apply byte-exact, the rest skip with a clear, actionable reason. Mod-author reference: `docs/FORMAT3_OPS.md`.

## Verification

- **Unit:** new tests across all ops (byte-exact match鈫攈and-authored equivalence; clone/delete/new_record faithful-copy, self-check refusals, index integrity, composition; array_append validation; validation gates). Full `test_format3_*` + `test_whole_table_*` suites green (**279 passed, 2 skipped**).
- **Real tables:** extracted genuine vanilla tables from an installed copy of the game and ran the ops through the real engine and the real orchestrator (`parse_format3_mod_targets` 鈫?`expand_format3_into_aggregated`): on `wantedinfo` (35 records, u16 keys) match edited exactly the matching records byte-identically to hand-authored sets, clone/new_record produced a faithful copy + patch with all originals intact, delete removed a middle record with survivors byte-identical and the index reshifted, and a real `.field.json` mod file composed match + a record op into the correct whole-table body + `.pabgh` companion; on `dropsetinfo` (14,575 records) parse鈫抯erialize round-trips byte-exact on every record and array_append preserved existing drops byte-for-byte on 200/200 sampled records.

## Provenance

`parse_records`, the existing per-table writers, and the `verified_fields` gate 鈥?CDUMM's own RE, no third-party parser or schema. Self-contained on `upstream/master` (no dependency on the game-data PRs), so it merges in any order.
