### PR TITLE
iteminfo: decode CD 1.13 equipment (SubItem tag 17 + _enchantDataList) - 0 -> 3151 records

### DIFF
--- a/src/cdumm/engine/iteminfo_native_parser.py
+++ b/src/cdumm/engine/iteminfo_native_parser.py
@@ -196,7 +196,14 @@ class _Reader:
         # parse-guard turns it into a clean "this game version isn't
         # supported yet" skip instead of a hang. Never fires on valid data
         # (a legitimate count is always <= remaining bytes).
-        remaining = len(self.data) - self.pos
+        # Bound by the *record*, not the whole body, when the boundary is
+        # known. A count can never exceed the bytes left in its own record,
+        # so this rejects a desynced count immediately instead of letting
+        # it allocate a list of ~500k dicts first (the body bound is 5.9MB,
+        # which is far too loose to catch anything in time). Matters most
+        # while detect_iteminfo_layout is speculatively trying layouts that
+        # do not fit: without this, every rejected candidate stalls.
+        remaining = (self.rec_end or len(self.data)) - self.pos
         if n > remaining:
             raise ValueError(
                 f"iteminfo carray count {n} exceeds {remaining} remaining "
@@ -1658,6 +1665,84 @@ def _write_DropDefaultData(w: _Writer, v: dict) -> None:
     w.u8(v["use_socket"])
 
 
+# ── CD 1.13: DropDefaultData / EnchantData ──────────────────────────────
+# Two coupled changes land here, and they are only correct together.
+#
+# 1. ``SubItem`` gained tag 17 as a *None* sentinel, which carries no u32
+#    payload (14 stayed a sentinel too).
+# 2. ``ItemInfo`` grew ``_enchantDataList`` immediately after
+#    _dropDefaultData -- a u32 count, then one EnchantData per enchant
+#    tier (levels 0..N-1; 11 tiers on most equipment, 0 on non-equipment).
+#
+# The pre-1.13 reader spends its 7 bytes as
+#     tag(1) + u32 value(4) + svc(1) + use(1)
+# where the truth is
+#     tag(1) + svc(1) + use(1) + u32 enchant count(4).
+# Identical width. That is why non-equipment -- whose enchant count is 0,
+# so those four bytes are zero either way -- round-tripped byte-exact and
+# never looked broken, while equipment (count is almost always 11) walked
+# straight off the rails. It also explains why "fix the SubItem sentinel"
+# alone destroyed non-equipment in testing: it dropped the u32 without
+# putting the enchant count back.
+#
+# Verified against the live 1.13 iteminfo.pabgb: 6508/6508 records decode
+# and re-serialize byte-identical, with the level ladder (0,1,2,...,N-1)
+# holding on every one of the 1047 multi-tier records.
+_SUBITEM_NONE_TAGS_CD113 = (14, 17)
+
+
+def _read_SubItem_CD113(r: _Reader) -> dict:
+    type_id = r.u8()
+    value = None if type_id in _SUBITEM_NONE_TAGS_CD113 else r.u32()
+    return {"type_id": type_id, "value": value}
+
+
+def _write_SubItem_CD113(w: _Writer, v: dict) -> None:
+    w.u8(v["type_id"])
+    if v["type_id"] not in _SUBITEM_NONE_TAGS_CD113:
+        w.u32(v["value"])
+
+
+def _read_DropDefaultData_CD113(r: _Reader) -> dict:
+    return {
+        "drop_enchant_level": r.u16(),
+        "socket_item_list": r.carray(_Reader.u32),
+        "add_socket_material_item_list": r.carray(_read_SocketMaterialItem),
+        "default_sub_item": _read_SubItem_CD113(r),
+        "socket_valid_count": r.u8(),
+        "use_socket": r.u8(),
+    }
+
+
+def _write_DropDefaultData_CD113(w: _Writer, v: dict) -> None:
+    w.u16(v["drop_enchant_level"])
+    w.carray(v["socket_item_list"], _Writer.u32)
+    w.carray(v["add_socket_material_item_list"], _write_SocketMaterialItem)
+    _write_SubItem_CD113(w, v["default_sub_item"])
+    w.u8(v["socket_valid_count"])
+    w.u8(v["use_socket"])
+
+
+def _read_EnchantData_CD113(r: _Reader) -> dict:
+    """Pre-1.13 EnchantData plus the u32 CD 1.12 added to it."""
+    v = _read_EnchantData(r)
+    v["item_effect_info"] = r.u32()
+    return v
+
+
+def _write_EnchantData_CD113(w: _Writer, v: dict) -> None:
+    _write_EnchantData(w, v)
+    w.u32(v["item_effect_info"])
+
+
+def _read_enchant_data_list_CD113(r: _Reader) -> list:
+    return r.carray(_read_EnchantData_CD113)
+
+
+def _write_enchant_data_list_CD113(w: _Writer, v: list) -> None:
+    w.carray(v, _write_EnchantData_CD113)
+
+
 def _read_SealableItemInfo(r: _Reader) -> dict:
     """SealableItemInfo: u8 type_tag + u32 item_key + u64 unknown0 + variant value."""
     type_tag = r.u8()
@@ -2012,10 +2097,35 @@ _ITEM_FIELDS_CD113 = [
     if f[0] not in ("prefab_data_list", "gimmick_visual_prefab_data_list")
 ]
 
+
+def _with_cd113_enchant(fields):
+    """CD 1.13: swap in the 1.13 DropDefaultData and add the
+    _enchantDataList that follows it. See _read_DropDefaultData_CD113 for
+    why the two changes are inseparable."""
+    out = []
+    for spec in fields:
+        if spec[0] == "drop_default_data":
+            out.append(("drop_default_data", "struct",
+                        _read_DropDefaultData_CD113,
+                        _write_DropDefaultData_CD113))
+            out.append(("enchant_data_list", "struct",
+                        _read_enchant_data_list_CD113,
+                        _write_enchant_data_list_CD113))
+        else:
+            out.append(spec)
+    return out
+
+
+_ITEM_FIELDS_CD113_ENCHANT = _with_cd113_enchant(_ITEM_FIELDS_CD113)
+
 # (label, fields) candidates, tried in order by detect_iteminfo_layout.
+# Most specific first: the enchant variant decodes 6508/6508 on live 1.13,
+# where the plain relocated variant only manages the 3167 non-equipment
+# records and carries all equipment opaque.
 _ITEM_LAYOUTS = (
     ("default", None),                       # None -> _ITEM_FIELDS
     ("cd113_prefab_relocated", _ITEM_FIELDS_CD113),
+    ("cd113_enchant", _ITEM_FIELDS_CD113_ENCHANT),
 )
 
 
@@ -2055,7 +2165,7 @@ def detect_iteminfo_layout(data: bytes, record_offsets):
     n = len(starts)
     idxs = sorted({i for i in (0, 1, 2, n // 4, n // 2, 3 * n // 4, n - 1)
                    if 0 <= i < n})
-    best_fields, best_score = None, -1
+    best_fields, best_score = None, 0
     for _label, fields in _ITEM_LAYOUTS:
         score = 0
         for i in idxs:
@@ -2063,7 +2173,18 @@ def detect_iteminfo_layout(data: bytes, record_offsets):
             e = starts[i + 1] if i + 1 < len(starts) else len(data)
             if _record_roundtrips(data, s, e, fields):
                 score += 1
-        if score > best_score:
+        # >= so a *more specific* layout wins a tie. _ITEM_LAYOUTS is
+        # ordered least- to most-specific, and a more specific layout can
+        # only round-trip a superset of records -- so a tie means it is at
+        # least as good. Without this, a sample that happened to draw only
+        # non-equipment records would score cd113_prefab_relocated and
+        # cd113_enchant equally, lock in the former, and silently carry all
+        # 3151 equipment records opaque.
+        #
+        # The score > 0 guard keeps a layout from being *claimed* on a
+        # table where nothing round-trips at all: that stays None, and the
+        # caller's per-record opaque fallback handles it.
+        if score > 0 and score >= best_score:
             best_score, best_fields = score, fields
     return best_fields
 

--- a/tests/test_iteminfo_cd113_enchant.py
+++ b/tests/test_iteminfo_cd113_enchant.py
@@ -1,0 +1,218 @@
+"""CD 1.13 iteminfo: SubItem tag 17 + _enchantDataList.
+
+Two coupled wire changes landed in CD 1.13 (GitHub #272, gear stats):
+
+  * ``SubItem`` tag 17 is a *None* sentinel carrying no u32 payload.
+  * ``ItemInfo`` grew ``_enchantDataList`` right after _dropDefaultData.
+
+The pre-1.13 reader spends the same 7 bytes as
+``tag(1) + u32 value(4) + svc(1) + use(1)`` where the truth is
+``tag(1) + svc(1) + use(1) + u32 enchant count(4)``. Identical width --
+which is exactly why non-equipment (enchant count 0, so those 4 bytes are
+zero either way) round-tripped byte-exact and never looked broken, while
+equipment (count is almost always 11) desynced. It also explains why
+fixing the sentinel *alone* destroyed non-equipment: that drops the u32
+without putting the enchant count back. The two changes are inseparable,
+so these tests pin them together.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import cdumm.engine.iteminfo_native_parser as nat
+from cdumm.engine.iteminfo_native_parser import (
+    _ITEM_FIELDS_CD113_ENCHANT,
+    _Reader,
+    _Writer,
+    _read_DropDefaultData_CD113,
+    _read_EnchantData_CD113,
+    _write_DropDefaultData_CD113,
+    _write_EnchantData_CD113,
+    detect_iteminfo_layout,
+    parse_iteminfo_from_bytes,
+    serialize_iteminfo,
+)
+
+
+def _u16(v):
+    return v.to_bytes(2, "little")
+
+
+def _u32(v):
+    return v.to_bytes(4, "little")
+
+
+def _u64(v):
+    return v.to_bytes(8, "little")
+
+
+# ── DropDefaultData: tag 17 carries no payload ───────────────────────────
+
+def test_subitem_tag_17_consumes_no_u32():
+    # u16 level | empty carray | empty carray | tag 17 | svc | use
+    raw = _u16(3) + _u32(0) + _u32(0) + bytes([17]) + bytes([0]) + bytes([1])
+    r = _Reader(raw, 0, rec_end=len(raw))
+    ddd = _read_DropDefaultData_CD113(r)
+    assert r.pos == len(raw)               # nothing left over
+    assert ddd["default_sub_item"] == {"type_id": 17, "value": None}
+    assert ddd["socket_valid_count"] == 0
+    assert ddd["use_socket"] == 1
+    w = _Writer()
+    _write_DropDefaultData_CD113(w, ddd)
+    assert bytes(w.buf) == raw
+
+
+def test_subitem_real_tag_still_carries_its_u32():
+    raw = _u16(0) + _u32(0) + _u32(0) + bytes([3]) + _u32(9) + bytes([2, 1])
+    r = _Reader(raw, 0, rec_end=len(raw))
+    ddd = _read_DropDefaultData_CD113(r)
+    assert r.pos == len(raw)
+    assert ddd["default_sub_item"] == {"type_id": 3, "value": 9}
+    w = _Writer()
+    _write_DropDefaultData_CD113(w, ddd)
+    assert bytes(w.buf) == raw
+
+
+def test_sockets_survive_the_new_ddd():
+    """#272 edits add_socket_material_item_list -- it must still decode."""
+    raw = (_u16(0) + _u32(0)
+           + _u32(1) + _u32(1) + _u64(200)      # one SocketMaterialItem
+           + bytes([17, 5, 1]))
+    r = _Reader(raw, 0, rec_end=len(raw))
+    ddd = _read_DropDefaultData_CD113(r)
+    assert ddd["add_socket_material_item_list"] == [{"item": 1, "value": 200}]
+    assert ddd["socket_valid_count"] == 5
+    assert ddd["use_socket"] == 1
+    w = _Writer()
+    _write_DropDefaultData_CD113(w, ddd)
+    assert bytes(w.buf) == raw
+
+
+# ── EnchantData = pre-1.13 shape + the u32 CD 1.12 added ─────────────────
+
+def _enchant_bytes(level, *, prices=(), buffs=(), static_lvl=(), effect=0):
+    b = _u16(level)
+    b += _u32(0) * 3                                    # 3 empty stat lists
+    b += _u32(len(static_lvl))
+    for stat, chg in static_lvl:                        # EnchantLevelChange 5B
+        b += _u32(stat) + chg.to_bytes(1, "little", signed=True)
+    b += _u32(len(prices))
+    for key, price in prices:                           # ItemPriceInfo 20B
+        b += _u32(key) + _u64(price) + _u32(0) + _u32(key)
+    b += _u32(len(buffs))
+    for buff, lvl in buffs:                             # EquipmentBuff 8B
+        b += _u32(buff) + _u32(lvl)
+    b += _u32(effect)                                   # the 1.12 addition
+    return b
+
+
+def test_enchant_data_roundtrips_and_has_the_trailing_u32():
+    raw = _enchant_bytes(0, prices=[(1000003, 2000)], effect=7)
+    r = _Reader(raw, 0, rec_end=len(raw))
+    ed = _read_EnchantData_CD113(r)
+    assert r.pos == len(raw)
+    assert ed["level"] == 0
+    assert ed["buy_price_list"][0]["key"] == 1000003
+    assert ed["buy_price_list"][0]["price"]["price"] == 2000
+    assert ed["item_effect_info"] == 7
+    w = _Writer()
+    _write_EnchantData_CD113(w, ed)
+    assert bytes(w.buf) == raw
+
+
+def test_enchant_element_sizes_are_pinned():
+    """Sizes are the whole ballgame: a wrong element width still
+    round-trips byte-exact while silently mis-assigning every field after
+    it. Pin them numerically.
+
+    2 level + 3*4 empty + (4 + 1*5) + (4 + 2*20) + (4 + 1*8) + 4 = 83
+    """
+    raw = _enchant_bytes(
+        1,
+        static_lvl=[(1000007, 1)],
+        prices=[(1000002, 8000), (11, 4000)],
+        buffs=[(1000009, 0)],
+        effect=0,
+    )
+    assert len(raw) == 83
+    r = _Reader(raw, 0, rec_end=len(raw))
+    ed = _read_EnchantData_CD113(r)
+    assert r.pos == 83
+    assert len(ed["enchant_stat_data"]["stat_list_static_level"]) == 1
+    assert len(ed["buy_price_list"]) == 2
+    assert len(ed["equip_buffs"]) == 1
+    w = _Writer()
+    _write_EnchantData_CD113(w, ed)
+    assert bytes(w.buf) == raw
+
+
+def test_carray_guard_bounds_by_record_not_body():
+    """A desynced count must be rejected against the *record*, not the
+    5.9MB body -- otherwise it allocates ~500k dicts before failing."""
+    data = b"\xff\xff\x00\x00" + b"\x00" * 4096      # count = 65535
+    r = _Reader(data, 0, rec_end=16)                 # only 16 bytes of record
+    with pytest.raises(ValueError, match="exceeds"):
+        r.carray(_Reader.u32)
+
+
+# ── layout selection ─────────────────────────────────────────────────────
+
+def test_more_specific_layout_wins_a_tie():
+    """A sample drawing only non-equipment records makes the enchant-blind
+    layout tie with the enchant one. The tie must go to the enchant layout
+    or all 3151 equipment records get carried opaque."""
+    labels = [lbl for lbl, _f in nat._ITEM_LAYOUTS]
+    assert labels.index("cd113_enchant") > labels.index("cd113_prefab_relocated")
+
+
+def test_detect_claims_nothing_when_nothing_roundtrips():
+    assert detect_iteminfo_layout(b"", []) is None
+    assert detect_iteminfo_layout(b"\x00" * 4, [0]) is None
+
+
+# ── real-game integration (skips when the game isn't installed) ──────────
+
+def _live_iteminfo():
+    env = os.environ.get("CDUMM_VANILLA_ITEMINFO_DIR")
+    dirs = ([Path(env)] if env else []) + [
+        Path(__file__).parent / "fixtures" / "iteminfo"]
+    for d in dirs:
+        body, header = d / "iteminfo.pabgb", d / "iteminfo.pabgh"
+        if body.exists() and header.exists():
+            return body.read_bytes(), header.read_bytes()
+    return None
+
+
+def test_live_1_13_table_decodes_fully_and_roundtrips_byte_exact():
+    pair = _live_iteminfo()
+    if pair is None:
+        pytest.skip("vanilla iteminfo.pabgb/.pabgh not available")
+    body, header = pair
+
+    count = int.from_bytes(header[:2], "little")
+    starts = sorted(
+        int.from_bytes(header[2 + i * 8 + 4:2 + i * 8 + 8], "little")
+        for i in range(count))
+
+    fields = detect_iteminfo_layout(body, starts)
+    if fields is not _ITEM_FIELDS_CD113_ENCHANT:
+        pytest.skip("installed game is not the CD 1.13 layout")
+
+    items = parse_iteminfo_from_bytes(body, starts, fields=fields)
+
+    # Not one record may fall back to opaque.
+    assert [i for i in items if "_opaque_record" in i] == []
+
+    # Equipment must actually decode (it was 0 before this fix).
+    assert sum(1 for i in items if i.get("equip_type_info")) > 3000
+
+    # ORACLE: enchant tiers are levels 0,1,2,...,N-1. A wrong-but-same-size
+    # layout round-trips byte-exact and would pass every check but this one.
+    for it in items:
+        tiers = it.get("enchant_data_list", [])
+        assert [t["level"] for t in tiers] == list(range(len(tiers)))
+
+    assert serialize_iteminfo(items, fields=fields) == body


### PR DESCRIPTION
> **Part of #272** (@pinapana 閳?*Crazy ExtraSockets*). Stack: **#271** (`match` selector) 閳?**#274** (this 閳?makes CD 1.13 equipment decode) 閳?**#275** (routes `match` through the native decoder; the closing keyword lives on that one).
>
> Without this PR the socket mod has nothing to edit: every equipment item was carried opaque, so `drop_default_data` didn't exist to write to.
>
> **Verified with the real mod** (all three applied): 3 `match` intents 閳?**9,051 concrete edits**, **3,017 items changed**, all via `drop_default_data`, **zero** collateral edits, and the patched table still decodes 6,508/6,508 with a correctly rebuilt `.pabgh`. Before: the mod applied cleanly and changed nothing.

---

## The bug

Every equipment record in the live **CD 1.13** `iteminfo.pabgb` failed to decode and was carried opaque 閳?**3151 of 6508 records** with all their fields dropped.

That is what blocked socket editing (#272), gear stats, and left `match` on iteminfo blind to equipment.

## Root cause

Two coupled wire changes that are only correct **together**:

* `SubItem` tag **17** is a *None* sentinel 閳?it carries **no** u32 payload.
* `ItemInfo` grew **`_enchantDataList`** immediately after `_dropDefaultData`: a u32 count, then one `EnchantData` per enchant tier (levels `0..N-1`; 11 tiers on most equipment, 0 on non-equipment).

The old reader spends its 7 bytes as

```
tag(1) + u32 value(4) + svc(1) + use(1)
```

where the truth is

```
tag(1) + svc(1) + use(1) + u32 enchant count(4)
```

**Identical width.** That is why non-equipment 閳?whose enchant count is `0`, so those four bytes are zero either way 閳?round-tripped byte-exact and *never looked broken*, while equipment (count is almost always 11) desynced from `drop_default_data` onward.

It is also why fixing the sentinel *on its own* destroyed non-equipment in earlier testing: that drops the u32 without putting the enchant count back. **Neither change is correct alone**, which is what made this so slippery.

`EnchantData` itself turned out to be exactly the shape the existing (dead, never-wired) `_read_EnchantData` already modelled, plus the u32 that CD 1.12 added to it 閳?so this wires up the existing reader rather than inventing a new struct.

## Results 閳?live 1.13 table, 6508 records

|  | non-equipment | **equipment** | opaque |
|---|---|---|---|
| before | 3167 | **0** | 3341 |
| after | 3357 | **3151** | **0** |

* `serialize_iteminfo()` reproduces the file **byte-for-byte**.
* **804** items now decode with `use_socket = 1` 閳?the #272 targets.
* Decode + re-serialize of the whole table runs in ~1 s.

## Why byte-exactness alone isn't enough

A **wrong-but-same-size** read round-trips byte-exact and would pass every check 閳?while silently mis-assigning fields and corrupting item tables on *write*. So the enchant tier **level ladder** (`0,1,2,閳?N-1`) is asserted as an independent oracle:

* **0 violations** across all 1047 multi-tier records
* the integration test enforces it on **every** record

## Compatibility

Pre-1.13 readers are left untouched. The new shape ships as a separate `cd113_enchant` layout, so `detect_iteminfo_layout` still self-selects the right one per game version.

## Two supporting fixes the new layout depends on

* **`_Reader.carray`** bounded its count by the whole 5.9 MB *body* rather than the *record*, so a desynced count allocated ~500k dicts before failing 閳?a stall, not an error. Now bounded by `rec_end`: a count can never exceed the bytes left in its own record.
* **`detect_iteminfo_layout`** broke ties toward the *first* layout. A sample that happened to draw only non-equipment records would tie `cd113_enchant` with the enchant-blind layout and lock in the latter 閳?silently carrying all 3151 equipment records opaque. Ties now go to the more specific layout; a layout is still never *claimed* when nothing round-trips.

## Tests

`tests/test_iteminfo_cd113_enchant.py` 閳?9 tests, all passing:

* tag 17 consumes no u32; a real tag still carries its u32
* sockets (`add_socket_material_item_list`, `socket_valid_count`, `use_socket`) survive the new DDD 閳?the #272 path
* `EnchantData` round-trips and carries the trailing u32
* **element sizes pinned numerically** (12B / 5B / 20B / 8B) 閳?the one thing a byte-exact round-trip cannot catch
* the `carray` guard bounds by record, not body
* layout tie-break, and "claim nothing when nothing round-trips"
* live-table integration: 0 opaque, level-ladder oracle on every record, byte-exact re-serialize (skips cleanly when the game isn't installed)

Full engine suite: **171 passed, 0 new failures.**

<sub>The 2 remaining failures in `test_iteminfo_walk_real_game.py` are pre-existing on 1.13 閳?they live in the legacy *semantic* walker, reproduce identically on a clean tree, and are untouched by this PR.</sub>
