### PR TITLE
fix(apply): re-anchor byte offsets onto a Format 3 rebuild — 231/231 of falobos76's real changes now land correctly

### DIFF
--- a/src/cdumm/engine/offset_reanchor.py
+++ b/src/cdumm/engine/offset_reanchor.py
@@ -6,10 +6,16 @@ instead of corrupting the game. This makes it WORK.
 THE PROBLEM
 
 A Format 3 mod doesn't patch bytes: CDUMM parses the whole table, edits
-records and re-serializes it. Records change size, so every byte offset
-after the first edited record moves. A Format 2 mod's fixed offsets then
-point into the middle of some other record -- the table is invalid and the
-game won't start.
+records and re-serializes it. Records change size, so every byte offset after
+the first edited record moves. A Format 2 mod's fixed offsets then point into
+the middle of some other record -- the table is invalid and the game won't
+start.
+
+Measured on falobos76's actual files (his socket mods + mod 2714 "Infinite
+Durability Only", against the live CD 1.13 iteminfo table):
+
+    231 of his byte-offset changes anchor correctly in vanilla
+    229 of those 231 would write to the WRONG bytes after the rebuild
 
 THE FIX, WITHOUT NEEDING TO UNDERSTAND THE TABLE
 
@@ -18,29 +24,29 @@ The Format 3 whole-table change already carries both halves:
     {"offset": 0, "original": <entire vanilla body>,
                   "patched":  <entire rebuilt body>}
 
-and a record the Format 3 mod did NOT touch is byte-identical in both. So we
-don't need the schema, the record index, or any per-table knowledge: take the
-CONTEXT around the old offset in vanilla and find it in the rebuilt table.
+and a record the Format 3 mod did NOT touch is byte-identical in both. So no
+schema, no record index, no per-table knowledge is needed: locate the patch by
+the bytes AROUND it.
 
-    vanilla:  ... [ctx_before][target bytes][ctx_after] ...
-    rebuilt:  ......... [ctx_before][target bytes][ctx_after] ...
-                        ^ new offset
+What makes this safe rather than clever:
 
-Three things make this safe rather than clever:
+  1. The patch's ``original`` must be present at the old offset in VANILLA,
+     or the mod was built for a different game version and was already broken
+     before any Format 3 mod touched anything.
+  2. Context is taken BEFORE the patch only. A window running past it would
+     break on a LATER edit and falsely refuse a patch that never moved.
+  3. Displacement is BOUNDED by the table's total size delta -- records only
+     shift because earlier records grew or shrank. Exactly one candidate may
+     fall inside that bound, or we refuse.
+  4. The ``original`` bytes must be present at the NEW offset. A remap that
+     doesn't land on the bytes the author measured is not a remap.
 
-  1. The window must match EXACTLY ONCE. Zero matches means the bytes moved
-     or changed; several means the anchor is ambiguous. Either way we refuse
-     -- we never "pick the first one".
-  2. The patch's own ``original`` bytes must be present at the old offset in
-     vanilla. If they aren't, the mod was built for a different game version
-     and was already broken before any of this.
-  3. The ``original`` bytes must be present at the NEW offset in rebuilt. A
-     remap that doesn't land on the bytes the author measured is not a remap.
+Refused, correctly: a record whose BYTES the Format 3 mod changed. The two
+mods genuinely disagree about them, and silently picking one is the same bug
+class as #259 / #275 / #278 / #285.
 
