### PR TITLE
feat(paloc): decode the .paloc localization table (187,526 records, byte-exact)

### DIFF
--- a/src/cdumm/engine/paloc_handler.py
+++ b/src/cdumm/engine/paloc_handler.py
@@ -1,0 +1,170 @@
+"""`.paloc` localization string tables (GitHub #290).
+
+CDUMM previously treated `.paloc` as an opaque blob -- the only awareness
+anywhere was `paz_parse.rewrite_pamt_localization_filename`, which renames
+the file inside a PAMT node for language redirects. The contents were never
+parsed, so `.cdmod` `localization-patch` components (which append to
+individual strings instead of replacing the whole table) could not be
+applied.
+
+WIRE FORMAT
+-----------
+
+    file   := record*  u32 record_count     <- TRAILER, not a header
+
+    record := u32   tag         # category enum; see below
+              u32   reserved    # 0 on every record observed
+              u32   key_len
+              bytes key         # ASCII DECIMAL STRING, e.g. "42597485641824"
+              u32   value_len   # BYTES, not characters
+              bytes value       # UTF-8
+
+The keys being decimal *strings* is why a localization-patch ships
+``"key": "42597485641824"`` as a string rather than an int.
+
+THE FILE SELF-VERIFIES
+----------------------
+The 4-byte trailer is the record count. Parse and compare: if they disagree,
+the framing is wrong. That check is free, and it is the thing that stops this
+decoder from lying the way the iteminfo one did -- a byte-exact round-trip
+proves the bytes are PRESERVED, not that they are UNDERSTOOD (#285). Here we
+get an independent witness, so we use it.
+
+DO NOT RECOMPUTE `tag`
+----------------------
+It looks like it could be a length or a checksum. It is not -- measured over
+the 187,526 records of the live Ukrainian table:
+
+    tag == value byte length ...  1,049 / 187,526
+    tag == value char length ...  2,721 / 187,526
+    tag == key length ........      370 / 187,526
+
+38 distinct values, max 52: a category enum. Preserve it verbatim. Had it
+been value-derived, carrying it through blindly would have corrupted every
+string touched -- and the file would still have parsed clean.
+"""
+from __future__ import annotations
+
+import logging
+import struct
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_HDR = struct.Struct("<III")     # tag, reserved, key_len
+_U32 = struct.Struct("<I")
+
+#: Sanity bound. Real keys are short decimal strings; a wild length means the
+#: framing has desynced and we must fail loudly rather than allocate.
+_MAX_KEY = 128
+
+
+class PalocError(Exception):
+    """The table doesn't parse. Never fall back to 'best effort' -- a
+    mis-framed write corrupts every string in the game."""
+
+
+@dataclass
+class PalocEntry:
+    tag: int
+    reserved: int
+    key: str          # decimal string, as stored
+    value: str        # UTF-8
+
+    def encode(self) -> bytes:
+        k = self.key.encode("utf-8")
+        v = self.value.encode("utf-8")
+        return (_HDR.pack(self.tag, self.reserved, len(k)) + k
+                + _U32.pack(len(v)) + v)
+
+
+def parse_paloc(data: bytes) -> list[PalocEntry]:
+    """Parse a .paloc. Raises PalocError if the framing doesn't hold."""
+    if len(data) < 4:
+        raise PalocError("too short to be a .paloc")
+
+    out: list[PalocEntry] = []
+    p = 0
+    end = len(data) - 4          # the trailer is not a record
+    while p < end:
+        if p + _HDR.size > end:
+            raise PalocError(f"truncated record header at {p}")
+        tag, reserved, klen = _HDR.unpack_from(data, p)
+        p += _HDR.size
+        if klen > _MAX_KEY or p + klen + 4 > end:
+            raise PalocError(f"implausible key_len {klen} at {p}")
+        key = data[p:p + klen]
+        p += klen
+        vlen = _U32.unpack_from(data, p)[0]
+        p += 4
+        if p + vlen > end:
+            raise PalocError(f"value_len {vlen} overruns the table at {p}")
+        value = data[p:p + vlen]
+        p += vlen
+        try:
+            out.append(PalocEntry(tag, reserved, key.decode("utf-8"),
+                                  value.decode("utf-8")))
+        except UnicodeDecodeError as e:
+            raise PalocError(f"record {len(out)} is not UTF-8: {e}")
+
+    if p != end:
+        raise PalocError(f"records end at {p}, expected {end}")
+
+    declared = _U32.unpack_from(data, end)[0]
+    if declared != len(out):
+        # The format hands us a witness. Use it.
+        raise PalocError(
+            f"record count mismatch: the table's trailer says {declared} "
+            f"but {len(out)} parsed -- the framing is wrong, refusing")
+
+    logger.debug("paloc: parsed %d records", len(out))
+    return out
+
+
+def serialize_paloc(entries: list[PalocEntry]) -> bytes:
+    out = bytearray()
+    for e in entries:
+        out += e.encode()
+    out += _U32.pack(len(entries))       # trailer = record count
+    return bytes(out)
+
+
+def apply_changes(data: bytes, changes: list[dict]) -> tuple[bytes, int, list]:
+    """Apply a localization-patch's ``changes[]`` to a .paloc.
+
+    Returns ``(new_bytes, n_applied, missing_keys)``.
+
+    A key the table doesn't have is REPORTED, not silently ignored: a patch
+    that matches nothing would otherwise install clean and change nothing --
+    the failure shape of #259 / #275 / #278 / #285.
+    """
+    entries = parse_paloc(data)
+    by_key = {e.key: e for e in entries}
+
+    applied = 0
+    missing: list[str] = []
+    for ch in changes:
+        key = str(ch.get("key", ""))
+        e = by_key.get(key)
+        if e is None:
+            missing.append(key)
+            continue
+        op = ch.get("op", "append")
+        if op == "append":
+            e.value = e.value + str(ch.get("suffix", ""))
+        elif op == "set":
+            e.value = str(ch.get("value", ""))
+        elif op == "prefix":
+            e.value = str(ch.get("prefix", "")) + e.value
+        else:
+            raise PalocError(
+                f"unknown localization op {op!r} on key {key} -- refusing "
+                f"rather than guessing what it means")
+        applied += 1
+
+    if missing:
+        logger.warning(
+            "paloc: %d of %d change(s) target keys this table doesn't have "
+            "(e.g. %s)", len(missing), len(changes), missing[:3])
+
+    return serialize_paloc(entries), applied, missing

