### PR TITLE
fix(macOS): restore hidden window from Dock and menu bar

### DIFF
--- a/src/cdumm/gui/app_icon.py
+++ b/src/cdumm/gui/app_icon.py
@@ -45,3 +45,21 @@ def application_icon() -> QIcon:
     """Load the platform application icon, or return a null icon."""
     path = application_icon_path()
     return QIcon(str(path)) if path is not None else QIcon()
+
+
+def apply_application_icon(target) -> bool:
+    """Set a Qt application/window icon without overriding the macOS Dock.
+
+    A bundled macOS app gets its Dock icon from ``CFBundleIconFile``. Calling
+    ``setWindowIcon`` with the raw PNG replaces that native icon at runtime
+    and makes it render noticeably larger than neighboring Dock icons. The
+    PNG remains available through :func:`application_icon` for the separate
+    menu-bar status item.
+    """
+    if IS_MACOS:
+        return False
+    icon = application_icon()
+    if icon.isNull():
+        return False
+    target.setWindowIcon(icon)
+    return True

--- a/src/cdumm/gui/app_icon.py
+++ b/src/cdumm/gui/app_icon.py
@@ -1,0 +1,47 @@
+"""Resolve the runtime application icon consistently across platforms."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PySide6.QtGui import QIcon
+
+from cdumm.platform import IS_LINUX, IS_MACOS
+
+
+def application_icon_path() -> Path | None:
+    """Return the first icon asset that exists for the current platform.
+
+    The macOS bundle deliberately does not ship the Windows ``cdumm.ico``.
+    Its PNG logo is included as a normal PyInstaller data file, making it
+    suitable for both ``QApplication`` and ``QSystemTrayIcon``.
+    """
+    if getattr(sys, "frozen", False):
+        root = Path(sys._MEIPASS)
+    else:
+        root = Path(__file__).resolve().parents[3]
+
+    if IS_MACOS:
+        candidates = (
+            root / "assets" / "cdumm-logo.png",
+            root / "cdumm.icns",
+        )
+    elif IS_LINUX:
+        candidates = (
+            root / "assets" / "cdumm-icon-square.png",
+            root / "assets" / "cdumm-logo.png",
+            root / "cdumm.ico",
+        )
+    else:
+        candidates = (
+            root / "cdumm.ico",
+            root / "assets" / "cdumm-logo.png",
+        )
+
+    return next((candidate for candidate in candidates if candidate.exists()), None)
+
+
+def application_icon() -> QIcon:
+    """Load the platform application icon, or return a null icon."""
+    path = application_icon_path()
+    return QIcon(str(path)) if path is not None else QIcon()

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -14,8 +14,8 @@ from cdumm.platform import (
 )
 
 from PySide6.QtCore import Property, QEasingCurve, QObject, QPropertyAnimation, Qt, QThread, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QIcon, QPainter, QPixmap
-from PySide6.QtWidgets import QMenu, QSystemTrayIcon, QVBoxLayout, QWidget
+from PySide6.QtGui import QAction, QPainter, QPixmap
+from PySide6.QtWidgets import QApplication, QMenu, QSystemTrayIcon, QVBoxLayout, QWidget
 
 from qfluentwidgets import (
     FluentWindow,
@@ -939,13 +939,12 @@ class CdummWindow(FluentWindow):
         self.titleBar.titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.titleBar.titleLabel.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
 
-        # Still set taskbar icon
-        if getattr(sys, "frozen", False):
-            icon_path = Path(sys._MEIPASS) / "cdumm.ico"
-        else:
-            icon_path = Path(__file__).resolve().parents[3] / "cdumm.ico"
-        if icon_path.exists():
-            self.setWindowIcon(QIcon(str(icon_path)))
+        # Reuse the application icon for this window and the menu-bar status
+        # item. On macOS the frozen bundle ships a PNG/.icns, not cdumm.ico.
+        from cdumm.gui.app_icon import application_icon
+        icon = application_icon()
+        if not icon.isNull():
+            self.setWindowIcon(icon)
 
         # ── Window-scoped drag-drop ──────────────────────────────────
         self.setAcceptDrops(True)
@@ -1097,6 +1096,13 @@ class CdummWindow(FluentWindow):
         # game session without relaunching the exe.
         self._tray_icon: QSystemTrayIcon | None = None
         self._setup_tray_icon()
+        # macOS does not automatically re-show a QWidget hidden with hide()
+        # when the user clicks the Dock icon. Restore it whenever the app is
+        # activated with no visible main window (or a minimized one).
+        app = QApplication.instance()
+        if IS_MACOS and app is not None:
+            app.applicationStateChanged.connect(
+                self._on_application_state_changed)
 
         # ── Deferred startup (after window is visible) ────────────────
         QTimer.singleShot(500, self._deferred_startup)
@@ -6533,8 +6539,17 @@ class CdummWindow(FluentWindow):
             logger.info("System tray not available, hide-on-launch will "
                         "fall back to minimize")
             return
+        icon = self.windowIcon()
+        if icon.isNull():
+            app = QApplication.instance()
+            if app is not None:
+                icon = app.windowIcon()
+        if icon.isNull():
+            logger.warning("System tray icon is null, hide-on-launch will "
+                           "fall back to minimize")
+            return
         tray = QSystemTrayIcon(self)
-        tray.setIcon(self.windowIcon())
+        tray.setIcon(icon)
         tray.setToolTip(tr("app.name_short") + " v" + __version__)
         menu = QMenu(self)
         show_action = QAction(tr("tray.show"), self)
@@ -6549,7 +6564,17 @@ class CdummWindow(FluentWindow):
         self._tray_icon = tray
 
     def _on_tray_activated(self, reason) -> None:
-        if reason == QSystemTrayIcon.ActivationReason.DoubleClick:
+        if reason in (
+            QSystemTrayIcon.ActivationReason.Trigger,
+            QSystemTrayIcon.ActivationReason.DoubleClick,
+        ):
+            self._restore_from_tray()
+
+    def _on_application_state_changed(self, state) -> None:
+        """Restore a hidden/minimized window when macOS activates CDUMM."""
+        if not IS_MACOS or state != Qt.ApplicationState.ApplicationActive:
+            return
+        if not self.isVisible() or self.isMinimized():
             self._restore_from_tray()
 
     def _restore_from_tray(self) -> None:
@@ -6587,6 +6612,11 @@ class CdummWindow(FluentWindow):
             self.showMinimized()
             return
         self._tray_icon.show()
+        if not self._tray_icon.isVisible():
+            logger.warning("System tray icon failed to become visible; "
+                           "minimizing instead of hiding")
+            self.showMinimized()
+            return
         try:
             self._tray_icon.showMessage(
                 tr("app.name_short"),

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -6594,6 +6594,13 @@ class CdummWindow(FluentWindow):
     def _quit_from_tray(self) -> None:
         if self._tray_icon is not None:
             self._tray_icon.hide()
+        # On macOS, make the primary window visible before closing it so
+        # quitOnLastWindowClosed can end the event loop naturally. Calling
+        # QApplication.quit() from closeEvent while NSApplication is already
+        # handling a native Quit event recursively terminates Qt/Python and
+        # can crash in Shiboken::Object::recursive_invalidate.
+        if IS_MACOS and not self.isVisible():
+            self.show()
         self.close()
 
     def _hide_for_game_launch(self) -> None:
@@ -8265,8 +8272,14 @@ class CdummWindow(FluentWindow):
         # lingers in the background holding .gui_lock and the next
         # launch refuses with "another_running". Force the event
         # loop to exit so atexit releases the lock file handle.
+        #
+        # Do not do this on macOS. A native AppKit Quit event reaches
+        # closeEvent while NSApplication terminate: is already on the stack;
+        # synchronously calling QApplication.quit() here re-enters terminate:
+        # and can segfault while Shiboken tears down QObject parent links.
+        if IS_MACOS:
+            return
         try:
-            from PySide6.QtWidgets import QApplication
             _qapp = QApplication.instance()
             if _qapp is not None:
                 _qapp.quit()

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -939,12 +939,10 @@ class CdummWindow(FluentWindow):
         self.titleBar.titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.titleBar.titleLabel.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
 
-        # Reuse the application icon for this window and the menu-bar status
-        # item. On macOS the frozen bundle ships a PNG/.icns, not cdumm.ico.
-        from cdumm.gui.app_icon import application_icon
-        icon = application_icon()
-        if not icon.isNull():
-            self.setWindowIcon(icon)
+        # Keep the macOS Dock icon under CFBundleIconFile control. The status
+        # item gets its own explicit PNG later in _setup_tray_icon.
+        from cdumm.gui.app_icon import apply_application_icon
+        apply_application_icon(self)
 
         # ── Window-scoped drag-drop ──────────────────────────────────
         self.setAcceptDrops(True)
@@ -6539,11 +6537,17 @@ class CdummWindow(FluentWindow):
             logger.info("System tray not available, hide-on-launch will "
                         "fall back to minimize")
             return
-        icon = self.windowIcon()
-        if icon.isNull():
-            app = QApplication.instance()
-            if app is not None:
-                icon = app.windowIcon()
+        if IS_MACOS:
+            # Do not reuse/setWindowIcon on macOS: that replaces the native
+            # Dock .icns with this raw PNG and changes its apparent size.
+            from cdumm.gui.app_icon import application_icon
+            icon = application_icon()
+        else:
+            icon = self.windowIcon()
+            if icon.isNull():
+                app = QApplication.instance()
+                if app is not None:
+                    icon = app.windowIcon()
         if icon.isNull():
             logger.warning("System tray icon is null, hide-on-launch will "
                            "fall back to minimize")

--- a/src/cdumm/main.py
+++ b/src/cdumm/main.py
@@ -423,24 +423,14 @@ def main() -> int:
     if IS_LINUX:
         QGuiApplication.setDesktopFileName("cdumm")
 
-    # Set application-level icon (shows in taskbar)
-    from PySide6.QtGui import QIcon
-    if getattr(sys, 'frozen', False):
-        _app_ico = Path(sys._MEIPASS) / "cdumm.ico"
-    else:
-        _app_ico = Path(__file__).resolve().parents[2] / "cdumm.ico"
-    # On Linux prefer the source PNG over the Windows .ico: Qt's ICO
-    # plugin reads the file but produces a lower-fidelity QIcon than
-    # loading the native 735x735 PNG directly. The .desktop entry
-    # installed by the launcher uses the same PNG so the in-window
-    # and taskbar icons match.
-    if IS_LINUX:
-        _app_png = (Path(__file__).resolve().parents[2]
-                    / "assets" / "cdumm-icon-square.png")
-        if _app_png.exists():
-            _app_ico = _app_png
-    if _app_ico.exists():
-        app.setWindowIcon(QIcon(str(_app_ico)))
+    # Set one application-level icon for the Dock/taskbar, windows, and
+    # QSystemTrayIcon. The macOS bundle does not contain cdumm.ico; resolving
+    # that Windows-only filename left the menu-bar status item with a null
+    # icon, so CDUMM could hide itself with no visible way to restore it.
+    from cdumm.gui.app_icon import application_icon
+    _app_icon = application_icon()
+    if not _app_icon.isNull():
+        app.setWindowIcon(_app_icon)
 
     # Load Oxanium font
     from PySide6.QtGui import QFontDatabase

--- a/src/cdumm/main.py
+++ b/src/cdumm/main.py
@@ -423,14 +423,11 @@ def main() -> int:
     if IS_LINUX:
         QGuiApplication.setDesktopFileName("cdumm")
 
-    # Set one application-level icon for the Dock/taskbar, windows, and
-    # QSystemTrayIcon. The macOS bundle does not contain cdumm.ico; resolving
-    # that Windows-only filename left the menu-bar status item with a null
-    # icon, so CDUMM could hide itself with no visible way to restore it.
-    from cdumm.gui.app_icon import application_icon
-    _app_icon = application_icon()
-    if not _app_icon.isNull():
-        app.setWindowIcon(_app_icon)
+    # Windows/Linux need an explicit Qt icon. On macOS, leave the Dock icon
+    # under CFBundleIconFile control; setting the raw PNG here overrides the
+    # native .icns and makes the Dock tile render larger than neighboring apps.
+    from cdumm.gui.app_icon import apply_application_icon
+    apply_application_icon(app)
 
     # Load Oxanium font
     from PySide6.QtGui import QFontDatabase

--- a/tests/test_macos_window_restore.py
+++ b/tests/test_macos_window_restore.py
@@ -1,0 +1,75 @@
+"""Regression tests for macOS hide-on-launch window recovery."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QSystemTrayIcon
+
+import cdumm.gui.app_icon as app_icon
+import cdumm.gui.fluent_window as fluent_window
+from cdumm.gui.fluent_window import CdummWindow
+
+
+def test_frozen_macos_icon_uses_bundled_png(monkeypatch, tmp_path):
+    logo = tmp_path / "assets" / "cdumm-logo.png"
+    logo.parent.mkdir()
+    logo.write_bytes(b"png fixture")
+
+    monkeypatch.setattr(app_icon, "IS_MACOS", True)
+    monkeypatch.setattr(app_icon, "IS_LINUX", False)
+    monkeypatch.setattr(app_icon.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(app_icon.sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert app_icon.application_icon_path() == logo
+
+
+def _fake_window(*, visible: bool, minimized: bool):
+    calls = []
+    window = SimpleNamespace(
+        isVisible=lambda: visible,
+        isMinimized=lambda: minimized,
+        _restore_from_tray=lambda: calls.append("restore"),
+    )
+    return window, calls
+
+
+def test_macos_dock_activation_restores_hidden_window(monkeypatch):
+    monkeypatch.setattr(fluent_window, "IS_MACOS", True)
+    window, calls = _fake_window(visible=False, minimized=False)
+
+    CdummWindow._on_application_state_changed(
+        window, Qt.ApplicationState.ApplicationActive)
+
+    assert calls == ["restore"]
+
+
+def test_macos_inactive_event_does_not_restore(monkeypatch):
+    monkeypatch.setattr(fluent_window, "IS_MACOS", True)
+    window, calls = _fake_window(visible=False, minimized=False)
+
+    CdummWindow._on_application_state_changed(
+        window, Qt.ApplicationState.ApplicationInactive)
+
+    assert calls == []
+
+
+def test_visible_window_is_not_needlessly_restored(monkeypatch):
+    monkeypatch.setattr(fluent_window, "IS_MACOS", True)
+    window, calls = _fake_window(visible=True, minimized=False)
+
+    CdummWindow._on_application_state_changed(
+        window, Qt.ApplicationState.ApplicationActive)
+
+    assert calls == []
+
+
+def test_single_click_on_menu_bar_icon_restores_window():
+    calls = []
+    window = SimpleNamespace(
+        _restore_from_tray=lambda: calls.append("restore"))
+
+    CdummWindow._on_tray_activated(
+        window, QSystemTrayIcon.ActivationReason.Trigger)
+
+    assert calls == ["restore"]

--- a/tests/test_macos_window_restore.py
+++ b/tests/test_macos_window_restore.py
@@ -1,6 +1,7 @@
 """Regression tests for macOS hide-on-launch window recovery."""
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 
 from PySide6.QtCore import Qt
@@ -85,3 +86,27 @@ def test_single_click_on_menu_bar_icon_restores_window():
         window, QSystemTrayIcon.ActivationReason.Trigger)
 
     assert calls == ["restore"]
+
+
+def test_hidden_macos_tray_quit_shows_window_before_close(monkeypatch):
+    calls = []
+    tray = SimpleNamespace(hide=lambda: calls.append("hide-tray"))
+    window = SimpleNamespace(
+        _tray_icon=tray,
+        isVisible=lambda: False,
+        show=lambda: calls.append("show-window"),
+        close=lambda: calls.append("close-window"),
+    )
+    monkeypatch.setattr(fluent_window, "IS_MACOS", True)
+
+    CdummWindow._quit_from_tray(window)
+
+    assert calls == ["hide-tray", "show-window", "close-window"]
+
+
+def test_macos_close_event_does_not_reenter_qapplication_quit():
+    source = inspect.getsource(CdummWindow.closeEvent)
+    guard = source.index("if IS_MACOS:")
+    forced_quit = source.index("_qapp.quit()")
+
+    assert guard < forced_quit

--- a/tests/test_macos_window_restore.py
+++ b/tests/test_macos_window_restore.py
@@ -24,6 +24,18 @@ def test_frozen_macos_icon_uses_bundled_png(monkeypatch, tmp_path):
     assert app_icon.application_icon_path() == logo
 
 
+def test_macos_does_not_override_native_dock_icon(monkeypatch):
+    calls = []
+    target = SimpleNamespace(
+        setWindowIcon=lambda icon: calls.append(icon))
+    monkeypatch.setattr(app_icon, "IS_MACOS", True)
+
+    applied = app_icon.apply_application_icon(target)
+
+    assert applied is False
+    assert calls == []
+
+
 def _fake_window(*, visible: bool, minimized: bool):
     calls = []
     window = SimpleNamespace(


### PR DESCRIPTION
## What & why

On native macOS, hide-on-launch can leave CDUMM running with no visible main window and no usable recovery path. The runtime icon loader only looked for the Windows `cdumm.ico`, Dock activation did not restore a hidden Qt window, and tray activation only handled double-clicks.

Manual testing also exposed a native-Quit crash: while AppKit was already processing `NSApplication terminate:`, `closeEvent()` synchronously called `QApplication.quit()` again. That recursive termination could segfault during Shiboken QObject invalidation.

These lifecycle problems affect both v3.5.0 and v3.6.0.

Fixes #300

## Changes

- Resolve a platform-appropriate icon for the menu-bar status item, using the bundled PNG on macOS.
- Preserve the native `CFBundleIconFile` / `.icns` Dock icon instead of overriding it with a raw PNG.
- Restore hidden or minimized CDUMM windows when macOS activates the app from the Dock.
- Restore on both single-click (`Trigger`) and double-click tray activation.
- Fall back to minimizing if no valid/visible tray icon is available.
- Avoid re-entering `QApplication.quit()` while AppKit is already handling native termination.
- Make a hidden tray window visible before closing it on macOS so `quitOnLastWindowClosed` exits naturally.
- Add macOS-focused regression coverage for icon handling, window restoration, and safe native Quit behavior.

## Verification

- [ ] `python -m pytest` passes
- [ ] `ruff check .` is clean
- [x] Added or updated a regression test (fails before, passes after)

Targeted checks:

```text
QT_QPA_PLATFORM=offscreen python -m pytest -q \
  tests/test_macos_window_restore.py \
  tests/test_close_event_stops_all_nexus_timers.py \
  tests/test_macos_game_finder.py
27 passed

ruff check tests/test_macos_window_restore.py
All checks passed!

ruff check src/cdumm/gui/fluent_window.py --select F401
All checks passed!
```

The patched macOS `.app` was built successfully; its code signature and generated DMG integrity were verified.

Manual/integration verification:

- Launch game, exit game, then restore CDUMM from the Dock: passed.
- Preserve native Dock icon sizing: passed.
- Launch the packaged app and terminate it through a native macOS Quit AppleEvent: exited cleanly with status `0`, with no SIGSEGV/Shiboken crash.

## Notes

The change intentionally does not add game-process polling. Restoring from Dock/application activation fixes the unreachable-window state without coupling this lifecycle fix to game executable detection.