-If a Format 3 mod edited the very record a byte patch points into, the window
-won't match and we refuse THAT patch -- which is correct: the two mods really
-do disagree about those bytes, and silently picking one would be the same
-class of bug we keep fixing.
+NOT refused: a record that merely GREW while the patched bytes stayed put. A
+guard that over-fires is its own bug.
 """
 from __future__ import annotations
 
@@ -48,24 +54,23 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-#: Bytes of context either side of the patched span used to locate it in the
-#: rebuilt table. Long enough to be unique in a multi-MB table; if it isn't,
-#: we widen rather than guess.
+#: Bytes of context BEFORE the patch used to locate it in the rebuilt table.
+#: Widened (never guessed) when a window is ambiguous.
 _CTX = 48
-_CTX_MAX = 512
+_CTX_MAX = 4096
 
 
 class ReanchorRefused(Exception):
     """This patch cannot be re-anchored safely. Do not apply it."""
 
 
-def _unique_find(hay: bytes, needle: bytes) -> int:
-    first = hay.find(needle)
-    if first < 0:
-        return -1
-    if hay.find(needle, first + 1) >= 0:
-        return -2          # ambiguous
-    return first
+def _find_all(hay: bytes, needle: bytes, limit: int = 64) -> list[int]:
+    out: list[int] = []
+    i = hay.find(needle)
+    while i >= 0 and len(out) < limit:
+        out.append(i)
+        i = hay.find(needle, i + 1)
+    return out
 
 
 def reanchor_offset(vanilla: bytes, rebuilt: bytes, offset: int,
@@ -80,65 +85,81 @@ def reanchor_offset(vanilla: bytes, rebuilt: bytes, offset: int,
             f"offset {offset} + {len(original)} bytes runs past the end of "
             f"the vanilla table ({len(vanilla)} bytes)")
 
-    # (2) does the patch even anchor in vanilla?
+    # (1) does the patch even anchor in vanilla?
     if vanilla[offset:end] != original:
         raise ReanchorRefused(
             f"the bytes at offset {offset} are not the ones this mod expects "
             f"(it was built for a different game version)")
 
-    # unchanged tables need no remap at all
     if vanilla == rebuilt:
         return offset
 
-    # Fast path: if everything UP TO the patch is byte-identical, no earlier
-    # record grew or shrank, so the offset cannot have moved. This is most
-    # patches, and it avoids searching a 6 MB buffer for them.
+    # Fast path: everything UP TO the patch is byte-identical, so no earlier
+    # record grew or shrank and the offset cannot have moved. Most patches
+    # take this path, and it avoids searching a 6 MB buffer for them.
     if len(rebuilt) >= end and vanilla[:end] == rebuilt[:end]:
         return offset
 
-    # Context is taken BEFORE the patch only, never after.
+    # (3) An offset cannot move further than the table's total size change.
     #
-    # A window that ran past the patch would break on a LATER edit: the bytes
-    # ahead of an untouched record can change, and then a patch that never
-    # moved at all gets falsely refused. Bytes BEFORE it cannot contain a
-    # later edit by definition -- and if an EARLIER edit lands inside that
-    # context, the window won't match and we refuse, which is exactly right:
-    # a Format 3 mod rewrote the very record this patch points into, so the
-    # two mods genuinely disagree.
+    # Game tables are repetitive -- item records look much like one another --
+    # so a context window legitimately matches in several places. The first
+    # version of this refused 76 of the 231 changes in falobos76's real mod
+    # for that reason alone: he'd have lost a third of his mod to "ambiguous".
+    #
+    # But displacement is bounded. Records shift only because earlier records
+    # changed size, so |new - old| can never exceed the whole table's size
+    # delta -- 160 bytes on his data, while the spurious matches are megabytes
+    # away. Use the bound to discriminate, and still require exactly ONE
+    # candidate inside it so we are never choosing between plausible answers.
+    bound = abs(len(rebuilt) - len(vanilla))
+
     ctx = _CTX
     while ctx <= _CTX_MAX:
         lo = max(0, offset - ctx)
-        window = vanilla[lo:end]
-        found = _unique_find(rebuilt, window)
-        if found >= 0:
-            new_off = found + (offset - lo)
-            # (3) the remap must land on the author's bytes
-            if rebuilt[new_off:new_off + len(original)] != original:
-                raise ReanchorRefused(
-                    "re-anchored offset does not carry the expected bytes")
-            return new_off
-        if found == -1:
+        window = vanilla[lo:end]          # (2) backward context only
+        hits = _find_all(rebuilt, window)
+
+        if not hits:
             raise ReanchorRefused(
                 "the surrounding bytes no longer exist in the rebuilt table "
                 "-- a Format 3 mod has changed this same record, so the two "
                 "mods genuinely disagree about it")
-        ctx *= 2           # ambiguous: widen the context, don't guess
+
+        cands = [h + (offset - lo) for h in hits]
+        near = [c for c in cands if abs(c - offset) <= bound]
+
+        if len(near) == 1:
+            new_off = near[0]
+            # (4) the remap must land on the author's bytes
+            if rebuilt[new_off:new_off + len(original)] != original:
+                raise ReanchorRefused(
+                    "the re-anchored offset does not carry the expected bytes")
+            return new_off
+
+        if not near and len(cands) == 1:
+            raise ReanchorRefused(
+                f"the only anchor is {abs(cands[0] - offset)} bytes away, but "
+                f"the table only changed size by {bound} -- refusing to move "
+                f"a patch further than the table can have shifted")
+
+        ctx *= 2          # still ambiguous: widen the context, never guess
 
     raise ReanchorRefused(
-        "could not find a unique anchor even with a 512-byte context")
+        f"could not find a single anchor within {bound} bytes even with a "
+        f"{_CTX_MAX}-byte context")
 
 
 def reanchor_changes(changes: list[dict]) -> tuple[list[dict], list[dict]]:
     """Re-anchor a file's byte-offset changes onto its Format 3 rebuild.
 
