### PR TITLE
fix(conflicts): the same table is not the same edit — stop flagging mods that work together (#292)

### DIFF
--- a/src/cdumm/engine/conflict_detector.py
+++ b/src/cdumm/engine/conflict_detector.py
@@ -13,6 +13,12 @@ from cdumm.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
+#: Format 3 ops that name the record they edit, so we can say up front
+#: which items a mod touches. `match` selects by predicate; clone_record /
+#: new_record / delete_record add or remove records. For those, the record
+#: set isn't knowable without the game files — so we don't claim to know.
+_KEYED_OPS = frozenset({"set", "array_append"})
+
 
 @dataclass
 class Conflict:
@@ -32,70 +38,123 @@ class Conflict:
 class ConflictDetector:
     def __init__(self, db: Database) -> None:
         self._db = db
+        #: json_source -> {target: {(key, field)}}. Detection is O(mods^2),
+        #: so each mod's Format 3 file is parsed once, not once per pair.
+        self._f3_cache: dict[str, dict] = {}
+
+    def _format3_touches(self, json_source: str | None) -> dict | None:
+        """What a Format 3 mod actually edits: target -> {(key, field)}.
+
+        GitHub #292 (falobos76, via #191). Two mods that both edit
+        iteminfo.pabgb were declared to conflict UNCONDITIONALLY, even
+        when one sets sockets on helmets and the other sets them on
+        gloves. All of pinapana's socket mods really do apply together in
+        game -- CDUMM just told the user they didn't, which pushes people
+        to disable mods that were working. The worst kind of false
+        positive.
+
+        Format 3 mods carry per-record, per-field intents and apply_engine
+        merges them, so CDUMM already KNOWS what each mod touches. The
+        detector just wasn't looking: a Format 3 mod stores no delta and
+        no byte ranges (its mod_deltas row is a stub whose byte_start/end
+        are the PAZ ENTRY's, identical for every mod targeting that
+        table), so file/entry granularity is all it had.
+
+        Returns None when the intents can't be read -- the caller then
+        keeps the old conservative "same entry = conflict" verdict rather
+        than inventing a compatible one.
+        """
+        if not json_source:
+            return None
+        cached = self._f3_cache.get(json_source)
+        if cached is not None:
+            return cached or None
+        from pathlib import Path
+        try:
+            from cdumm.engine.format3_handler import parse_format3_mod_targets
+            pairs = parse_format3_mod_targets(Path(json_source))
+        except Exception:
+            self._f3_cache[json_source] = {}
+            return None
+
+        touches: dict[str, set] = {}
+        for target, intents in pairs:
+            for intent in intents:
+                # Which records an intent hits is only knowable up front for
+                # ops that name their record. A `match` intent selects by a
+                # predicate and parses with **key=0** — not None — so a naive
+                # guard reads it as "edits item 0" and cheerfully declares it
+                # compatible with everything. Gate on the OP, not the key.
+                if intent.op not in _KEYED_OPS:
+                    touches[target] = None
+                    break
+                if touches.get(target, set()) is None:
+                    continue
+                touches.setdefault(target, set()).add(
+                    (intent.key, intent.field))
+        self._f3_cache[json_source] = touches
+        return touches
+
+    @staticmethod
+    def _entry_matches(target: str, entry_path: str) -> bool:
+        """A Format 3 target is a bare name (iteminfo.pabgb); an entry_path
+        may be the full game path. Compare on the basename -- the same trap
+        that made `match` select zero records (#275) and array_append a
+        no-op (#278)."""
+        t = (target or "").lower().replace("\\", "/").rsplit("/", 1)[-1]
+        e = (entry_path or "").lower().replace("\\", "/").rsplit("/", 1)[-1]
+        return bool(t) and t == e
 
     def _semantic_conflict_info(
         self, entry_path: str,
         mod_a_name: str, mod_b_name: str,
         a_deltas: list[dict], b_deltas: list[dict],
-    ) -> str | None:
-        """Try to get field-level conflict info using the semantic system.
+    ) -> tuple[str, bool] | None:
+        """Compare two mods on this entry at RECORD + FIELD level.
 
-        Returns a human-readable explanation string, or None if semantic
-        analysis is unavailable for this entry.
+        Returns ``(explanation, is_conflict)``, or None when either mod's
+        intents can't be read (caller keeps the conservative verdict).
         """
-        try:
-            from cdumm.semantic.parser import identify_table_from_path
-            table_name = identify_table_from_path(entry_path)
-            if not table_name:
-                return None
-
-            # Check if delta metadata has semantic_fields_changed
-            a_fields = set()
-            b_fields = set()
-            for d in a_deltas:
-                if d.get("entry_path") == entry_path:
-                    # Try to read from stored metadata
-                    try:
-                        from cdumm.engine.delta_engine import load_entry_delta
-                        from pathlib import Path
-                        _, meta = load_entry_delta(Path(d["delta_path"]))
-                        fields = meta.get("semantic_fields_changed", [])
-                        a_fields.update(fields)
-                    except Exception:
-                        pass
-            for d in b_deltas:
-                if d.get("entry_path") == entry_path:
-                    try:
-                        from cdumm.engine.delta_engine import load_entry_delta
-                        from pathlib import Path
-                        _, meta = load_entry_delta(Path(d["delta_path"]))
-                        fields = meta.get("semantic_fields_changed", [])
-                        b_fields.update(fields)
-                    except Exception:
-                        pass
-
-            if not a_fields and not b_fields:
-                return None
-
-            shared = a_fields & b_fields
-            only_a = a_fields - b_fields
-            only_b = b_fields - a_fields
-
-            parts = []
-            if shared:
-                parts.append(f"Both modify: {', '.join(sorted(shared))}")
-            if only_a:
-                parts.append(f"{mod_a_name} only: {', '.join(sorted(only_a))}")
-            if only_b:
-                parts.append(f"{mod_b_name} only: {', '.join(sorted(only_b))}")
-
-            if shared:
-                return f"{entry_path} — CONFLICT on {', '.join(sorted(shared))}. " + ". ".join(parts)
-            else:
-                return f"{entry_path} — Compatible (different fields). " + ". ".join(parts)
-
-        except Exception:
+        a_src = a_deltas[0].get("json_source") if a_deltas else None
+        b_src = b_deltas[0].get("json_source") if b_deltas else None
+        a_all = self._format3_touches(a_src)
+        b_all = self._format3_touches(b_src)
+        if not a_all or not b_all:
             return None
+
+        def _for(all_touches):
+            for target, keys in all_touches.items():
+                if self._entry_matches(target, entry_path):
+                    return keys
+            return None
+
+        a = _for(a_all)
+        b = _for(b_all)
+        if a is None or b is None:
+            # one of them uses `match` on this table (or doesn't target it
+            # at all) -- we can't say, so we don't.
+            return None
+
+        shared = a & b
+        if shared:
+            fields = sorted({f for _, f in shared})
+            records = len({k for k, _ in shared})
+            return (
+                f"{mod_a_name} and {mod_b_name} both change "
+                f"{', '.join(fields)} on {records} of the same "
+                f"item(s) in {entry_path}.", True)
+
+        a_recs = {k for k, _ in a}
+        b_recs = {k for k, _ in b}
+        if a_recs & b_recs:
+            why = (f"the same {len(a_recs & b_recs)} item(s), but "
+                   f"different fields")
+        else:
+            why = "different items"
+        return (
+            f"{mod_a_name} ({len(a_recs)} item(s)) and {mod_b_name} "
+            f"({len(b_recs)} item(s)) both edit {entry_path}, but "
+            f"{why}. Both apply — compatible.", False)
 
     def detect_all(self) -> list[Conflict]:
         """Run full conflict detection across all enabled mods.
@@ -149,15 +208,20 @@ class ConflictDetector:
 
     def _get_enabled_mods(self) -> dict[int, list[dict]]:
         """Get all enabled PAZ mods with their delta byte ranges and priority."""
+        # json_source is where a Format 3 mod's intents actually live. It
+        # was never selected, so the detector had no way to see WHAT a mod
+        # edits -- only which file (#292).
         cursor = self._db.connection.execute(
             "SELECT m.id, m.name, m.priority, md.file_path, md.byte_start, md.byte_end, "
-            "md.entry_path, md.delta_path, m.conflict_mode "
+            "md.entry_path, md.delta_path, m.conflict_mode, m.json_source "
             "FROM mods m JOIN mod_deltas md ON m.id = md.mod_id "
             "WHERE m.enabled = 1 AND m.mod_type = 'paz' "
             "ORDER BY m.priority"
         )
         mods: dict[int, list[dict]] = {}
-        for mod_id, mod_name, priority, file_path, byte_start, byte_end, entry_path, delta_path, conflict_mode in cursor.fetchall():
+        for (mod_id, mod_name, priority, file_path, byte_start, byte_end,
+             entry_path, delta_path, conflict_mode,
+             json_source) in cursor.fetchall():
             if mod_id not in mods:
                 mods[mod_id] = []
             mods[mod_id].append({
@@ -169,6 +233,7 @@ class ConflictDetector:
                 "entry_path": entry_path,
                 "delta_path": delta_path,
                 "conflict_mode": conflict_mode or "normal",
+                "json_source": json_source,
             })
         return mods
 
@@ -253,13 +318,32 @@ class ConflictDetector:
                 shared_entries = a_entries & b_entries
                 if shared_entries:
                     for entry_path in sorted(shared_entries):
-                        # Try semantic analysis for richer conflict info
-                        sem_explanation = self._semantic_conflict_info(
+                        # Same table is NOT the same edit. Compare on
+                        # (record, field) when both mods carry intents
+                        # (#292) — two socket mods on different items
+                        # compose, and saying otherwise makes people
+                        # disable mods that were working.
+                        sem = self._semantic_conflict_info(
                             entry_path, mod_a_name, mod_b_name,
                             a_deltas, b_deltas)
-                        if sem_explanation:
+                        if sem is not None:
+                            explanation, is_conflict = sem
+                            if not is_conflict:
+                                # Compatible: report it, but with no winner
+                                # and no "conflict" level, so the mod's
+                                # status stays clean.
+                                conflicts.append(Conflict(
+                                    mod_a_id=mod_a_id, mod_a_name=mod_a_name,
+                                    mod_b_id=mod_b_id, mod_b_name=mod_b_name,
+                                    file_path=file_path,
+                                    level="paz",
+                                    byte_start=None, byte_end=None,
+                                    explanation=explanation,
+                                ))
+                                continue
                             level = "semantic"
-                            explanation = sem_explanation
+                            explanation = (
+                                f"{explanation} Winner: {_winner_reason}.")
                         else:
                             level = "byte_range"
                             explanation = (
@@ -405,13 +489,17 @@ class ConflictDetector:
         levels = {row[0] for row in rows}
         winners = {row[1] for row in rows if row[1] is not None}
 
-        if "byte_range" in levels:
-            # All byte_range conflicts have a winner via load order
+        # 'semantic' means two mods really do fight over the same field on
+        # the same record. It was never emitted before (#292: the code that
+        # produced it read a metadata key nothing writes), so neither status
+        # function handled it -- a real conflict would have reported CLEAN.
+        if levels & {"byte_range", "semantic"}:
+            # All of these have a winner via load order
             if winners:
                 return "resolved"
             return "conflict"
         if "paz" in levels:
-            return "clean"  # same file, different byte ranges = compatible
+            return "clean"  # same file, different records/bytes = compatible
         if "papgt" in levels:
             return "clean"  # PAPGT is auto-handled
         return "clean"
@@ -430,7 +518,7 @@ class ConflictDetector:
 
         statuses: dict[int, str] = {}
         for mid, levels in mod_levels.items():
-            if "byte_range" in levels:
+            if levels & {"byte_range", "semantic"}:
                 statuses[mid] = "resolved" if mod_has_winner.get(mid) else "conflict"
             else:
                 statuses[mid] = "clean"

--- a/tests/test_conflict_detector_record_level.py
+++ b/tests/test_conflict_detector_record_level.py
@@ -1,0 +1,208 @@
+"""Two mods editing the same TABLE are not two mods editing the same THING.
+
+GitHub #292 (falobos76, via #191): every one of pinapana's socket mods was
+listed as conflicting with every other, so only the top one "won" — while
+in game all of them applied perfectly, to different items. The apply path
+was right; the report was wrong, and it pushes people to disable mods that
+were working.
+
+The detector compared at file/entry granularity. It needs record + field.
+"""
+import json
+
+import pytest
+
+from cdumm.engine.conflict_detector import ConflictDetector
+from cdumm.storage.database import Database
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = Database(tmp_path / "cdumm.db")
+    d.initialize()
+    yield d
+    d.close()
+
+
+def _f3(tmp_path, name, intents, target="iteminfo.pabgb"):
+    p = tmp_path / f"{name}.field.json"
+    p.write_text(json.dumps({
+        "format": 3, "target": target,
+        "modinfo": {"title": name},
+        "intents": [
+            {"entry": "", "key": k, "field": f, "op": "set", "new": v}
+            for k, f, v in intents
+        ],
+    }), encoding="utf-8")
+    return p
+
+
+def _add_mod(db, name, json_source, priority, entry="iteminfo.pabgb"):
+    cur = db.connection.execute(
+        "INSERT INTO mods (name, mod_type, enabled, priority, json_source) "
+        "VALUES (?, 'paz', 1, ?, ?)", (name, priority, str(json_source)))
+    mod_id = cur.lastrowid
+    db.connection.execute(
+        "INSERT INTO mod_deltas (mod_id, file_path, delta_path, byte_start, "
+        "byte_end, entry_path) VALUES (?, '0008/0.paz', '', 100, 200, ?)",
+        (mod_id, entry))
+    db.connection.commit()
+    return mod_id
+
+
+def test_different_items_same_table_is_not_a_conflict(db, tmp_path):
+    """The reported bug. Sockets on helmets + sockets on gloves = fine."""
+    a = _add_mod(db, "Armor Five Sockets",
+                 _f3(tmp_path, "a", [(1001, "use_socket", 1),
+                                     (1002, "use_socket", 1)]), 1)
+    b = _add_mod(db, "Weapon Five Sockets",
+                 _f3(tmp_path, "b", [(2001, "use_socket", 1),
+                                     (2002, "use_socket", 1)]), 2)
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    c = conflicts[0]
+    assert c.level == "paz", "different items must not be a conflict"
+    assert c.winner_id is None, "a compatible pair has no loser"
+    assert "different items" in c.explanation
+    assert "compatible" in c.explanation.lower()
+
+    statuses = ConflictDetector(db).get_all_mod_statuses()
+    assert statuses[a] == "clean"
+    assert statuses[b] == "clean"
+
+
+def test_same_item_different_fields_is_not_a_conflict(db, tmp_path):
+    """pinapana ships 'All EQ Dyeable' explicitly to be used WITH a socket
+    mod. Same items, different fields — apply merges them per field."""
+    _add_mod(db, "5 Socket",
+             _f3(tmp_path, "a", [(1001, "use_socket", 1)]), 1)
+    _add_mod(db, "All EQ Dyeable",
+             _f3(tmp_path, "b", [(1001, "is_dyeable", 1)]), 2)
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    assert conflicts[0].level == "paz"
+    assert conflicts[0].winner_id is None
+    assert "different fields" in conflicts[0].explanation
+
+
+def test_same_item_same_field_IS_a_conflict(db, tmp_path):
+    """The guard must still fire. Two mods setting the same field on the
+    same item genuinely disagree, and one of them will lose."""
+    a = _add_mod(db, "Two Sockets",
+                 _f3(tmp_path, "a", [(1001, "socket_count", 2)]), 1)
+    b = _add_mod(db, "Five Sockets",
+                 _f3(tmp_path, "b", [(1001, "socket_count", 5)]), 2)
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    c = conflicts[0]
+    assert c.level == "semantic"
+    assert c.winner_id == a, "lower priority number wins (applied last)"
+    assert "socket_count" in c.explanation
+    assert "1 of the same item" in c.explanation
+
+    statuses = ConflictDetector(db).get_all_mod_statuses()
+    assert statuses[a] == "resolved"
+    assert statuses[b] == "resolved"
+
+
+def test_a_real_conflict_is_never_reported_as_clean(db, tmp_path):
+    """The 'semantic' level existed but was never emitted (its input was a
+    metadata key nothing in the codebase writes), so neither status
+    function handled it. Making it fire without this would have turned a
+    real conflict into a CLEAN badge."""
+    a = _add_mod(db, "A", _f3(tmp_path, "a", [(1, "price", 10)]), 1)
+    b = _add_mod(db, "B", _f3(tmp_path, "b", [(1, "price", 20)]), 2)
+
+    det = ConflictDetector(db)
+    det.detect_all()
+
+    assert det.get_mod_status(a) != "clean"
+    assert det.get_mod_status(b) != "clean"
+
+
+def test_partial_overlap_reports_only_the_shared_records(db, tmp_path):
+    a = _add_mod(db, "A", _f3(tmp_path, "a", [(1, "price", 10),
+                                              (2, "price", 10),
+                                              (3, "price", 10)]), 1)
+    _add_mod(db, "B", _f3(tmp_path, "b", [(3, "price", 20),
+                                          (4, "price", 20)]), 2)
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    assert conflicts[0].level == "semantic"
+    assert "1 of the same item" in conflicts[0].explanation
+    assert conflicts[0].winner_id == a
+
+
+def test_a_match_mod_falls_back_instead_of_guessing(db, tmp_path):
+    """`match` selects records by a predicate, so which items it hits isn't
+    knowable without the game files. Don't claim compatibility we can't
+    prove — keep the conservative verdict."""
+    p = tmp_path / "m.field.json"
+    p.write_text(json.dumps({
+        "format": 3, "target": "iteminfo.pabgb",
+        "modinfo": {"title": "m"},
+        "intents": [{"entry": "", "field": "price", "op": "match",
+                     "match": {"item_tier": 5}, "new": 1}],
+    }), encoding="utf-8")
+    _add_mod(db, "Match Mod", p, 1)
+    _add_mod(db, "Plain Mod",
+             _f3(tmp_path, "b", [(9999, "price", 20)]), 2)
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    assert conflicts[0].level == "byte_range", (
+        "unknown records must NOT be reported as compatible")
+    assert conflicts[0].winner_id is not None
+
+
+def test_a_mod_with_no_intents_file_keeps_the_old_verdict(db, tmp_path):
+    """Non-Format-3 mods have no json_source. Nothing to compare, so the
+    conservative behaviour must survive untouched."""
+    cur = db.connection.execute(
+        "INSERT INTO mods (name, mod_type, enabled, priority) "
+        "VALUES ('Old A', 'paz', 1, 1)")
+    a = cur.lastrowid
+    cur = db.connection.execute(
+        "INSERT INTO mods (name, mod_type, enabled, priority) "
+        "VALUES ('Old B', 'paz', 1, 2)")
+    b = cur.lastrowid
+    for mid in (a, b):
+        db.connection.execute(
+            "INSERT INTO mod_deltas (mod_id, file_path, delta_path, "
+            "byte_start, byte_end, entry_path) "
+            "VALUES (?, '0008/0.paz', '', 100, 200, 'iteminfo.pabgb')",
+            (mid,))
+    db.connection.commit()
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    assert conflicts[0].level == "byte_range"
+    assert conflicts[0].winner_id is not None
+
+
+def test_the_target_may_be_a_path_or_a_bare_name(db, tmp_path):
+    """Format 3 ships `iteminfo.pabgb`; an entry_path can be
+    `gamedata/iteminfo.pabgb`. Comparing them raw never matches — the same
+    trap that made `match` select 0 records (#275) and array_append a no-op
+    (#278)."""
+    _add_mod(db, "A", _f3(tmp_path, "a", [(1, "price", 10)]), 1,
+             entry="gamedata/iteminfo.pabgb")
+    _add_mod(db, "B", _f3(tmp_path, "b", [(2, "price", 20)]), 2,
+             entry="gamedata/iteminfo.pabgb")
+
+    conflicts = ConflictDetector(db).detect_all()
+
+    assert len(conflicts) == 1
+    assert conflicts[0].level == "paz", (
+        "the path/bare-name mismatch must not defeat the comparison")
+    assert conflicts[0].winner_id is None


### PR DESCRIPTION
Closes #292. Reported by **falobos76** on #191:

> the conflict list lists ALL of them as conflicting, thus only the first one in activation order (the highest one) wins ... I checked in-game, but it seems that all of them apply their modifications to the various items

He's right — and he spotted the important half: **the apply is correct, the report is wrong.** All of pinapana's socket mods really do apply together in game. CDUMM just told him they didn't.

That's the worst kind of false positive: it pushes people to disable mods that were working.

## Root cause — deeper than the issue said

I filed #292 saying the granularity was file/entry and needed to be record+field. Reading the code, it's worse:

**A Format 3 mod stores no delta and no byte ranges.** Its `mod_deltas` row is a stub whose `byte_start` / `byte_end` are the **PAZ entry's** — identical for every mod targeting that table. So the detector had nothing to compare *but* the filename, and two mods on `iteminfo.pabgb` were **always** declared to conflict, with a winner.

And `_semantic_conflict_info` — the function meant to give the richer field-level verdict — reads a delta metadata key, `semantic_fields_changed`, that **nothing in this codebase has ever written**. It always returned `None`. The "semantic" verdict has never once fired since the day it was added.

The intents were there the whole time, in `mods.json_source`. The detector just wasn't looking.

## The fix

Compare on `(target, record key, field)`:

| | verdict |
|---|---|
| different items | **compatible** — no winner, status stays clean |
| same items, different fields | **compatible** — apply merges per field (pinapana ships *All EQ Dyeable* explicitly to be used *with* a socket mod) |
| same item, **same field** | **real conflict** — named, and resolved by load order |

## Two more bugs this shook out

Both would have made the fix worse than the bug:

1. **The `semantic` level was handled by neither status function.** `get_mod_status` and `get_all_mod_statuses` check for `byte_range` and `paz`; anything else falls through to `clean`. Since `semantic` was dead code it never mattered — but *emitting* it without fixing this would have reported a genuine field-level conflict as **CLEAN**. One false verdict traded for another.

2. **A `match` intent parses with `key=0`, not `None`.**
   ```
   Format3Intent(entry='', key=0, field='price', op='match', new=1, old=None)
   ```
   My first guard keyed "records we can't know" off `key is None` — so a `match` mod would be read as *"edits item 0"* and cheerfully declared compatible with everything. Caught by the test that exists precisely to pin that fallback. Now gated on the **op**, not the key.

## What still gets the conservative verdict

`match`, `clone_record`, `new_record`, `delete_record` — the record set isn't knowable without the game files — and any non-Format-3 mod, which has no intents to read. Those keep the old behaviour exactly.

**We narrow the warning only where we can prove it. We never invent a compatibility we can't demonstrate** — that's the same discipline as #294/#296, and the reason this project's warnings are worth reading at all.

## Tests

8, pinning the refusals as hard as the compatibility: a real same-field conflict must still fire, must never read as clean, and an unknowable `match` mod must fall back rather than be waved through. Plus the path-vs-bare-name trap (`gamedata/iteminfo.pabgb` vs `iteminfo.pabgb`) that already caused #275 and #278.

Existing conflict tests: 31 passed, no regressions.
