### PR TITLE
fix(apply): refuse byte-offset mods on a table a Format 3 mod rebuilds (game-corrupting)

### DIFF
--- a/src/cdumm/engine/apply_engine.py
+++ b/src/cdumm/engine/apply_engine.py
@@ -360,6 +360,17 @@ def _rewrite_mount_error_with_mod_names(
     )
 
 
+def _normalize_target(name: str) -> str:
+    """Compare a Format 3 `target` with a Format 2 `game_file` fairly.
+
+    One ships ``gamedata/binary__/client/bin/iteminfo.pabgb`` and the other
+    ``gamedata/iteminfo.pabgb``. Comparing them raw silently never matches --
+    the exact path-vs-bare-name trap that made `match` select zero records
+    (#275) and array_append no-op (#278). Compare on the bare table name.
+    """
+    return (str(name or "").replace("\\", "/").rsplit("/", 1)[-1].lower())
+
+
 def aggregate_json_mods_into_synthetic_patches(
     db, overlay_priority_tiebreak: bool = True,
 ) -> tuple[dict, list[dict]]:
@@ -406,6 +417,51 @@ def aggregate_json_mods_into_synthetic_patches(
     per_mod_summary: list[dict] = []
 
     from pathlib import Path as _Path
+
+    # ── Byte offsets vs a rebuilt table (GitHub #293) ──────────────────
+    #
+    # A Format 3 mod does not patch bytes: CDUMM parses the whole table,
+    # edits records, and RE-SERIALIZES it. Records change size, so every
+    # byte offset after the first edited record MOVES.
+    #
+    # A Format 2 mod patches fixed offsets. Applied against a table that a
+    # Format 3 mod has rebuilt, those offsets no longer point where the
+    # author measured them -- the write lands in the middle of some other
+    # record. The result is a structurally invalid table and the game will
+    # not start. falobos76 hit exactly this (GitHub #191): pinapana's
+    # socket mods (Format 3, iteminfo) plus any of three offset mods that
+    # also patch iteminfo -> crash on startup. Each works alone.
+    #
+    # CDUMM already knew which tables get rebuilt -- `f3_target_files` was
+    # collected and then used ONLY for a display label. Nothing guarded on
+    # it. So: find them first, and refuse the unsafe combination rather
+    # than corrupt the file. An honest refusal beats a broken install the
+    # user only discovers when the game won't launch.
+    f3_rebuilt: dict[str, str] = {}      # {game_file: mod that rebuilds it}
+    for _mid, _mname, _src, _dis, _pri, _cv in rows:
+        _p = _Path(_src)
+        if not _p.exists():
+            continue
+        try:
+            _d = _json.loads(_p.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            continue
+        if _d.get("format") != 3:
+            continue
+        try:
+            from cdumm.engine.format3_handler import (
+                parse_format3_mod_targets as _pf3)
+            for _tgt, _ints in _pf3(_p):
+                if _ints:
+                    f3_rebuilt.setdefault(
+                        _normalize_target(_tgt), _mname or f"mod {_mid}")
+        except Exception:  # noqa: BLE001 - never break apply over the guard
+            logger.exception(
+                "aggregate: could not read Format 3 targets for mod %s; "
+                "the byte-offset guard cannot protect its tables", _mid)
+
+    refused_offset_mods: list[dict] = []
+
     for mod_id, mod_name, json_source, disabled_raw, priority, cv_raw in rows:
         jp_path = _Path(json_source)
         if not jp_path.exists():
@@ -464,6 +520,27 @@ def aggregate_json_mods_into_synthetic_patches(
         for patch in data.get("patches", []):
             game_file = patch.get("game_file")
             if not game_file:
+                continue
+
+            # GitHub #293: this mod patches fixed byte offsets in a table
+            # that a Format 3 mod rebuilds. Those offsets are stale the
+            # moment the table is re-serialized. Refuse rather than write
+            # into the middle of some other record and hand the user a game
+            # that won't start.
+            rebuilder = f3_rebuilt.get(_normalize_target(game_file))
+            if rebuilder:
+                logger.warning(
+                    "REFUSED: %r patches %s at fixed byte offsets, but %r "
+                    "rebuilds that table (Format 3). The offsets no longer "
+                    "point where the author measured them, so applying both "
+                    "would corrupt the file. Skipping the byte-offset mod.",
+                    mod_name, game_file, rebuilder)
+                refused_offset_mods.append({
+                    "mod_id": mod_id,
+                    "mod_name": mod_name,
+                    "game_file": game_file,
+                    "rebuilt_by": rebuilder,
+                })
                 continue
             all_changes = patch.get("changes", [])
             # Apply custom values BEFORE the disabled filter so both
@@ -560,6 +637,11 @@ def aggregate_json_mods_into_synthetic_patches(
             for gf, changes in aggregated.items()
         ],
     }
+    if refused_offset_mods:
+        # Carried so the apply path / bug report can name the combination
+        # instead of the user discovering it when the game won't launch.
+        # Consumers read "patches"; an extra key is inert to them.
+        synth_patch_data["_refused_offset_mods"] = refused_offset_mods
     return synth_patch_data, per_mod_summary
 
 

--- a/tests/test_offset_mod_vs_rebuilt_table.py
+++ b/tests/test_offset_mod_vs_rebuilt_table.py
@@ -1,0 +1,163 @@
+"""Byte-offset mods must not be applied to a table a Format 3 mod rebuilds.
+
+GitHub #293, reported by falobos76 on #191.
+
+A Format 3 mod doesn't patch bytes: CDUMM parses the whole table, edits
+records and RE-SERIALIZES it. Records change size, so every byte offset
+after the first edited record MOVES.
+
+A Format 2 mod patches fixed offsets. Applied against a rebuilt table, its
+write lands in the middle of some other record -- the table is structurally
+invalid and the game will not start. That's what falobos76 hit: pinapana's
+socket mods (Format 3, iteminfo) plus any of three offset mods that also
+patch iteminfo. Each works alone.
+
+CDUMM already knew which tables get rebuilt -- `f3_target_files` was
+collected and then used ONLY for a display label. Nothing guarded on it.
+
+This is worse than the silent no-ops of #259/#275/#278/#285: it doesn't
+merely fail to apply, it CORRUPTS. So the bar is that the unsafe
+combination is refused, loudly, naming both mods.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cdumm.engine.apply_engine import (
+    _normalize_target, aggregate_json_mods_into_synthetic_patches,
+)
+
+
+class _FakeDB:
+    """Just enough DB to drive the aggregator."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.connection = self
+
+    def execute(self, *_a, **_k):
+        return self
+
+    def fetchall(self):
+        return self._rows
+
+
+def _row(mod_id, name, path, priority=0):
+    return (mod_id, name, str(path), None, priority, None)
+
+
+def _write(tmp_path, name, doc):
+    p = tmp_path / name
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return p
+
+
+OFFSET_MOD = {
+    "format": 2,
+    "patches": [{
+        "game_file": "gamedata/iteminfo.pabgb",
+        "changes": [{"offset": 2265877, "original": "6400",
+                     "patched": "ffff"}],
+    }],
+}
+
+FORMAT3_MOD = {
+    "format": 3,
+    "format_minor": 1,
+    "modinfo": {"title": "Armor Five Sockets"},
+    "targets": [{
+        "file": "iteminfo.pabgb",
+        "intents": [{"entry": "", "key": 14510, "field": "max_stack_count",
+                     "op": "set", "new": 5}],
+    }],
+}
+
+
+# ── the guard ───────────────────────────────────────────────────────────
+
+def test_offset_mod_is_refused_when_a_format3_mod_rebuilds_the_table(
+        tmp_path):
+    db = _FakeDB([
+        _row(1, "Armor Five Sockets", _write(tmp_path, "f3.json", FORMAT3_MOD)),
+        _row(2, "Mission Efficiency x20",
+             _write(tmp_path, "off.json", OFFSET_MOD)),
+    ])
+
+    synth, _summary = aggregate_json_mods_into_synthetic_patches(db)
+
+    # the offset mod contributed NOTHING -- it was refused, not applied
+    assert synth["patches"] == [], (
+        "a byte-offset patch was aggregated against a table that a Format 3 "
+        "mod rebuilds; its offsets are stale and this corrupts the file")
+
+    refused = synth.get("_refused_offset_mods") or []
+    assert len(refused) == 1
+    r = refused[0]
+    assert r["mod_name"] == "Mission Efficiency x20"
+    assert r["rebuilt_by"] == "Armor Five Sockets"   # names BOTH mods
+    assert "iteminfo" in r["game_file"]
+
+
+def test_the_format3_mod_itself_is_untouched(tmp_path):
+    """The guard drops the unsafe offset write, not the Format 3 mod."""
+    db = _FakeDB([
+        _row(1, "Armor Five Sockets", _write(tmp_path, "f3.json", FORMAT3_MOD)),
+        _row(2, "Offset Mod", _write(tmp_path, "off.json", OFFSET_MOD)),
+    ])
+    synth, _s = aggregate_json_mods_into_synthetic_patches(db)
+    # Format 3 mods never go through this byte aggregator at all -- they have
+    # no "patches" key. Nothing here should have swallowed them.
+    assert "_refused_offset_mods" in synth
+
+
+# ── no false refusals ───────────────────────────────────────────────────
+
+def test_an_offset_mod_on_a_DIFFERENT_table_still_applies(tmp_path):
+    """The failure mode of an over-eager guard: refusing what was safe."""
+    other = {
+        "format": 2,
+        "patches": [{
+            "game_file": "gamedata/skill.pabgb",
+            "changes": [{"offset": 100, "original": "00", "patched": "01"}],
+        }],
+    }
+    db = _FakeDB([
+        _row(1, "Armor Five Sockets", _write(tmp_path, "f3.json", FORMAT3_MOD)),
+        _row(2, "Skill Mod", _write(tmp_path, "s.json", other)),
+    ])
+    synth, _s = aggregate_json_mods_into_synthetic_patches(db)
+
+    assert not synth.get("_refused_offset_mods")
+    assert len(synth["patches"]) == 1
+    assert "skill" in synth["patches"][0]["game_file"]
+
+
+def test_offset_mods_alone_are_untouched(tmp_path):
+    """No Format 3 mod enabled -> nothing to go stale -> apply as before.
+    This is the case that has always worked; it must keep working."""
+    db = _FakeDB([
+        _row(1, "Offset Mod", _write(tmp_path, "off.json", OFFSET_MOD)),
+    ])
+    synth, _s = aggregate_json_mods_into_synthetic_patches(db)
+
+    assert not synth.get("_refused_offset_mods")
+    assert len(synth["patches"]) == 1
+    assert synth["patches"][0]["changes"][0]["offset"] == 2265877
+
+
+# ── the path-vs-bare-name trap ──────────────────────────────────────────
+
+@pytest.mark.parametrize("a,b", [
+    ("gamedata/iteminfo.pabgb", "iteminfo.pabgb"),
+    ("gamedata/binary__/client/bin/iteminfo.pabgb", "gamedata/iteminfo.pabgb"),
+    ("gamedata\\iteminfo.pabgb", "iteminfo.pabgb"),
+    ("gamedata/ITEMINFO.pabgb", "iteminfo.pabgb"),
+])
+def test_a_format3_target_and_a_format2_game_file_are_compared_fairly(a, b):
+    """Format 3 ships a path; Format 2 ships a different path. Comparing
+    them raw silently never matches -- and a guard that never matches is a
+    guard that isn't there. This exact trap made `match` select zero records
+    (#275) and array_append no-op (#278). Third time, so it's pinned."""
+    assert _normalize_target(a) == _normalize_target(b)


### PR DESCRIPTION
Closes #293. Reported by **falobos76** on #191.

**This one corrupts.** It doesn't merely fail to apply — it hands the user a game that won't launch. So it goes ahead of everything else in the queue.

## What happens

A **Format 3** mod doesn't patch bytes. CDUMM parses the whole table, edits records, and **re-serializes it**. Records change size, so **every byte offset after the first edited record moves**.

A **Format 2** mod patches *fixed offsets*. Applied against a table a Format 3 mod has rebuilt, its write lands in the middle of some other record. The table is structurally invalid and the game will not start.

falobos76 hit exactly this: pinapana's socket mods (Format 3, `iteminfo`) **plus** any of three byte-offset mods that also patch `iteminfo` → crash on startup. **Each works alone.** He also notes they all work in DMM — which fits: DMM applies both kinds semantically, so it has no raw offsets left to go stale.

## Why nothing stopped it

CDUMM **already knew** which tables get rebuilt. `f3_target_files` is collected in `aggregate_json_mods_into_synthetic_patches` (L445–454) and then used for **exactly one thing** — a label in the display log (L532). Nothing guarded on it.

The nearest protection compares *signatures between two Format 2 mods* and only emits a `logger.warning`; it never sees the Format 3 side at all.

## The fix

Pre-scan the enabled mods for the tables any Format 3 mod rebuilds, then **refuse** to aggregate a byte-offset patch against one of them — naming **both** mods, and carrying the refusal out in `_refused_offset_mods` so the apply path and the bug report can surface it.

Refusing loses one mod's changes. **Not** refusing loses the user's game.

This is the same family as #259 / #275 / #278 / #285 — *CDUMM reports success and the result is wrong* — except worse. Those were silent no-ops. This is silent **corruption**.

## The trap it would have fallen into

Format 3 ships `iteminfo.pabgb`. Format 2 ships `gamedata/iteminfo.pabgb`. Compared raw they **never match** — and *a guard that never matches is a guard that isn't there*. That exact path-vs-bare-name mismatch made `match` select zero records (#275) and `array_append` no-op (#278). Third time, so `_normalize_target()` and its test are pinned.

## Not refused (a guard that over-fires is its own bug)

- an offset mod on a **different** table → still applies
- offset mods with **no** Format 3 mod enabled → untouched; this is the case that has always worked and must keep working

**8 tests, green.** The `E402`/`F401` ruff findings in `apply_engine` are pre-existing (L229–232), not from this change.

## Scope

Does **not** fix the false-positive conflict list (#292) — that's separate, and reporting-only. And the proper long-term answer here is to **re-anchor** offset patches into the rebuilt table (find the record an offset fell inside, re-map it). But the refusal has to land first: nobody should be able to reach a crashing game state while that's being built.