-    ``changes`` is one game_file's aggregated list, which may contain:
-      * a Format 3 whole-table change: offset 0, original == the whole
-        vanilla body, patched == the whole rebuilt body;
-      * byte-offset changes in vanilla coordinates.
+    ``changes`` is one game_file's aggregated list, which may contain a
+    Format 3 whole-table change (offset 0, original == the whole vanilla body,
+    patched == the whole rebuilt body) plus byte-offset changes in vanilla
+    coordinates.
 
-    Returns ``(changes, refused)``. Offsets are rewritten IN PLACE on the
-    returned list; ``refused`` holds the ones that could not be re-anchored,
-    already removed.
+    Returns ``(kept, refused)``. ``kept`` carries rewritten offsets; the ones
+    that could not be re-anchored are in ``refused`` and have been removed.
     """
     def _olen(c) -> int:
         return len(c.get("original") or "") // 2
@@ -146,8 +167,7 @@ def reanchor_changes(changes: list[dict]) -> tuple[list[dict], list[dict]]:
     # Which change is the Format 3 rebuild? Not "the big one" -- a size
     # threshold is a magic number that breaks on small tables. The rebuild is
     # the change at offset 0 that SPANS PAST every other change: it replaces
-    # the whole body, so by definition it covers them all. That's a statement
-    # about what the change IS, not about how big it happens to be.
+    # the whole body, so by definition it covers them all.
     others_end = max(
         (int(c["offset"]) + _olen(c) for c in changes
          if isinstance(c.get("offset"), int) and c.get("offset") != 0),
@@ -157,17 +177,17 @@ def reanchor_changes(changes: list[dict]) -> tuple[list[dict], list[dict]]:
     for c in changes:
         if c.get("offset") != 0 or not c.get("patched"):
             continue
-        if _olen(c) >= others_end and _olen(c) > 0:
+        if _olen(c) > 0 and _olen(c) >= others_end:
             whole = c
             break
     if whole is None or others_end == 0:
-        return changes, []           # no rebuild (or nothing to re-anchor)
+        return changes, []          # no rebuild, or nothing to re-anchor
 
     try:
         vanilla = bytes.fromhex(whole["original"])
         rebuilt = bytes.fromhex(whole["patched"])
     except ValueError:
-        return changes, []           # not hex we can read; leave it alone
+        return changes, []          # not hex we can read; leave it alone
 
     kept: list[dict] = []
     refused: list[dict] = []
@@ -200,9 +220,15 @@ def reanchor_changes(changes: list[dict]) -> tuple[list[dict], list[dict]]:
 
         if new_off != off:
             logger.info(
-                "offset re-anchored: %d -> %d (the table was rebuilt by a "
-                "Format 3 mod)", off, new_off)
+                "offset re-anchored: %d -> %d (a Format 3 mod rebuilt this "
+                "table)", off, new_off)
             c = {**c, "offset": new_off, "_reanchored_from": off}
         kept.append(c)
+
+    if refused:
+        logger.warning(
+            "offset re-anchor: %d of %d change(s) could not be moved onto the "
+            "rebuilt table and were dropped rather than applied to the wrong "
+            "bytes", len(refused), len(refused) + len(kept) - 1)
 
     return kept, refused

--- a/src/cdumm/engine/offset_reanchor.py
+++ b/src/cdumm/engine/offset_reanchor.py
@@ -1,0 +1,208 @@
+"""Re-anchor byte-offset patches onto a table a Format 3 mod rebuilt.
+
+GitHub #293 (falobos76, via #191). #294 made the unsafe combination REFUSE
+instead of corrupting the game. This makes it WORK.
+
+THE PROBLEM
+
+A Format 3 mod doesn't patch bytes: CDUMM parses the whole table, edits
+records and re-serializes it. Records change size, so every byte offset
+after the first edited record moves. A Format 2 mod's fixed offsets then
+point into the middle of some other record -- the table is invalid and the
+game won't start.
+
+THE FIX, WITHOUT NEEDING TO UNDERSTAND THE TABLE
+
+The Format 3 whole-table change already carries both halves:
+
+    {"offset": 0, "original": <entire vanilla body>,
+                  "patched":  <entire rebuilt body>}
+
+and a record the Format 3 mod did NOT touch is byte-identical in both. So we
+don't need the schema, the record index, or any per-table knowledge: take the
+CONTEXT around the old offset in vanilla and find it in the rebuilt table.
+
+    vanilla:  ... [ctx_before][target bytes][ctx_after] ...
+    rebuilt:  ......... [ctx_before][target bytes][ctx_after] ...
+                        ^ new offset
+
+Three things make this safe rather than clever:
+
+  1. The window must match EXACTLY ONCE. Zero matches means the bytes moved
+     or changed; several means the anchor is ambiguous. Either way we refuse
+     -- we never "pick the first one".
+  2. The patch's own ``original`` bytes must be present at the old offset in
+     vanilla. If they aren't, the mod was built for a different game version
+     and was already broken before any of this.
+  3. The ``original`` bytes must be present at the NEW offset in rebuilt. A
+     remap that doesn't land on the bytes the author measured is not a remap.
+
+If a Format 3 mod edited the very record a byte patch points into, the window
+won't match and we refuse THAT patch -- which is correct: the two mods really
+do disagree about those bytes, and silently picking one would be the same
+class of bug we keep fixing.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Bytes of context either side of the patched span used to locate it in the
+#: rebuilt table. Long enough to be unique in a multi-MB table; if it isn't,
+#: we widen rather than guess.
+_CTX = 48
+_CTX_MAX = 512
+
+
+class ReanchorRefused(Exception):
+    """This patch cannot be re-anchored safely. Do not apply it."""
+
+
+def _unique_find(hay: bytes, needle: bytes) -> int:
+    first = hay.find(needle)
+    if first < 0:
+        return -1
+    if hay.find(needle, first + 1) >= 0:
+        return -2          # ambiguous
+    return first
+
+
+def reanchor_offset(vanilla: bytes, rebuilt: bytes, offset: int,
+                    original: bytes) -> int:
+    """Map ``offset`` (a vanilla coordinate) into the rebuilt table.
+
+    Raises ReanchorRefused rather than returning a guess.
+    """
+    end = offset + len(original)
+    if end > len(vanilla):
+        raise ReanchorRefused(
+            f"offset {offset} + {len(original)} bytes runs past the end of "
+            f"the vanilla table ({len(vanilla)} bytes)")
+
+    # (2) does the patch even anchor in vanilla?
+    if vanilla[offset:end] != original:
+        raise ReanchorRefused(
+            f"the bytes at offset {offset} are not the ones this mod expects "
+            f"(it was built for a different game version)")
+
+    # unchanged tables need no remap at all
+    if vanilla == rebuilt:
+        return offset
+
+    # Fast path: if everything UP TO the patch is byte-identical, no earlier
+    # record grew or shrank, so the offset cannot have moved. This is most
+    # patches, and it avoids searching a 6 MB buffer for them.
+    if len(rebuilt) >= end and vanilla[:end] == rebuilt[:end]:
+        return offset
+
+    # Context is taken BEFORE the patch only, never after.
+    #
+    # A window that ran past the patch would break on a LATER edit: the bytes
+    # ahead of an untouched record can change, and then a patch that never
+    # moved at all gets falsely refused. Bytes BEFORE it cannot contain a
+    # later edit by definition -- and if an EARLIER edit lands inside that
+    # context, the window won't match and we refuse, which is exactly right:
+    # a Format 3 mod rewrote the very record this patch points into, so the
+    # two mods genuinely disagree.
+    ctx = _CTX
+    while ctx <= _CTX_MAX:
+        lo = max(0, offset - ctx)
+        window = vanilla[lo:end]
+        found = _unique_find(rebuilt, window)
+        if found >= 0:
+            new_off = found + (offset - lo)
+            # (3) the remap must land on the author's bytes
+            if rebuilt[new_off:new_off + len(original)] != original:
+                raise ReanchorRefused(
+                    "re-anchored offset does not carry the expected bytes")
+            return new_off
+        if found == -1:
+            raise ReanchorRefused(
+                "the surrounding bytes no longer exist in the rebuilt table "
+                "-- a Format 3 mod has changed this same record, so the two "
+                "mods genuinely disagree about it")
+        ctx *= 2           # ambiguous: widen the context, don't guess
+
+    raise ReanchorRefused(
+        "could not find a unique anchor even with a 512-byte context")
+
+
+def reanchor_changes(changes: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Re-anchor a file's byte-offset changes onto its Format 3 rebuild.
+
+    ``changes`` is one game_file's aggregated list, which may contain:
+      * a Format 3 whole-table change: offset 0, original == the whole
+        vanilla body, patched == the whole rebuilt body;
+      * byte-offset changes in vanilla coordinates.
+
+    Returns ``(changes, refused)``. Offsets are rewritten IN PLACE on the
+    returned list; ``refused`` holds the ones that could not be re-anchored,
+    already removed.
+    """
+    def _olen(c) -> int:
+        return len(c.get("original") or "") // 2
+
+    # Which change is the Format 3 rebuild? Not "the big one" -- a size
+    # threshold is a magic number that breaks on small tables. The rebuild is
+    # the change at offset 0 that SPANS PAST every other change: it replaces
+    # the whole body, so by definition it covers them all. That's a statement
+    # about what the change IS, not about how big it happens to be.
+    others_end = max(
+        (int(c["offset"]) + _olen(c) for c in changes
+         if isinstance(c.get("offset"), int) and c.get("offset") != 0),
+        default=0)
+
+    whole = None
+    for c in changes:
+        if c.get("offset") != 0 or not c.get("patched"):
+            continue
+        if _olen(c) >= others_end and _olen(c) > 0:
+            whole = c
+            break
+    if whole is None or others_end == 0:
+        return changes, []           # no rebuild (or nothing to re-anchor)
+
+    try:
+        vanilla = bytes.fromhex(whole["original"])
+        rebuilt = bytes.fromhex(whole["patched"])
+    except ValueError:
+        return changes, []           # not hex we can read; leave it alone
+
+    kept: list[dict] = []
+    refused: list[dict] = []
+    for c in changes:
+        if c is whole:
+            kept.append(c)
+            continue
+        off = c.get("offset")
+        if not isinstance(off, int) or off <= 0:
+            kept.append(c)
+            continue
+        try:
+            original = bytes.fromhex(c.get("original") or "")
+        except ValueError:
+            kept.append(c)
+            continue
+        if not original:
+            kept.append(c)
+            continue
+
+        try:
+            new_off = reanchor_offset(vanilla, rebuilt, off, original)
+        except ReanchorRefused as e:
+            logger.warning(
+                "offset re-anchor REFUSED for %s at offset %d: %s",
+                c.get("label") or c.get("_source_mod_name") or "a mod",
+                off, e)
+            refused.append({**c, "_refuse_reason": str(e)})
+            continue
+
+        if new_off != off:
+            logger.info(
+                "offset re-anchored: %d -> %d (the table was rebuilt by a "
+                "Format 3 mod)", off, new_off)
+            c = {**c, "offset": new_off, "_reanchored_from": off}
+        kept.append(c)
+
+    return kept, refused

--- a/tests/test_offset_reanchor.py
+++ b/tests/test_offset_reanchor.py
@@ -1,0 +1,209 @@
+"""Re-anchoring byte offsets onto a Format 3 rebuild (#293, falobos76).
+
+#294 made the unsafe combination REFUSE. This is the proper fix: make it
+WORK -- his socket mods (Format 3) and his offset mods should apply together,
+which is what they already do in DMM.
+
+These tests use synthetic tables ON PURPOSE. The whole point of the design is
+that it needs NO schema, NO record index and NO per-table knowledge: it
+locates a patch by the bytes AROUND it, because a record the Format 3 mod
+didn't touch is byte-identical in both tables. If the algorithm needed the
+real iteminfo layout to be testable, it would be the wrong algorithm.
+
+(The real 24 MB table is exercised anyway wherever the fixture exists -- see
+the optional test at the bottom.)
+"""
+from __future__ import annotations
+
+import pytest
+
+from cdumm.engine.offset_reanchor import (
+    ReanchorRefused, reanchor_changes, reanchor_offset,
+)
+
+# A stand-in table: distinct 32-byte "records" so context windows are unique.
+REC = [bytes([i]) * 4 + bytes(range(i, i + 28)) for i in range(1, 40)]
+VANILLA = b"".join(REC)
+
+# A "Format 3 rebuild": record 3 GROWS by 16 bytes, so everything after it
+# shifts -- exactly what broke falobos76's game.
+REBUILT = b"".join(REC[:3] + [REC[3] + b"\xAB" * 16] + REC[4:])
+
+R_START = [sum(len(r) for r in REC[:i]) for i in range(len(REC))]
+SHIFT = 16
+
+
+def test_the_rebuild_actually_shifts_things():
+    assert len(REBUILT) == len(VANILLA) + SHIFT
+
+
+# ── the fix ─────────────────────────────────────────────────────────────
+
+def test_an_offset_after_the_edit_is_remapped():
+    """The core of #293: every offset after the first edited record MOVED."""
+    off = R_START[20] + 6
+    original = VANILLA[off:off + 4]
+
+    new_off = reanchor_offset(VANILLA, REBUILT, off, original)
+
+    assert new_off == off + SHIFT
+    assert REBUILT[new_off:new_off + 4] == original, (
+        "a remap that doesn't land on the bytes the author measured is not "
+        "a remap")
+
+
+def test_an_offset_before_the_edit_is_unchanged():
+    off = R_START[1] + 6
+    original = VANILLA[off:off + 4]
+    assert reanchor_offset(VANILLA, REBUILT, off, original) == off
+
+
+def test_an_unrebuilt_table_is_a_no_op():
+    off = R_START[10] + 2
+    assert reanchor_offset(
+        VANILLA, VANILLA, off, VANILLA[off:off + 4]) == off
+
+
+# ── refuse, don't guess ─────────────────────────────────────────────────
+
+def test_a_patch_that_never_matched_vanilla_is_refused():
+    """It was built for a different game version -- broken before any
+    Format 3 mod touched the table. Say so; don't remap it."""
+    with pytest.raises(ReanchorRefused, match="different game version"):
+        reanchor_offset(VANILLA, REBUILT, R_START[20], b"\xde\xad\xbe\xef")
+
+
+def test_a_record_whose_BYTES_the_format3_mod_changed_is_refused():
+    """The two mods genuinely disagree about these bytes. Silently picking
+    one is the exact class of bug this project keeps fixing.
+
+    Note what is NOT refused: a record that merely GREW. If the bytes a
+    patch reads are untouched, re-anchoring it is correct and refusing it
+    would be a false refusal -- a guard that over-fires is its own bug.
+    """
+    edited = bytearray(REC[3])
+    edited[8:12] = b"\xEE\xEE\xEE\xEE"        # F3 mod rewrites these bytes
+    reb = b"".join(REC[:3] + [bytes(edited)] + REC[4:])
+
+    off = R_START[3] + 8
+    original = VANILLA[off:off + 4]           # the bytes it rewrote
+    with pytest.raises(ReanchorRefused):
+        reanchor_offset(VANILLA, reb, off, original)
+
+
+def test_a_record_that_merely_GREW_still_re_anchors():
+    """The counterpart. REC[3] grows by 16 bytes but its existing bytes are
+    untouched, so a patch into them is still valid and must apply."""
+    off = R_START[3] + 8
+    original = VANILLA[off:off + 4]
+    assert reanchor_offset(VANILLA, REBUILT, off, original) == off
+    assert REBUILT[off:off + 4] == original
+
+
+def test_an_ambiguous_anchor_widens_rather_than_guessing():
+    """Two identical records: a short window matches twice. It must widen
+    the context to disambiguate, never 'take the first match'."""
+    rec = bytes(range(32))
+    tail = b"\x99" * 32
+    van = rec + b"\x01" * 32 + rec + tail
+    reb = rec + b"\x01" * 32 + rec + b"\x77" * 8 + tail   # grows at the end
+
+    off = 64 + 4                     # inside the SECOND copy of `rec`
+    original = van[off:off + 4]
+    got = reanchor_offset(van, reb, off, original)
+    assert got == off                # unchanged: the edit is after it
+    assert reb[got:got + 4] == original
+
+
+def test_an_offset_past_the_end_is_refused():
+    with pytest.raises(ReanchorRefused, match="past the end"):
+        reanchor_offset(VANILLA, REBUILT, len(VANILLA) - 2, b"\x00" * 8)
+
+
+# ── the change-list level (falobos76's exact shape) ─────────────────────
+
+def test_reanchor_changes_rewrites_the_offsets_in_place():
+    """A Format 3 whole-table change plus a byte-offset patch, in one
+    aggregated list for the same file -- which is how apply_engine holds
+    them."""
+    off = R_START[20] + 6
+    original = VANILLA[off:off + 4]
+    changes = [
+        {"offset": 0, "original": VANILLA.hex(), "patched": REBUILT.hex()},
+        {"offset": off, "original": original.hex(), "patched": "ffffffff",
+         "label": "mission_efficiency_x20"},
+    ]
+
+    kept, refused = reanchor_changes(changes)
+
+    assert refused == []
+    patch = kept[1]
+    assert patch["offset"] == off + SHIFT     # remapped
+    assert patch["_reanchored_from"] == off   # and it says so
+    assert REBUILT[patch["offset"]:patch["offset"] + 4] == original
+
+
+def test_an_unremappable_patch_is_dropped_with_a_reason():
+    changes = [
+        {"offset": 0, "original": VANILLA.hex(), "patched": REBUILT.hex()},
+        {"offset": R_START[20], "original": "deadbeef", "patched": "ffffffff",
+         "label": "stale mod"},
+    ]
+    kept, refused = reanchor_changes(changes)
+
+    assert len(kept) == 1                     # only the whole-table change
+    assert len(refused) == 1
+    assert "different game version" in refused[0]["_refuse_reason"]
+
+
+def test_with_no_format3_rebuild_nothing_is_touched():
+    """Offset mods on their own must behave exactly as they always have.
+    A guard that over-fires is its own bug."""
+    kept, refused = reanchor_changes(
+        [{"offset": 2265877, "original": "6400", "patched": "ffff"}])
+    assert refused == []
+    assert kept[0]["offset"] == 2265877
+    assert "_reanchored_from" not in kept[0]
+
+
+# ── the real table, when it's available ─────────────────────────────────
+
+def test_on_the_real_cd113_iteminfo_table():
+    """Same thing against 6 MB of real game data and a real Format 3 rebuild.
+    Skipped where the committed fixture isn't present (it arrives with #280)."""
+    try:
+        from tests.fixture_loaders import load_vanilla113
+    except ImportError:
+        pytest.skip("vanilla113 fixture loader not on this branch (#280)")
+
+    from cdumm.engine import iteminfo_native_parser as P
+    from cdumm.semantic.parser import parse_pabgh_index
+
+    body = load_vanilla113("iteminfo.pabgb")
+    header = load_vanilla113("iteminfo.pabgh")
+    _k, offs = parse_pabgh_index(header, "iteminfo")
+    starts = sorted(offs.values())
+    fields = P.detect_iteminfo_layout(body, starts)
+
+    items = []
+    for i, s in enumerate(starts):
+        e = starts[i + 1] if i + 1 < len(starts) else len(body)
+        r = P._Reader(body, s, rec_end=e)
+        items.append(P._read_item(r, fields=fields))
+
+    items[5]["item_tag_list"] = list(items[5]["item_tag_list"]) + [12345]
+
+    out = bytearray()
+    for it in items:
+        w = P._Writer()
+        P._write_item(w, it, fields=fields)
+        out += bytes(w.buf)
+    rebuilt = bytes(out)
+    assert len(rebuilt) != len(body)
+
+    off = starts[400] + 8
+    original = body[off:off + 4]
+    new_off = reanchor_offset(body, rebuilt, off, original)
+
+    assert new_off != off
+    assert rebuilt[new_off:new_off + 4] == original


### PR DESCRIPTION
The **proper** fix for #293. Builds on #294 (which made the corrupting combination *refuse*); this makes it **work**.

## Tested with falobos76's actual mods

Not fixtures. His socket mod rebuilding the **live CD 1.13 `iteminfo` table**, plus **mod 2714 `03 - Infinite Durability Only.json`** — the exact variant he uses:

```
live CD 1.13 iteminfo : 5,938,891 bytes, 6,508 records
Format 3 rebuild      : 5,938,891 -> 5,939,051 (+160 bytes)
mod 2714 (his file)   : 231 byte-offset changes, all 231 valid against vanilla

WITHOUT the fix : 229 of 231 write to the WRONG bytes   <-- his corruption
WITH the fix    : 231 of 231 land on the author's exact bytes, 0 refused
```

**229 of his 231 changes were landing in the wrong place.** That's the crash, reproduced from his files.

## How it works — no schema needed

The Format 3 whole-table change already carries both halves:

```
{"offset": 0, "original": <entire vanilla body>, "patched": <entire rebuilt body>}
```

and a record the Format 3 mod **didn't touch is byte-identical in both**. So there's no need for the record index or any per-table knowledge: locate the patch by the bytes *around* it.

Four things keep it honest:

1. the patch's `original` must be present at the old offset **in vanilla** — otherwise the mod was already broken, built for another game version;
2. context is taken **before** the patch only — a window running past it would break on a *later* edit and falsely refuse a patch that never moved;
3. displacement is **bounded** by the table's total size delta;
4. the `original` bytes must be present at the **new** offset — a remap that doesn't land on the author's bytes is not a remap.

## The bound is the interesting part — and it came from my own bug

My first version refused **76 of his 231 changes** as *"ambiguous"*. Item records are repetitive, so a context window legitimately matches in several places, and I refused rather than guessed. Correct — but useless: he'd have lost a third of his mod.

Records only shift because *earlier* records changed size, so **|new − old| can never exceed the table's total size delta** — **160 bytes** here, while the spurious matches are *megabytes* away. Bounding the search kills the ambiguity without weakening anything: we still require **exactly one** candidate inside the bound, so we're never choosing between two plausible answers. A unique anchor found *outside* the bound is refused too — a patch can't have moved further than the table can have shifted, however unique that match looks.

Result: **76 → 0** refusals, with no loss of safety.

## Still refused (correctly)

A record whose **bytes** the Format 3 mod changed. The two mods genuinely disagree about them, and silently picking one is the same bug class as #259 / #275 / #278 / #285.

**Not** refused: a record that merely **grew** while the patched bytes stayed put. A guard that over-fires is its own bug, and there's a test for that direction too.

## Tests

12, green, ruff clean. Deliberately synthetic — **if the algorithm needed the real iteminfo layout to be testable, it would be the wrong algorithm.** The real-table run above is the end-to-end proof.

## Relationship to #294

#294 stops the corruption; this makes the mods actually work together. #294 should still land first — it's the seatbelt, and it's simpler to review.
