### PR TITLE
fix(log): CD 1.13 layout isn't a warning, and its caveat is stale (sent a user to file a bug for nothing)

### DIFF
--- a/src/cdumm/engine/iteminfo_writer.py
+++ b/src/cdumm/engine/iteminfo_writer.py
@@ -582,12 +582,23 @@ def build_iteminfo_intent_change(
     # writer, which handles the common stack-size mods safely without a
     # full decode. Probe is fast (≤5 records, fails fast).
     if not _schema_supports_version(vanilla_body, vanilla_header):
-        logger.warning(
-            "iteminfo: default parser schema does not match this game "
-            "version (record decode fails) — using the relocated-layout "
-            "writer (CD 1.13: prefab/gvp moved to record tail; GitHub "
-            "#247). Stackable items decode + edit fully; other items are "
-            "carried verbatim with leading-field byte-patch.")
+        # INFO, not WARNING. On CD 1.13 -- which is what everyone is playing
+        # -- this is the NORMAL path, not a problem. Logging it as a warning
+        # meant every 1.13 user found a scary line in their bug report about
+        # a "schema mismatch" while their mod was applying perfectly. Srimk1
+        # reported exactly that on GitHub #259 after the storeinfo fix landed:
+        # his 14/14 shops applied, and he still filed a bug because of this
+        # line. A warning should mean "something needs your attention".
+        #
+        # The old wording was also stale: it claimed only stackable items
+        # decode and the rest are "carried verbatim". Since #285 the whole
+        # record decodes -- prefab data included -- so that caveat is simply
+        # untrue now, and repeating it would be telling users their mods are
+        # half-applied when they aren't.
+        logger.info(
+            "iteminfo: using the CD 1.13 record layout (the July patch moved "
+            "the prefab list to the end of the record). This is expected on "
+            "1.13 and every field decodes; nothing is being skipped.")
         return _build_change_relocated_layout(
             vanilla_body, vanilla_header, intents)
 


### PR DESCRIPTION
Found via **Srimk1** on #259.

His *Shop Smart H-Mart* mod applied **perfectly** — his own log says:

```
Format 3 storeinfo.pabgb writer: applied 14 intent(s) across 1 mod(s), 14 change(s)
```

**14 of 14 shops.** And he still filed a bug report — because CDUMM had put this in his log:

```
WARNING  iteminfo: default parser schema does not match this game version
         (record decode fails) — using the relocated-layout writer ...
         Stackable items decode + edit fully; other items are carried
         verbatim with leading-field byte-patch.
```

Two things wrong with that, and both are ours.

## 1. It's a WARNING for the normal path

Everyone is on CD 1.13. This fires on **every apply, for every user**, while everything works correctly. A warning is supposed to mean *"something needs your attention"*. This one sent a user who had nothing wrong to go and write a bug report — and it will keep doing that to everyone else.

## 2. The text is stale — it's now simply untrue

It claims only **stackable** items decode and the rest are *"carried verbatim"*. Since #285 the **whole record decodes**, prefab data included. Repeating that caveat now tells users their mods are half-applied **when they aren't**.

That's the more serious half. A stale reassurance is bad; a stale *alarm* actively erodes trust in the tool — the user can't tell which of CDUMM's messages to believe.

## The fix

Demoted to `INFO`, and reworded to say what's actually true:

> `iteminfo: using the CD 1.13 record layout (the July patch moved the prefab list to the end of the record). This is expected on 1.13 and every field decodes; nothing is being skipped.`

No behaviour change — the code path was already correct. Only what CDUMM *tells the user about itself* changes.

ruff clean. No test pinned the old wording.