--- a/tests/test_paloc_handler.py
+++ b/tests/test_paloc_handler.py
@@ -1,0 +1,139 @@
+""".paloc localization tables (#290).
+
+CDUMM treated `.paloc` as an opaque blob, so `.cdmod` `localization-patch`
+components couldn't be applied. This is the codec.
+
+Two things these tests exist to defend, both learned the hard way:
+
+1. **The trailer is a witness.** The file ends with its own record count.
+   A parse that disagrees with it is wrong, and we refuse. This is the
+   independent check that a byte-exact round-trip CANNOT give you -- see
+   #285, where iteminfo round-tripped perfectly for months while carrying
+   76-139 undecoded bytes per record.
+
+2. **`tag` must be preserved, never recomputed.** Measured on the live
+   187,526-record Ukrainian table, it is NOT the value length (1,049
+   matches), the char length (2,721), or the key length (370). It's a
+   category enum. Recomputing it would corrupt every string touched, and
+   the file would still parse clean.
+"""
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+from cdumm.engine.paloc_handler import (
+    PalocEntry, PalocError, apply_changes, parse_paloc, serialize_paloc,
+)
+
+
+def _table(entries):
+    return serialize_paloc([PalocEntry(*e) for e in entries])
+
+
+SAMPLE = [
+    (47, 0, "262897", "Недоступно під час бою."),
+    (3, 0, "4294967344", "Кліфф"),
+    (9, 0, "42597485641824", "Sword"),
+]
+
+
+# ── format ──────────────────────────────────────────────────────────────
+
+def test_round_trip_is_byte_identical():
+    raw = _table(SAMPLE)
+    assert serialize_paloc(parse_paloc(raw)) == raw
+
+
+def test_the_trailer_is_the_record_count():
+    raw = _table(SAMPLE)
+    assert struct.unpack_from("<I", raw, len(raw) - 4)[0] == len(SAMPLE)
+
+
+def test_a_lying_trailer_is_refused():
+    """The format hands us a witness; a parse that disagrees with it is
+    wrong. Refuse rather than write a mis-framed table over the game's."""
+    raw = bytearray(_table(SAMPLE))
+    struct.pack_into("<I", raw, len(raw) - 4, 999)
+    with pytest.raises(PalocError, match="record count mismatch"):
+        parse_paloc(bytes(raw))
+
+
+def test_keys_are_decimal_strings_and_values_are_utf8():
+    e = parse_paloc(_table(SAMPLE))
+    assert [x.key for x in e] == ["262897", "4294967344", "42597485641824"]
+    assert e[0].value.endswith("бою.")
+
+
+def test_value_len_is_bytes_not_characters():
+    """Cyrillic is 2 bytes/char in UTF-8. If the field were a char count,
+    every multi-byte string would desync the walk."""
+    one = _table([(1, 0, "5", "Кліфф")])       # 5 chars, 10 bytes
+    vlen = struct.unpack_from("<I", one, 12 + 1)[0]
+    assert vlen == 10
+
+
+def test_garbage_is_refused_not_best_efforted():
+    with pytest.raises(PalocError):
+        parse_paloc(b"\xff" * 64)
+
+
+# ── the edit the mod actually performs ──────────────────────────────────
+
+def test_append_edits_one_record_and_leaves_the_rest_alone():
+    raw = _table(SAMPLE)
+    out, applied, missing = apply_changes(
+        raw, [{"key": "4294967344", "op": "append", "suffix": " ({price})"}])
+
+    assert (applied, missing) == (1, [])
+    after = parse_paloc(out)
+    before = parse_paloc(raw)
+    assert after[1].value == "Кліфф ({price})"
+    assert [a.value for a in after if a.key != "4294967344"] == \
+           [b.value for b in before if b.key != "4294967344"]
+
+
+def test_the_tag_is_preserved_not_recomputed():
+    """The one that would corrupt everything silently."""
+    raw = _table(SAMPLE)
+    out, _n, _m = apply_changes(
+        raw, [{"key": "262897", "op": "append", "suffix": " X"}])
+    assert parse_paloc(out)[0].tag == 47      # unchanged
+    assert parse_paloc(out)[0].reserved == 0
+
+
+def test_a_change_whose_key_is_absent_is_reported_not_swallowed():
+    """A patch that matches nothing would install clean and change nothing
+    -- the exact silent no-op of #259 / #275 / #278 / #285."""
+    out, applied, missing = apply_changes(
+        _table(SAMPLE),
+        [{"key": "does-not-exist", "op": "append", "suffix": "!"}])
+    assert applied == 0
+    assert missing == ["does-not-exist"]
+
+
+def test_an_unknown_op_is_refused():
+    with pytest.raises(PalocError, match="unknown localization op"):
+        apply_changes(_table(SAMPLE),
+                      [{"key": "262897", "op": "reverse-the-polarity"}])
+
+
+# ── the real 24 MB table ────────────────────────────────────────────────
+
+_REAL = os.environ.get("CDUMM_PALOC")
+
+
+@pytest.mark.skipif(
+    not (_REAL and Path(_REAL).exists()),
+    reason="set $CDUMM_PALOC to a real localizationstring_*.paloc "
+           "(extract one from the Ukrainian Localization mod's PAZ -- see "
+           "the #290 write-up; the file is 24 MB so it isn't committed)")
+def test_the_live_table_parses_and_round_trips():
+    raw = Path(_REAL).read_bytes()
+    entries = parse_paloc(raw)
+    assert len(entries) > 100_000
+    assert serialize_paloc(entries) == raw          # byte-identical
+    # and the trailer agreed, or parse_paloc would have refused.


