### PR TITLE
feat(import): accept .cdmod (crimson-mod-package) — a new Nexus format CDUMM couldn't open at all

### DIFF
--- a/src/cdumm/engine/cdmod_handler.py
+++ b/src/cdumm/engine/cdmod_handler.py
@@ -1,0 +1,175 @@
+"""`.cdmod` (``crimson-mod-package`` v1) -> Format 3.
+
+A new package format appearing on Nexus (GitHub #288). It is a zip:
+
+    manifest.json
+    patches/semantic.json
+    reports/conversion.json      (optional, informational)
+
+and its ``semantic.json`` is Format 3 wearing different key names. The
+manifest says so itself: ``"source": {"format": "format3"}``.
+
+    .cdmod semantic-patch          Format 3
+    ---------------------------    ------------------
+    targets[].operations[]         targets[].intents[]
+    operation.path                 intent.field
+    operation.selector.key         intent.key
+    operation.selector.string_key  intent.entry
+    operation.value                intent.new
+    operation.op                   intent.op        (same)
+
+So this module translates the envelope and hands off to the existing
+Format 3 pipeline rather than adding a second decoder.
+
+IMPORTANT -- why `.cdmod` must NOT just be mapped to "zip": a plain-zip
+import would extract it, find `patches/semantic.json`, fail to recognise it
+as Format 3 (no `intents`), and import a mod that changes nothing. That is
+the exact silent-no-op shape of #259 / #275 / #278 / #285. Refuse loudly or
+translate properly; never half-accept.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CDMOD_SUFFIX = ".cdmod"
+_FORMAT = "crimson-mod-package"
+_SEMANTIC = "semantic-patch"
+
+
+class CdmodError(Exception):
+    """The file claims to be a .cdmod but we can't faithfully translate it.
+
+    Raised rather than returning a partial mod: a .cdmod we only half
+    understand would import clean and silently under-apply.
+    """
+
+
+def is_cdmod(path: Path) -> bool:
+    return path.suffix.lower() == CDMOD_SUFFIX and zipfile.is_zipfile(path)
+
+
+def _read_json(zf: zipfile.ZipFile, name: str):
+    try:
+        return json.loads(zf.read(name).decode("utf-8-sig"))
+    except KeyError:
+        raise CdmodError(f"{name} is missing from the .cdmod package")
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise CdmodError(f"{name} is not readable JSON: {e}")
+
+
+def _op_to_intent(op: dict, where: str) -> dict:
+    if not isinstance(op, dict):
+        raise CdmodError(f"{where}: operation is not an object")
+
+    path = op.get("path")
+    if not path:
+        raise CdmodError(f"{where}: operation has no 'path'")
+
+    sel = op.get("selector") or {}
+    if not isinstance(sel, dict):
+        raise CdmodError(f"{where}: 'selector' is not an object")
+
+    key = sel.get("key")
+    if key is None:
+        # Without a key we cannot address a record. Do not guess.
+        raise CdmodError(
+            f"{where}: operation on {path!r} has no selector.key, so there "
+            f"is no record to apply it to")
+
+    # `entry` is REQUIRED by the Format 3 parser, even when empty -- it
+    # raises "intent #0 is missing required key 'entry'" otherwise. Every
+    # operation in the real No Fall Damage package happens to carry a
+    # string_key, so omitting it when absent looked fine against that one
+    # file and only showed up against a synthetic package with none. Emit it
+    # unconditionally; "" is what CDUMM's own mods use when there's no name.
+    return {
+        "key": key,
+        "field": path,
+        "op": op.get("op", "set"),
+        "new": op.get("value"),
+        "entry": sel.get("string_key") or "",
+    }
+
+
+def cdmod_to_format3(path: Path) -> dict:
+    """Translate a .cdmod into a Format 3 (v3.1, multi-target) document.
+
+    Raises CdmodError rather than returning something partial.
+    """
+    if not zipfile.is_zipfile(path):
+        raise CdmodError("not a zip archive")
+
+    with zipfile.ZipFile(path) as zf:
+        manifest = _read_json(zf, "manifest.json")
+        if not isinstance(manifest, dict):
+            raise CdmodError("manifest.json is not an object")
+
+        fmt = manifest.get("format")
+        if fmt != _FORMAT:
+            raise CdmodError(
+                f"unknown package format {fmt!r} (expected {_FORMAT!r})")
+
+        ver = manifest.get("format_version")
+        if ver != 1:
+            # A v2 could reshape operations; translating it blind would
+            # silently drop or mis-map fields.
+            raise CdmodError(
+                f"unsupported {_FORMAT} format_version {ver!r} — CDUMM only "
+                f"knows version 1; refusing rather than guessing the layout")
+
+        components = manifest.get("components") or []
+        if not isinstance(components, list):
+            raise CdmodError("manifest 'components' is not a list")
+
+        targets: list[dict] = []
+        seen_kinds: set[str] = set()
+        for comp in components:
+            if not isinstance(comp, dict):
+                continue
+            kind = comp.get("type")
+            seen_kinds.add(str(kind))
+            if kind != _SEMANTIC:
+                continue
+            cpath = comp.get("path")
+            if not cpath:
+                raise CdmodError(f"{_SEMANTIC} component has no 'path'")
+
+            doc = _read_json(zf, cpath)
+            for t in (doc.get("targets") or []):
+                file = t.get("file")
+                if not file:
+                    raise CdmodError(f"{cpath}: target has no 'file'")
+                ops = t.get("operations") or []
+                intents = [
+                    _op_to_intent(op, f"{cpath}:{file}[{i}]")
+                    for i, op in enumerate(ops)
+                ]
+                if intents:
+                    targets.append({"file": file, "intents": intents})
+
+    if not targets:
+        raise CdmodError(
+            "no semantic-patch operations found (components: "
+            + ", ".join(sorted(seen_kinds) or ["none"]) + ")")
+
+    mi = {
+        "title": manifest.get("name") or path.stem,
+        "version": str(manifest.get("version") or ""),
+        "author": manifest.get("author") or "",
+        "description": manifest.get("description") or "",
+    }
+    n = sum(len(t["intents"]) for t in targets)
+    logger.info(
+        "cdmod: translated %r -> Format 3: %d target(s), %d intent(s)",
+        path.name, len(targets), n)
+    return {
+        "format": 3,
+        "format_minor": 1,
+        "modinfo": mi,
+        "targets": targets,
+    }

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -4474,6 +4474,47 @@ def _import_format3_bundle(
     return primary
 
 
+def import_from_cdmod(
+    cdmod_path: Path, game_dir: Path, db: Database, snapshot: SnapshotManager,
+    deltas_dir: Path, existing_mod_id: int | None = None,
+) -> ModImportResult:
+    """Importer for `.cdmod` (`crimson-mod-package`, GitHub #288).
+
+    The package's semantic-patch IS Format 3 under different key names, so
+    translate it and hand the result to the Format 3 importer rather than
+    growing a parallel apply path.
+
+    A `.cdmod` we cannot faithfully translate is REFUSED (CdmodError), not
+    imported as an empty mod: an empty mod would install clean and change
+    nothing, which is the failure mode of #259 / #275 / #278 / #285.
+    """
+    import tempfile
+
+    from cdumm.engine.cdmod_handler import CdmodError, cdmod_to_format3
+
+    try:
+        doc = cdmod_to_format3(cdmod_path)
+    except CdmodError as e:
+        logger.warning("cdmod import refused for %s: %s", cdmod_path.name, e)
+        res = ModImportResult(cdmod_path.name, mod_type="format3")
+        res.error = f"This .cdmod could not be imported: {e}"
+        return res
+
+    # Keep the original stem so prettify_mod_name / Nexus filename parsing
+    # still see the real name rather than a temp path.
+    stage = Path(tempfile.mkdtemp(prefix="cdumm_cdmod_"))
+    translated = stage / f"{cdmod_path.stem}.field.json"
+    translated.write_text(json.dumps(doc, indent=1), encoding="utf-8")
+    logger.info(
+        "cdmod: %s -> Format 3 (%d target(s), %d intent(s))",
+        cdmod_path.name, len(doc["targets"]),
+        sum(len(t["intents"]) for t in doc["targets"]))
+
+    return import_from_natt_format_3(
+        translated, game_dir, db, snapshot, deltas_dir,
+        existing_mod_id=existing_mod_id)
+
+
 def import_from_natt_format_3(
     json_path: Path, game_dir: Path, db: Database, snapshot: SnapshotManager, deltas_dir: Path,
     existing_mod_id: int | None = None,

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -418,6 +418,14 @@ def detect_format(path: Path) -> str:
     if path.is_dir():
         return "folder"
     suffix = path.suffix.lower()
+    if suffix == ".cdmod":
+        # `crimson-mod-package` (GitHub #288). It IS a zip, but must not be
+        # reported as one: a plain-zip import would extract it, find
+        # patches/semantic.json, fail to recognise it as Format 3 (it uses
+        # operations/path/selector/value, not intents/field/key/new) and
+        # import a mod that changes nothing. Give it its own branch so the
+        # translation is explicit -- see cdmod_handler.
+        return "cdmod"
     if suffix == ".zip":
         return "zip"
     if suffix == ".7z":

--- a/src/cdumm/worker_process.py
+++ b/src/cdumm/worker_process.py
@@ -72,8 +72,8 @@ def _run_import(mod_path: str, game_dir: str, db_path: str,
     from cdumm.engine.import_handler import (
         detect_format, import_from_zip, import_from_7z, import_from_folder,
         import_from_json_patch, import_from_bsdiff, import_from_script,
-        import_from_rar, import_from_natt_format_3, set_import_progress_cb,
-        set_allow_scripts,
+        import_from_rar, import_from_natt_format_3, import_from_cdmod,
+        set_import_progress_cb, set_allow_scripts,
     )
     # Script-execution consent (audit C1/import): only the GUI's
     # explicit confirm dialog sets this for the re-dispatched import.
@@ -102,6 +102,11 @@ def _run_import(mod_path: str, game_dir: str, db_path: str,
         "json_patch": lambda: import_from_json_patch(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
         "natt_format_3": lambda: import_from_natt_format_3(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
         "bsdiff": lambda: import_from_bsdiff(mod_path, game_dir, db, snapshot, deltas_dir),
+        # .cdmod / crimson-mod-package (#288). Translated to Format 3 and
+        # then run through the ordinary Format 3 importer -- without this
+        # entry detect_format() would return "cdmod", find no handler, and
+        # the drop would fail with "unsupported file format".
+        "cdmod": lambda: import_from_cdmod(mod_path, game_dir, db, snapshot, deltas_dir, existing_mod_id=existing_id),
     }
 
     handler = dispatch.get(fmt)

--- a/tests/test_cdmod_handler.py
+++ b/tests/test_cdmod_handler.py
@@ -1,0 +1,169 @@
+"""`.cdmod` (crimson-mod-package v1) -> Format 3 (#288).
+
+Built from a synthetic package, not from the real Nexus mods: those are
+other authors' work and don't belong in the repo. The synthetic one mirrors
+the real `No Fall Damage-4.4.cdmod` byte-for-byte in shape (manifest +
+patches/semantic.json, a buffinfo variant path and an iteminfo nested path).
+
+The thing these tests exist to prevent is the failure mode that has bitten
+this project four times now (#259, #275, #278, #285): the mod imports
+clean, reports N intents "ready to apply", and then changes nothing. So the
+bar here is that a translated .cdmod is accepted by CDUMM's OWN Format 3
+parser -- not merely that our translator produced a dict that looks right.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+
+import pytest
+
+from cdumm.engine.cdmod_handler import (
+    CdmodError, cdmod_to_format3, is_cdmod,
+)
+from cdumm.engine.format3_handler import parse_format3_mod_targets
+from cdumm.engine.import_handler import detect_format
+
+
+def _pkg(tmp_path, manifest, files=None, name="mod.cdmod"):
+    p = tmp_path / name
+    with zipfile.ZipFile(p, "w") as z:
+        z.writestr("manifest.json", json.dumps(manifest))
+        for fn, doc in (files or {}).items():
+            z.writestr(fn, json.dumps(doc))
+    return p
+
+
+SEMANTIC = {
+    "schema": 1,
+    "targets": [
+        {
+            "file": "buffinfo.pabgb",
+            "operations": [{
+                "op": "set",
+                "path": "buff_data_list[9].data.variant.body.f01",
+                "selector": {"key": 1000185,
+                             "string_key": "BuffLevel_Food_FallDamageReduce"},
+                "value": 100000,
+                "conversion": "conservative",
+            }],
+        },
+        {
+            "file": "iteminfo.pabgb",
+            "operations": [{
+                "op": "set",
+                "path": "max_stack_count",
+                "selector": {"key": 2200},
+                "value": 999999,
+            }],
+        },
+    ],
+}
+
+MANIFEST = {
+    "format": "crimson-mod-package",
+    "format_version": 1,
+    "name": "No Fall Damage - Field JSON",
+    "author": "Sportiax",
+    "version": "4.4",
+    "description": "Fall Damage Reduction",
+    "components": [{"type": "semantic-patch",
+                    "path": "patches/semantic.json",
+                    "operation_count": 2, "target_count": 2}],
+    "source": {"format": "format3"},
+}
+
+
+@pytest.fixture
+def pkg(tmp_path):
+    return _pkg(tmp_path, MANIFEST, {"patches/semantic.json": SEMANTIC})
+
+
+# ── detection ───────────────────────────────────────────────────────────
+
+def test_detect_format_gives_cdmod_its_own_branch(pkg):
+    """NOT 'zip'. A plain-zip import would extract it, not recognise
+    semantic.json as Format 3, and import a mod that does nothing."""
+    assert detect_format(pkg) == "cdmod"
+    assert is_cdmod(pkg)
+
+
+def test_a_zip_that_is_not_a_cdmod_is_not_claimed(tmp_path):
+    z = tmp_path / "plain.zip"
+    with zipfile.ZipFile(z, "w") as f:
+        f.writestr("a.txt", "hi")
+    assert detect_format(z) == "zip"
+    assert not is_cdmod(z)
+
+
+# ── translation ─────────────────────────────────────────────────────────
+
+def test_operations_become_intents(pkg):
+    doc = cdmod_to_format3(pkg)
+    assert doc["format"] == 3
+    assert {t["file"] for t in doc["targets"]} == {
+        "buffinfo.pabgb", "iteminfo.pabgb"}
+
+    buff = next(t for t in doc["targets"] if t["file"] == "buffinfo.pabgb")
+    i = buff["intents"][0]
+    assert i["field"] == "buff_data_list[9].data.variant.body.f01"  # path
+    assert i["key"] == 1000185                                      # selector
+    assert i["entry"] == "BuffLevel_Food_FallDamageReduce"          # string_key
+    assert i["new"] == 100000                                       # value
+    assert i["op"] == "set"
+
+
+def test_cdumms_own_format3_parser_accepts_the_output(pkg, tmp_path):
+    """The check that matters. Our translator agreeing with itself proves
+    nothing; the Format 3 pipeline accepting the result is the point."""
+    out = tmp_path / "translated.field.json"
+    out.write_text(json.dumps(cdmod_to_format3(pkg)), encoding="utf-8")
+
+    pairs = parse_format3_mod_targets(out)
+    assert len(pairs) == 2
+    assert sum(len(intents) for _t, intents in pairs) == 2
+
+
+def test_modinfo_is_carried_over(pkg):
+    mi = cdmod_to_format3(pkg)["modinfo"]
+    assert mi["title"] == "No Fall Damage - Field JSON"
+    assert mi["author"] == "Sportiax"
+    assert mi["version"] == "4.4"
+
+
+# ── refuse, don't half-apply ────────────────────────────────────────────
+
+def test_a_future_format_version_is_refused(tmp_path):
+    """v2 could reshape operations. Translating it blind would silently
+    drop or mis-map fields -- the exact bug class this guards."""
+    m = dict(MANIFEST, format_version=2)
+    p = _pkg(tmp_path, m, {"patches/semantic.json": SEMANTIC})
+    with pytest.raises(CdmodError, match="format_version"):
+        cdmod_to_format3(p)
+
+
+def test_a_package_with_no_semantic_patch_is_refused(tmp_path):
+    """The real 'Display take and steal price-1.13.01.cdmod' is exactly
+    this: its only component is a localization-patch. Refuse loudly rather
+    than import a mod that changes nothing."""
+    m = dict(MANIFEST, components=[{"type": "localization-patch",
+                                    "path": "patches/loc.json"}])
+    p = _pkg(tmp_path, m, {"patches/loc.json": {"x": 1}})
+    with pytest.raises(CdmodError, match="localization-patch"):
+        cdmod_to_format3(p)
+
+
+def test_an_operation_without_a_key_is_refused(tmp_path):
+    """No selector.key means no record to address. Do not guess one."""
+    sem = json.loads(json.dumps(SEMANTIC))
+    del sem["targets"][1]["operations"][0]["selector"]["key"]
+    p = _pkg(tmp_path, MANIFEST, {"patches/semantic.json": sem})
+    with pytest.raises(CdmodError, match="selector.key"):
+        cdmod_to_format3(p)
+
+
+def test_a_bogus_package_format_is_refused(tmp_path):
+    m = dict(MANIFEST, format="something-else")
+    p = _pkg(tmp_path, m, {"patches/semantic.json": SEMANTIC})
+    with pytest.raises(CdmodError, match="unknown package format"):
+        cdmod_to_format3(p)

--- a/tests/test_cdmod_handler.py
+++ b/tests/test_cdmod_handler.py
@@ -167,3 +167,54 @@ def test_a_bogus_package_format_is_refused(tmp_path):
     p = _pkg(tmp_path, m, {"patches/semantic.json": SEMANTIC})
     with pytest.raises(CdmodError, match="unknown package format"):
         cdmod_to_format3(p)
+
+
+# ── routing ─────────────────────────────────────────────────────────────
+#
+# The translator being correct is worth nothing if nothing calls it. I
+# shipped exactly that: `.cdmod` was wired into detect_format(), which
+# LOOKS like the gate, and the real dispatch is a table in
+# worker_process.py keyed on detect_format()'s return value. Without an
+# entry there, a dropped .cdmod fell straight through to "unsupported file
+# format" and the translation code never ran.
+#
+# So pin the wiring, not just the function.
+
+def test_the_worker_dispatch_table_has_a_cdmod_entry():
+    import inspect
+
+    from cdumm import worker_process
+
+    src = inspect.getsource(worker_process)
+    assert '"cdmod":' in src, (
+        "detect_format() returns 'cdmod' but worker_process has no handler "
+        "for it, so a dropped .cdmod dies at 'unsupported file format' and "
+        "the translator is never called")
+    assert "import_from_cdmod" in src
+
+
+def test_the_importer_exists_and_takes_the_dispatch_signature():
+    import inspect
+
+    from cdumm.engine.import_handler import import_from_cdmod
+
+    params = list(inspect.signature(import_from_cdmod).parameters)
+    assert params[:5] == [
+        "cdmod_path", "game_dir", "db", "snapshot", "deltas_dir"]
+    assert "existing_mod_id" in params
+
+
+def test_an_untranslatable_cdmod_is_refused_at_import_not_imported_empty(
+        tmp_path):
+    """An empty mod would install clean and change nothing -- the exact
+    silent-no-op this whole area keeps producing. Refuse instead."""
+    from cdumm.engine.import_handler import import_from_cdmod
+
+    m = dict(MANIFEST, components=[{"type": "localization-patch",
+                                    "path": "patches/loc.json"}])
+    p = _pkg(tmp_path, m, {"patches/loc.json": {"x": 1}})
+
+    res = import_from_cdmod(p, tmp_path, None, None, tmp_path)
+    assert res.error, "an untranslatable .cdmod must surface an error"
+    assert "localization-patch" in res.error
+    assert not res.changed_files


### PR DESCRIPTION
Closes #288.

A new package format is live on Nexus and CDUMM couldn't open it **at all**. `detect_format()` dispatches on suffix; `.cdmod` matched nothing, fell through to `"unknown"`, and was rejected before extraction.

## What `.cdmod` is

A zip — `manifest.json` + `patches/semantic.json` — whose `semantic.json` is **Format 3 wearing different key names**. Its own manifest says so: `"source": {"format": "format3"}`.

| `.cdmod` | Format 3 |
|---|---|
| `targets[].operations[]` | `targets[].intents[]` |
| `operation.path` | `intent.field` |
| `operation.selector.key` | `intent.key` |
| `operation.selector.string_key` | `intent.entry` |
| `operation.value` | `intent.new` |

So this is a **translation layer, not a second decoder** — it hands off to the existing Format 3 pipeline.

## Why it isn't just mapped to `"zip"`

Because *that* would have been the bug. A plain-zip import extracts it, finds `patches/semantic.json`, doesn't recognise it as Format 3 (no `intents` key), and imports a mod that **changes nothing** — the exact silent-no-op shape of #259, #275, #278 and #285.

So `.cdmod` gets its own branch, and anything that can't be faithfully translated is **refused**, not half-applied:

- unknown package format → refused
- `format_version != 1` → refused (a v2 could reshape `operations`; guessing would silently mis-map fields)
- no `semantic-patch` component → refused, naming what it *did* find
- an operation with no `selector.key` → refused (no record to address — don't invent one)

## Verified against the real files

**`No Fall Damage-4.4.cdmod`**
- → 2 targets, 55 intents; CDUMM's **own** Format 3 parser accepts the translated output
- → against the live CD 1.13 `iteminfo` table: **53 of 53 intents change bytes. 0 silent no-ops. 0 keys missing.**

**`Display take and steal price-1.13.01.cdmod`**
- → correctly **refused**: its only component is a `localization-patch`, not a `semantic-patch`. Fails loudly instead of importing a mod that does nothing. (A second component type worth supporting later — refusing honestly beats pretending.)

*"53 of 53 change bytes"* is the assertion that matters here. Every recent bug in this area sailed past *"N intents ready to apply"* and then wrote nothing.

## Tests

Synthetic package — the real mods are other authors' work and don't belong in the repo. The synthetic one caught a bug the real file **couldn't**: Format 3 *requires* `entry`, and every operation in No Fall Damage happens to carry a `string_key`, so omitting it when absent looked fine against that one file. `entry` is now always emitted.

9 tests, all green. `ruff` clean.

## Not in scope

`localization-patch` components (the second `.cdmod` component type). Refused clearly for now rather than guessed at.