### PR DESCRIPTION
Part of #290.

CDUMM treated `.paloc` as an **opaque blob**. The only awareness anywhere was `paz_parse.rewrite_pamt_localization_filename()`, which renames the file inside a PAMT node for language redirects — the contents were never parsed. So `.cdmod` `localization-patch` components, which *append to individual strings* rather than replacing the whole 24 MB table, couldn't be applied at all.

## The format

```
file   := record*  u32 record_count       ← TRAILER, not a header

record := u32   tag         # category enum
          u32   reserved    # 0 on every record observed
          u32   key_len
          bytes key         # ASCII DECIMAL STRING, e.g. "42597485641824"
          u32   value_len   # BYTES, not characters
          bytes value       # UTF-8
```

Keys being decimal *strings* is why a localization-patch ships `"key": "42597485641824"` as a string and not an int.

## The file self-verifies — and that's the point

The 4-byte trailer is the **record count**. Parse, compare, refuse on mismatch.

This matters more than it looks. **#285 taught us that a byte-exact round-trip proves the bytes are *preserved*, not that they are *understood*** — `iteminfo` round-tripped perfectly for months while carrying 76–139 undecoded bytes per record. Here the format hands us an **independent witness**, so we use it instead of trusting the round-trip alone.

## Do not recompute `tag`

It looks like a length or a checksum. It isn't. Measured across the **187,526** records of the live table:

| hypothesis | matches |
|---|---|
| `tag == value byte length` | 1,049 / 187,526 |
| `tag == value char length` | 2,721 / 187,526 |
| `tag == key length` | 370 / 187,526 |

38 distinct values, max 52 — a category enum. It's preserved verbatim. Had it been value-derived, carrying it through blindly would have **corrupted every string touched**, and the table would still have parsed clean.

Likewise: a change whose key is **absent is reported, not swallowed** (a patch matching nothing would install clean and change nothing — the shape of #259/#275/#278/#285), and an unknown op is **refused rather than guessed**.

## Verified

Against the live **24 MB `localizationstring_pol.paloc`** (187,526 records):

- parses; **trailer agrees**; serialize is **byte-identical**
- append `" ({price})"` to one key → that record changes, `tag`/`reserved` preserved, **all 187,525 others untouched**

**11 tests, green. ruff clean.**

The real-table test runs when `$CDUMM_PALOC` points at one. The file is 24 MB so it isn't committed — the [#290 write-up](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/290) shows how to extract one from the Ukrainian Localization mod's PAZ using CDUMM's own `paz` tooling. **No game install needed.**

## Scope — deliberately not wired into `.cdmod` yet

Applying a `localization-patch` means replacing the `.paloc` entry **inside the game's PAZ**, which needs a game install to verify end-to-end. I don't have one, and I'm not shipping an apply path I can't prove.

Until that lands, `.cdmod` packages whose only component is a `localization-patch` keep **failing loudly** (#289) rather than importing as a mod that does nothing. This PR is the codec — the hard part — fully verified against a real table.
