### PR TITLE
Import QoL (Equip Everything, long-path zip, variant packs) + macOS Find Culprit + notification UX

### DIFF
--- a/MACOS.md
+++ b/MACOS.md
@@ -104,7 +104,7 @@ auto-detect locate it under `~/Games`, `~/Applications`,
 | Multi-variant pickers, configurable mods | ✓ |
 | Mod conflict detection + load order     | ✓ |
 | Game Update Recovery banner             | ✓ |
-| Find Culprit (auto-bisect crash search) | Windows only — needs Pearl Abyss' `crashpad_handler.exe` infrastructure |
+| Find Culprit (auto-bisect crash search) | ✓ — bisection classifies each round from whether the game process appears and survives (via `psutil`), not from Windows crash dumps. Detects the Proton/Wine `CrimsonDesert.exe` and the native macOS Steam `CrimsonDesert_Steam` process (#299). |
 | ASI plugins                             | Not possible — ASI is a Win32-only proxy DLL format. The page is hidden on macOS. |
 | `nxm://` Mod Manager Download buttons   | Windows only for now — macOS would need a packaged `.app` to register a URL scheme handler |
 | RAR archive import                      | Works out-of-box on most macOS systems via the built-in `/usr/bin/bsdtar`. RAR5 archives with v6 compression need `unar` (`brew install unar`) — the open-source `sevenzip` formula doesn't ship RARLAB's codec, so it can't decode v6 RAR5 files. CDUMM tries 7z, then unar, then bsdtar in sequence. |

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -1058,6 +1058,13 @@ LIST_WRITERS: dict[tuple[str, str], str] = {
     # itself is the source of truth for what's actually applicable.
     ("iteminfo", "enchant_data_list"):
         "iteminfo_writer.build_iteminfo_intent_change",
+    # prefab_data_list carries the tribe/gender equip restrictions; #285
+    # relocated it to the record tail on CD 1.13 and the native parser
+    # decodes it (5,687 items non-empty), but it was never registered here,
+    # so validation refused every whole-list write -- Equip Everything
+    # (13k dls) and AXIOM QoL (22k) applied 0 of ~5,098 intents.
+    ("iteminfo", "prefab_data_list"):
+        "iteminfo_writer.build_iteminfo_intent_change",
     ("iteminfo", "equip_passive_skill_list"):
         "iteminfo_writer.build_iteminfo_intent_change",
     ("iteminfo", "occupied_equip_slot_data_list"):

--- a/src/cdumm/engine/game_monitor.py
+++ b/src/cdumm/engine/game_monitor.py
@@ -35,6 +35,19 @@ logger = logging.getLogger(__name__)
 from cdumm.platform import IS_WINDOWS as _IS_WINDOWS
 
 GAME_EXE_NAME = "CrimsonDesert.exe"
+# Executable basenames the game process can have on non-Windows hosts.
+# Windows always uses CrimsonDesert.exe; a Proton/Wine launch keeps that
+# name in the command line; but the NATIVE macOS Steam build's
+# CFBundleExecutable is ``CrimsonDesert_Steam`` (inside
+# ``Crimson Desert/CrimsonDesert_Steam.app/Contents/MacOS/``). Matching
+# only ``crimsondesert.exe`` there meant Find Culprit never saw the game
+# and scored every bisection round as a crash — falsely blaming an
+# innocent mod (lwjiyuan, GitHub #299). Match any of these (lowercased).
+NON_WINDOWS_GAME_EXE_NAMES = frozenset({
+    "crimsondesert.exe",     # Proton / Wine
+    "crimsondesert_steam",   # native macOS Steam build
+    "crimsondesert",         # native build without the _Steam suffix
+})
 CRASH_DUMP_DIR = os.path.join(os.environ.get("LOCALAPPDATA", ""), "CrashDumps")
 FALLBACK_APP_ID = "3321460"
 
@@ -82,11 +95,11 @@ def find_game_process() -> int | None:
     hard-coded install path — is what makes this work on any machine.
     """
     if not _IS_WINDOWS:
-        target = GAME_EXE_NAME.lower()
         for proc in psutil.process_iter(["pid", "cmdline"]):
             try:
                 cmdline = proc.info.get("cmdline")
-                if cmdline and ntpath.basename(cmdline[0]).lower() == target:
+                if (cmdline and ntpath.basename(cmdline[0]).lower()
+                        in NON_WINDOWS_GAME_EXE_NAMES):
                     return proc.info["pid"]
             except (psutil.NoSuchProcess, psutil.AccessDenied,
                     psutil.ZombieProcess, IndexError):

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -55,6 +55,69 @@ def _open_zip_utf8(zip_path) -> "zipfile.ZipFile":
     except UnicodeDecodeError:
         return zipfile.ZipFile(zip_path)
 
+
+def _extractall_collapsing_wrapper(zf: "zipfile.ZipFile", dest) -> None:
+    """Extract a zip to ``dest``, collapsing a single redundant top-level
+    wrapper directory so long member paths don't blow past Windows'
+    260-char MAX_PATH.
+
+    DMM's Mod Builder exports each mod as ``ModName/ModName.json`` inside
+    ``ModName.zip`` — the json nested in a folder of the same (~100-char)
+    name. Under the extraction-staging path that doubled name pushes the
+    full path past 260 characters, so ``extractall`` fails with
+    ``[Errno 2] No such file or directory`` while importing the *bare*
+    json works fine (falobos76, GitHub #191). Collapsing the wrapper keeps
+    every extracted path short enough for the rest of the import pipeline,
+    which walks and reads these files with ordinary (non-extended) paths.
+
+    Only a single top-level *directory* is stripped, and only when it is
+    NOT a 4-digit PAZ dir (``0036/`` and friends carry meaning and must
+    survive). Zips that don't match this shape extract exactly as before.
+    """
+    tops: set[str] = set()
+    has_subpaths = False
+    for name in zf.namelist():
+        p = name.replace("\\", "/").lstrip("/")
+        if not p:
+            continue
+        parts = p.split("/", 1)
+        tops.add(parts[0])
+        if len(parts) > 1 and parts[1]:
+            has_subpaths = True
+
+    strip = None
+    if len(tops) == 1 and has_subpaths:
+        top = next(iter(tops))
+        is_paz_dir = top.isdigit() and len(top) == 4
+        if not is_paz_dir:
+            strip = top + "/"
+
+    if strip is None:
+        zf.extractall(dest)
+        return
+
+    logger.info(
+        "Import: collapsing redundant top-level folder %r to keep "
+        "extraction paths under the Windows 260-char limit (#191).", strip)
+    dest_abs = os.path.abspath(dest)
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        rel = info.filename.replace("\\", "/").lstrip("/")
+        if rel.startswith(strip):
+            rel = rel[len(strip):]
+        if not rel:
+            continue
+        out = os.path.normpath(os.path.join(dest_abs, *rel.split("/")))
+        # Path-traversal guard: never write outside dest.
+        if out != dest_abs and not out.startswith(dest_abs + os.sep):
+            logger.warning("Skipping unsafe zip member path: %r", info.filename)
+            continue
+        os.makedirs(os.path.dirname(out), exist_ok=True)
+        with zf.open(info) as src, open(out, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+
 import time
 
 # Thread-local progress callback for import operations.
@@ -3111,7 +3174,7 @@ def import_from_zip(
         tmp_path = Path(tmp)
         try:
             with _open_zip_utf8(zip_path) as zf:
-                zf.extractall(tmp_path)
+                _extractall_collapsing_wrapper(zf, tmp_path)
         except zipfile.BadZipFile as e:
             result.error = f"Invalid zip file: {e}"
             return result

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -56,7 +56,8 @@ def _open_zip_utf8(zip_path) -> "zipfile.ZipFile":
         return zipfile.ZipFile(zip_path)
 
 
-def _extractall_collapsing_wrapper(zf: "zipfile.ZipFile", dest) -> None:
+def _extractall_collapsing_wrapper(
+        zf: "zipfile.ZipFile", dest, archive_stem: "str | None" = None) -> None:
     """Extract a zip to ``dest``, collapsing a single redundant top-level
     wrapper directory so long member paths don't blow past Windows'
     260-char MAX_PATH.
@@ -70,9 +71,13 @@ def _extractall_collapsing_wrapper(zf: "zipfile.ZipFile", dest) -> None:
     every extracted path short enough for the rest of the import pipeline,
     which walks and reads these files with ordinary (non-extended) paths.
 
-    Only a single top-level *directory* is stripped, and only when it is
-    NOT a 4-digit PAZ dir (``0036/`` and friends carry meaning and must
-    survive). Zips that don't match this shape extract exactly as before.
+    The wrapper is stripped ONLY when it is the DMM self-named shape: a
+    single top-level directory whose name equals the archive's own stem
+    (``ModName.zip`` → ``ModName/``). That is deliberately narrow — a
+    generic single top-level folder like ``ui/`` inside ``DarkUI.zip`` is
+    meaningful (its members target ``ui/menu.css`` etc.) and must survive,
+    so it is NOT collapsed. Without an ``archive_stem`` to match against,
+    nothing is collapsed. Zips that don't match extract exactly as before.
     """
     tops: set[str] = set()
     has_subpaths = False
@@ -86,10 +91,10 @@ def _extractall_collapsing_wrapper(zf: "zipfile.ZipFile", dest) -> None:
             has_subpaths = True
 
     strip = None
-    if len(tops) == 1 and has_subpaths:
+    if len(tops) == 1 and has_subpaths and archive_stem:
         top = next(iter(tops))
         is_paz_dir = top.isdigit() and len(top) == 4
-        if not is_paz_dir:
+        if not is_paz_dir and top.lower() == archive_stem.strip().lower():
             strip = top + "/"
 
     if strip is None:
@@ -3174,7 +3179,7 @@ def import_from_zip(
         tmp_path = Path(tmp)
         try:
             with _open_zip_utf8(zip_path) as zf:
-                _extractall_collapsing_wrapper(zf, tmp_path)
+                _extractall_collapsing_wrapper(zf, tmp_path, zip_path.stem)
         except zipfile.BadZipFile as e:
             result.error = f"Invalid zip file: {e}"
             return result

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -3005,6 +3005,16 @@ def _import_from_extracted(
         # through to the generic "no recognized format" error.
         f3_pack = _scan_format3_variant_pack(tmp_path)
         if f3_pack:
+            # Import as ONE switchable mod (first enabled, rest on the cog)
+            # instead of dead-ending — same outcome the GUI picker gives,
+            # on every path incl. 7z/rar and re-import (#191). mod_name is
+            # already the archive-derived display name; wrap it as a source
+            # so the multi-variant mod is named for the archive.
+            mv = _import_format3_variant_pack_as_multi(
+                f3_pack, Path(mod_name), game_dir, db, deltas_dir,
+                existing_mod_id=existing_mod_id)
+            if mv is not None:
+                return mv
             ids = ", ".join(vid for _, vid in f3_pack)
             result.error = (
                 f"This archive contains {len(f3_pack)} variants of "
@@ -3488,6 +3498,15 @@ def import_from_zip(
             # "import one at a time" guidance.
             f3_pack = _scan_format3_variant_pack(tmp_path)
             if f3_pack:
+                # Import as ONE switchable mod (first variant enabled, the
+                # rest on the cog) instead of dead-ending — same outcome the
+                # GUI picker gives, but on every path (#191). Falls back to
+                # the old guidance only if the multi-variant import can't run.
+                mv = _import_format3_variant_pack_as_multi(
+                    f3_pack, zip_path, game_dir, db, deltas_dir,
+                    existing_mod_id=existing_mod_id)
+                if mv is not None:
+                    return _with_asi(mv)
                 ids = ", ".join(vid for _, vid in f3_pack)
                 result.error = (
                     f"This zip contains {len(f3_pack)} variants of "
@@ -4539,6 +4558,63 @@ def _import_format3_bundle(
         note += f" {len(failed)} could not be imported: {shown}."
     primary.info = f"{primary.info}\n{note}" if primary.info else note
     return primary
+
+
+def _import_format3_variant_pack_as_multi(
+    pack: "list[tuple[Path, str]]", source: Path, game_dir: Path,
+    db: Database, deltas_dir: Path, existing_mod_id: int | None = None,
+) -> "ModImportResult | None":
+    """Import a Format 3 variant pack (e.g. Fat Stacks: fat_stacks_2x …
+    _999999) as ONE switchable mod — the first variant enabled, the rest
+    reachable from the mod's cog — instead of dead-ending with a "drop it
+    on the main window to pick a variant" error.
+
+    The GUI's folder-variant picker already produces this outcome for
+    drag-drop. But a variant pack reaching the engine another way — a
+    re-import from source, a programmatic/CLI import, or a drop whose
+    pre-extract for the picker failed — used to hit that hard error and
+    the user got nothing. This backstops every path with the same result
+    the picker gives. GitHub #191 (falobos76 / Fat Stacks).
+
+    Returns a populated ModImportResult on success, or None so the caller
+    can fall back to its previous behaviour.
+    """
+    import json as _json
+    # Stable order so the enabled-by-default variant is deterministic.
+    ordered = sorted(pack, key=lambda t: t[0].name.lower())
+    presets: list[tuple[Path, dict]] = []
+    for jp, _vid in ordered:
+        try:
+            with open(jp, "r", encoding="utf-8-sig") as f:
+                presets.append((jp, _json.load(f)))
+        except (OSError, ValueError, UnicodeDecodeError) as e:
+            logger.warning(
+                "variant pack: skipping unreadable %s (%s)", jp.name, e)
+    if len(presets) < 2:
+        return None
+    try:
+        from cdumm.engine.variant_handler import import_multi_variant
+        mods_dir = deltas_dir.parent / "mods"
+        mods_dir.mkdir(parents=True, exist_ok=True)
+        mv = import_multi_variant(
+            presets, source, game_dir, mods_dir, db,
+            existing_mod_id=existing_mod_id,
+            initial_selection={presets[0][0]})
+    except Exception as e:  # noqa: BLE001 — fall back to the caller's error
+        logger.error(
+            "variant-pack multi-import failed (%s); caller falls back", e,
+            exc_info=True)
+        return None
+    if not mv:
+        return None
+    result = ModImportResult(mv.get("mod_name") or source.stem or "variant pack")
+    result.mod_id = int(mv["mod_id"])
+    n = len(mv.get("variants") or presets)
+    result.info = (
+        f"This archive holds {n} versions of one mod (for example, "
+        f"different stack sizes). CDUMM imported it as a single mod with "
+        f"one version enabled — use the mod's cog to switch to another.")
+    return result
 
 
 def import_from_cdmod(

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -6145,11 +6145,13 @@ class CdummWindow(FluentWindow):
 
         Cross-platform: scans the live process list via psutil (already
         a CDUMM dependency). On Windows the binary is
-        ``CrimsonDesert.exe``; on the native macOS build the executable
-        inside the .app bundle is ``CrimsonDesert`` (lives at
-        ``Crimson Desert.app/Contents/MacOS/CrimsonDesert``). Match
-        either name regardless of host platform, psutil reports the
-        leaf basename, no extension matching needed.
+        ``CrimsonDesert.exe``; on the native macOS Steam build the
+        executable inside the .app bundle is ``CrimsonDesert_Steam``
+        (lives at ``Crimson Desert/CrimsonDesert_Steam.app/Contents/
+        MacOS/CrimsonDesert_Steam``). Match any known name regardless of
+        host platform — psutil reports the leaf basename, so no extension
+        matching is needed. Sharing the set with game_monitor keeps the
+        Apply-guard and Find Culprit in agreement (lwjiyuan, #299).
 
         Falls open: any error during the scan returns True so the user
         can still apply mods. The downside (mod apply during game run)
@@ -6160,7 +6162,8 @@ class CdummWindow(FluentWindow):
         except Exception:
             return True
         try:
-            target_names = {"crimsondesert.exe", "crimsondesert"}
+            from cdumm.engine.game_monitor import NON_WINDOWS_GAME_EXE_NAMES
+            target_names = NON_WINDOWS_GAME_EXE_NAMES
             for proc in psutil.process_iter(attrs=("name",)):
                 try:
                     name = (proc.info.get("name") or "").lower()

--- a/src/cdumm/gui/notifications.py
+++ b/src/cdumm/gui/notifications.py
@@ -85,9 +85,22 @@ class NotificationStore(QObject):
 
     def add(self, level: str, title: str, message: str = "",
             action_label: str | None = None, action_cb=None) -> None:
+        title, message = str(title), str(message or "")
         self._items.insert(0, Notification(
-            level, str(title), str(message or ""), action_label, action_cb))
+            level, title, message, action_label, action_cb))
         del self._items[100:]  # keep the list bounded
+        # Mirror every notification into the app log so the text — e.g.
+        # the "N patches skipped" apply summary — survives in the bug
+        # report even after the toast disappears and can be copied from
+        # the log file. falobos76 asked for exactly this (#191): the
+        # on-screen/notification text used to live only in memory.
+        line = f"notification [{level}] {title}" + (f": {message}" if message else "")
+        try:
+            _lvl = {"error": logging.ERROR, "warning": logging.WARNING}.get(
+                level, logging.INFO)
+            logger.log(_lvl, "%s", line)
+        except Exception:
+            pass
         self.changed.emit()
 
     def items(self) -> list[Notification]:
@@ -230,16 +243,24 @@ class NotificationPanel(QWidget):
         dot.setStyleSheet(f"background: {colour}; border-radius: 5px;")
         h.addWidget(dot, 0, Qt.AlignmentFlag.AlignTop)
 
+        # Let the user select and copy the notification text — the apply
+        # "N patches skipped" summary only lived here and couldn't be
+        # copied before (falobos76, #191).
+        _selectable = (Qt.TextInteractionFlag.TextSelectableByMouse
+                       | Qt.TextInteractionFlag.TextSelectableByKeyboard)
+
         col = QVBoxLayout()
         col.setSpacing(1)
         title = BodyLabel(n.title, row)
         title.setWordWrap(True)
+        title.setTextInteractionFlags(_selectable)
         if n.read:
             title.setStyleSheet("BodyLabel { color: #9AA0A6; }")
         col.addWidget(title)
         if n.message:
             msg = CaptionLabel(n.message, row)
             msg.setWordWrap(True)
+            msg.setTextInteractionFlags(_selectable)
             col.addWidget(msg)
         col.addWidget(CaptionLabel(_rel_time(n.time), row))
         h.addLayout(col, 1)
@@ -257,8 +278,16 @@ class NotificationPanel(QWidget):
             act.clicked.connect(_do)
             h.addWidget(act, 0, Qt.AlignmentFlag.AlignVCenter)
 
+        # Scope the tint to the row itself. A bare ``QWidget { … }`` rule
+        # cascades to every child, so the BodyLabel / CaptionLabel each got
+        # their own translucent pill painted directly behind the text —
+        # which on some themes sits light-on-text and makes the notification
+        # hard to read in dark mode (falobos76, #191). An objectName
+        # selector paints only the row, so the text renders on the flat
+        # panel background with full theme contrast.
+        row.setObjectName("notifRow")
         row.setStyleSheet(
-            "QWidget { background: rgba(127,127,127,0.08); border-radius: 8px; }")
+            "#notifRow { background: rgba(127,127,127,0.08); border-radius: 8px; }")
         return row
 
 

--- a/tests/test_format3_variant_pack_imports_as_multi.py
+++ b/tests/test_format3_variant_pack_imports_as_multi.py
@@ -1,0 +1,82 @@
+"""A Format 3 variant pack (Fat Stacks: fat_stacks_2x … _999999 — 8 stack
+sizes in one zip) must import as ONE switchable mod on the engine path,
+not dead-end with a "drop it on the main window to pick a variant" error.
+GitHub #191 (falobos76).
+
+The GUI folder-variant picker already produces this outcome for drag-drop;
+this pins the engine backstop for every other path (re-import from source,
+a programmatic/CLI import, or a drop whose pre-extract for the picker
+failed). One variant is enabled; the rest live on the mod's cog.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+
+def _variant_json(mult: int) -> bytes:
+    # Same two intents in every variant (equal counts → ratio 1.0, so the
+    # pack detector treats them as one mod's variants); only `new` differs.
+    return json.dumps({
+        "modinfo": {"name": f"Fat Stacks {mult}x"},
+        "format": 3,
+        "target": "iteminfo.pabgb",
+        "intents": [
+            {"entry": "Pyeonjeon_Arrow", "key": 2200,
+             "field": "max_stack_count", "op": "set", "new": 1000 * mult},
+            {"entry": "Mujeon_Arrow", "key": 2201,
+             "field": "max_stack_count", "op": "set", "new": 1000 * mult},
+        ],
+    }).encode("utf-8")
+
+
+def _fat_stacks_zip(tmp_path: Path) -> Path:
+    zp = tmp_path / "Fat Stacks - JSONv3 157.zip"
+    with zipfile.ZipFile(zp, "w") as z:
+        for m in (2, 3, 5, 10, 20, 50, 100, 999999):
+            z.writestr(f"fat_stacks_{m}x.field.json", _variant_json(m))
+    return zp
+
+
+class _FakeSnapshot:
+    def get_file_hash(self, p):
+        return None
+
+    def get_all_files(self):
+        return []
+
+
+def test_fat_stacks_variant_pack_imports_as_one_switchable_mod(
+        tmp_path, monkeypatch, db):
+    from cdumm.engine import import_handler as ih
+    # Don't read a real game install for the version stamp.
+    monkeypatch.setattr(
+        "cdumm.engine.version_detector.detect_game_version", lambda gd: None)
+
+    game_dir = tmp_path / "game"
+    game_dir.mkdir()
+    deltas_dir = tmp_path / "deltas"
+    deltas_dir.mkdir()
+    zip_path = _fat_stacks_zip(tmp_path)
+
+    result = ih.import_from_zip(
+        zip_path, game_dir, db, _FakeSnapshot(), deltas_dir)
+
+    assert result is not None
+    assert result.error is None, (
+        f"variant pack must import, not error: {result.error!r}")
+    assert result.mod_id is not None, "a mod row must be created"
+
+    row = db.connection.execute(
+        "SELECT variants, configurable FROM mods WHERE id = ?",
+        (result.mod_id,)).fetchone()
+    assert row is not None
+    variants = json.loads(row[0])
+    assert len(variants) == 8, (
+        f"all 8 stack sizes must be kept as switchable variants, "
+        f"got {len(variants)}")
+    enabled = [v for v in variants if v.get("enabled")]
+    assert len(enabled) == 1, (
+        f"exactly one variant enabled by default, got {len(enabled)}")
+    assert row[1] == 1, "mod must be configurable (cog switches variant)"

--- a/tests/test_import_zip_longpath.py
+++ b/tests/test_import_zip_longpath.py
@@ -1,0 +1,101 @@
+"""Long-path zip import (#191, falobos76).
+
+DMM's Mod Builder exports each mod as ``ModName/ModName.json`` inside
+``ModName.zip`` — the json nested in a folder of the *same* ~100-char
+name. Extracted under the staging path (``<game>/CDMods/_import_staging/
+<32-hex>/``) that doubled name pushes the full path past Windows' 260-char
+MAX_PATH, so ``extractall`` fails with ``[Errno 2] No such file or
+directory`` while importing the bare json works. ``_extractall_collapsing_
+wrapper`` collapses the redundant single top-level wrapper so paths stay
+short (and normal) for the whole downstream pipeline.
+"""
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+
+import pytest
+
+from cdumm.engine.import_handler import _extractall_collapsing_wrapper
+
+
+def _zip(entries: list[tuple[str, bytes]]) -> zipfile.ZipFile:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, content in entries:
+            z.writestr(name, content)
+    buf.seek(0)
+    return zipfile.ZipFile(buf)
+
+
+def _files(root) -> list[str]:
+    out = []
+    for base, _dirs, files in os.walk(root):
+        for f in files:
+            out.append(
+                os.path.relpath(os.path.join(base, f), root).replace("\\", "/"))
+    return sorted(out)
+
+
+def test_dmm_wrapper_is_collapsed(tmp_path):
+    """Name/Name.json -> Name.json at the staging root (the #191 case)."""
+    name = "BrizMod-DMM_MaxStacks-InfDurability-Gathering5x-Trust100x"
+    z = _zip([(f"{name}/", b""), (f"{name}/{name}.json", b'{"format":3}')])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == [f"{name}.json"]
+    # content preserved
+    assert (tmp_path / f"{name}.json").read_bytes() == b'{"format":3}'
+
+
+def test_collapse_shortens_path_below_260(tmp_path):
+    """The fix's whole point: a real-length DMM name that overflows 260
+    when doubled fits once the wrapper is collapsed. Machine-independent —
+    asserts on path lengths, not on extractall raising (dev machines with
+    LongPathsEnabled=1 wouldn't raise; the user's packaged exe does)."""
+    name = ("BrizMod-DMM_MaxStacks-InfDurability-"
+            "IcreaseWildLifeSpawn-NoDragonAndCompanionCooldown-"
+            "Gathering5x-Trust100x")  # ~91 chars, like the real mod
+    user_base = (r"D:\GIOCHI\Steam\steamapps\common\Crimson Desert"
+                 r"\CDMods\_import_staging\f39c0d893efc4e948d1980ee8a28c8e6")
+    uncollapsed = len(user_base) + 1 + len(name) + 1 + len(name) + len(".json")
+    collapsed = len(user_base) + 1 + len(name) + len(".json")
+    assert uncollapsed > 260, "precondition: doubled name overflows MAX_PATH"
+    assert collapsed < 260, "collapsed path must fit under MAX_PATH"
+
+
+def test_paz_dir_is_never_collapsed(tmp_path):
+    """A 4-digit PAZ dir (0036/) carries meaning — must survive intact."""
+    z = _zip([("0036/data.paz", b"x"), ("0036/0.pamt", b"y")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == ["0036/0.pamt", "0036/data.paz"]
+
+
+def test_wrapper_around_paz_dir_collapses_to_the_paz_dir(tmp_path):
+    """MyMod/0036/x -> 0036/x: the wrapper goes, the PAZ dir stays."""
+    z = _zip([("MyMod/0036/data.paz", b"x"), ("MyMod/0036/0.pamt", b"y")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == ["0036/0.pamt", "0036/data.paz"]
+
+
+def test_bare_top_level_file_is_unchanged(tmp_path):
+    """A json already at the zip root has no wrapper to collapse."""
+    z = _zip([("mod.json", b"{}")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == ["mod.json"]
+
+
+def test_multiple_top_level_dirs_are_not_collapsed(tmp_path):
+    """Ambiguous shape (2+ top-level entries) extracts verbatim."""
+    z = _zip([("A/x.json", b"{}"), ("B/y.json", b"{}")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == ["A/x.json", "B/y.json"]
+
+
+def test_path_traversal_member_is_skipped(tmp_path):
+    """A member that resolves outside dest must never be written."""
+    z = _zip([("Mod/ok.json", b"{}"), ("Mod/../../evil.json", b"x")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    # only the safe member lands; nothing escapes tmp_path
+    assert _files(tmp_path) == ["ok.json"]
+    assert not (tmp_path.parent / "evil.json").exists()

--- a/tests/test_import_zip_longpath.py
+++ b/tests/test_import_zip_longpath.py
@@ -15,8 +15,6 @@ import io
 import os
 import zipfile
 
-import pytest
-
 from cdumm.engine.import_handler import _extractall_collapsing_wrapper
 
 

--- a/tests/test_import_zip_longpath.py
+++ b/tests/test_import_zip_longpath.py
@@ -40,7 +40,7 @@ def test_dmm_wrapper_is_collapsed(tmp_path):
     """Name/Name.json -> Name.json at the staging root (the #191 case)."""
     name = "BrizMod-DMM_MaxStacks-InfDurability-Gathering5x-Trust100x"
     z = _zip([(f"{name}/", b""), (f"{name}/{name}.json", b'{"format":3}')])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    _extractall_collapsing_wrapper(z, str(tmp_path), name)  # zip stem == wrapper
     assert _files(tmp_path) == [f"{name}.json"]
     # content preserved
     assert (tmp_path / f"{name}.json").read_bytes() == b'{"format":3}'
@@ -65,35 +65,55 @@ def test_collapse_shortens_path_below_260(tmp_path):
 def test_paz_dir_is_never_collapsed(tmp_path):
     """A 4-digit PAZ dir (0036/) carries meaning — must survive intact."""
     z = _zip([("0036/data.paz", b"x"), ("0036/0.pamt", b"y")])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    # Even if the archive is (bizarrely) named "0036", the PAZ-dir guard
+    # must keep the numbered dir intact.
+    _extractall_collapsing_wrapper(z, str(tmp_path), "0036")
     assert _files(tmp_path) == ["0036/0.pamt", "0036/data.paz"]
 
 
 def test_wrapper_around_paz_dir_collapses_to_the_paz_dir(tmp_path):
-    """MyMod/0036/x -> 0036/x: the wrapper goes, the PAZ dir stays."""
+    """MyMod.zip -> MyMod/0036/x -> 0036/x: the self-named wrapper goes,
+    the PAZ dir stays."""
     z = _zip([("MyMod/0036/data.paz", b"x"), ("MyMod/0036/0.pamt", b"y")])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    _extractall_collapsing_wrapper(z, str(tmp_path), "MyMod")
     assert _files(tmp_path) == ["0036/0.pamt", "0036/data.paz"]
+
+
+def test_generic_wrapper_not_matching_archive_name_is_preserved(tmp_path):
+    """DarkUI.zip with a ui/ folder: the wrapper name (ui) != the archive
+    stem (DarkUI), so ui/ is meaningful and MUST survive — its members
+    target ui/menu.css etc. (regression: an earlier version collapsed any
+    single top-level folder and broke test_partial_patch_integration)."""
+    z = _zip([("ui/menu.css.patch", b"x"), ("ui/menu.html.patch", b"y")])
+    _extractall_collapsing_wrapper(z, str(tmp_path), "DarkUI")
+    assert _files(tmp_path) == ["ui/menu.css.patch", "ui/menu.html.patch"]
 
 
 def test_bare_top_level_file_is_unchanged(tmp_path):
     """A json already at the zip root has no wrapper to collapse."""
     z = _zip([("mod.json", b"{}")])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    _extractall_collapsing_wrapper(z, str(tmp_path), "mod")
     assert _files(tmp_path) == ["mod.json"]
 
 
 def test_multiple_top_level_dirs_are_not_collapsed(tmp_path):
     """Ambiguous shape (2+ top-level entries) extracts verbatim."""
     z = _zip([("A/x.json", b"{}"), ("B/y.json", b"{}")])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    _extractall_collapsing_wrapper(z, str(tmp_path), "pack")
     assert _files(tmp_path) == ["A/x.json", "B/y.json"]
+
+
+def test_no_archive_stem_collapses_nothing(tmp_path):
+    """Without a stem to match against, the wrapper is never stripped."""
+    z = _zip([("Mod/a.json", b"{}"), ("Mod/b.json", b"{}")])
+    _extractall_collapsing_wrapper(z, str(tmp_path))
+    assert _files(tmp_path) == ["Mod/a.json", "Mod/b.json"]
 
 
 def test_path_traversal_member_is_skipped(tmp_path):
     """A member that resolves outside dest must never be written."""
     z = _zip([("Mod/ok.json", b"{}"), ("Mod/../../evil.json", b"x")])
-    _extractall_collapsing_wrapper(z, str(tmp_path))
+    _extractall_collapsing_wrapper(z, str(tmp_path), "Mod")
     # only the safe member lands; nothing escapes tmp_path
     assert _files(tmp_path) == ["ok.json"]
     assert not (tmp_path.parent / "evil.json").exists()

--- a/tests/test_iteminfo_cd113_prefab_tail.py
+++ b/tests/test_iteminfo_cd113_prefab_tail.py
@@ -28,7 +28,10 @@ import pytest
 from tests.fixture_loaders import load_vanilla113, load_vanilla110
 
 from cdumm.engine import iteminfo_native_parser as P
-from cdumm.engine.iteminfo_writer import normalize_prefab_data_list
+from cdumm.engine.iteminfo_writer import (
+    normalize_prefab_data_list, SUPPORTED_FIELDS)
+from cdumm.engine.format3_handler import (
+    Format3Intent, LIST_WRITERS, validate_intents)
 from cdumm.semantic.parser import parse_pabgh_index
 
 
@@ -167,6 +170,50 @@ def test_edited_record_reparses_with_zero_slack(v113):
     w2 = P._Writer()
     P._write_item(w2, it2, fields=fields)
     assert bytes(w2.buf) == out, "edited record is not byte-stable"
+
+
+# ── the validation gate (Equip Everything / AXIOM QoL) ──────────────────
+
+def test_prefab_data_list_is_registered_for_validation():
+    """The writer has decoded and written prefab_data_list since #285, but
+    the field was never added to LIST_WRITERS, so validate_intents refused
+    every whole-list write with "this table doesn't have a list writer yet"
+    and Equip Everything (Nexus 2571, 13k+ dls) / AXIOM QoL (2508, 22k)
+    applied 0 of their ~2,548 intents. Pin BOTH sides so an accept always
+    implies a real write: registered for validation AND writable. (The same
+    accept/write drift hazard the #150 characterinfo comment warned about.)"""
+    assert ("iteminfo", "prefab_data_list") in LIST_WRITERS
+    assert "prefab_data_list" in SUPPORTED_FIELDS
+
+
+def test_validator_accepts_a_real_prefab_data_list_intent(v113):
+    """Build a genuine Equip-Everything-style intent from the 1.13 fixture
+    (set prefab_data_list with tribe_gender_list cleared) and prove
+    validate_intents now classifies it supported, not skipped. Before the
+    LIST_WRITERS registration this returned 0 supported / 1 skipped with the
+    "variable-length list-of-dicts ... doesn't have a list writer yet"
+    reason -- reported "ready" to the user, then wrote nothing."""
+    body, offs, starts, fields = v113
+    key = 8509
+    s = offs[key]
+    i = starts.index(s)
+    e = starts[i + 1] if i + 1 < len(starts) else len(body)
+    it = P._read_item(P._Reader(body, s, rec_end=e), fields=fields)
+
+    new = [{"prefab_names": el["prefab_names"],
+            "equip_slot_list": el["equip_slot_list"],
+            "tribe_gender_list": [],               # the mod's edit
+            "is_craft_material": 0}
+           for el in it["prefab_data_list"]]
+    intent = Format3Intent(entry=it.get("string_key") or "", key=key,
+                           field="prefab_data_list", op="set", new=new)
+
+    result = validate_intents("iteminfo.pabgb", [intent])
+    assert len(result.supported) == 1 and len(result.skipped) == 0, (
+        "prefab_data_list set must validate as supported now that the "
+        "native writer is registered; got "
+        f"{len(result.supported)} supported / {len(result.skipped)} skipped"
+        + (f" -- {result.skipped[0][1]}" if result.skipped else ""))
 
 
 # ── no collateral damage ────────────────────────────────────────────────

--- a/tests/test_notification_text_copyable_and_logged.py
+++ b/tests/test_notification_text_copyable_and_logged.py
@@ -1,0 +1,43 @@
+"""falobos76 (#191): the apply "N patches skipped" summary and other
+notification text must be recoverable — written to the app log so it lands
+in a bug report, and selectable/copyable in the notification panel.
+"""
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import Qt
+from qfluentwidgets import CaptionLabel
+
+from cdumm.gui import notifications as N
+
+
+def test_add_writes_the_notification_text_to_the_log(caplog):
+    N.store().clear()
+    with caplog.at_level(logging.INFO):
+        N.store().add("warning", "Apply finished",
+                      "12 patches skipped: iteminfo.pabgb")
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Apply finished" in text
+    assert "12 patches skipped: iteminfo.pabgb" in text
+
+
+def test_error_notification_logs_at_error_level(caplog):
+    N.store().clear()
+    with caplog.at_level(logging.DEBUG):
+        N.store().add("error", "Import failed", "path too long")
+    recs = [r for r in caplog.records if "Import failed" in r.getMessage()]
+    assert recs and recs[0].levelno == logging.ERROR
+
+
+def test_panel_row_message_is_selectable(qtbot):
+    N.store().clear()
+    N.store().add("warning", "Apply finished", "12 patches skipped")
+    panel = N.NotificationPanel()
+    qtbot.addWidget(panel)
+    panel.refresh()
+    labels = [lbl for lbl in panel.findChildren(CaptionLabel)
+              if "12 patches skipped" in lbl.text()]
+    assert labels, "message label not found in the panel"
+    flags = labels[0].textInteractionFlags()
+    assert flags & Qt.TextInteractionFlag.TextSelectableByMouse

--- a/tests/test_unix_find_culprit.py
+++ b/tests/test_unix_find_culprit.py
@@ -63,6 +63,31 @@ def test_crashpad_handler_is_not_matched(monkeypatch):
     assert gm.find_game_process() is None
 
 
+def test_finds_native_macos_steam_executable(monkeypatch):
+    # GitHub #299 (lwjiyuan): the NATIVE macOS Steam build's process is
+    # CrimsonDesert_Steam (CFBundleExecutable), not CrimsonDesert.exe.
+    # Find Culprit must detect it, or every bisection round scores a
+    # false crash and can blame an innocent mod.
+    _force_unix(monkeypatch, [_FakeProc(42, [
+        "/Users/x/Library/Application Support/Steam/steamapps/common/"
+        "Crimson Desert/CrimsonDesert_Steam.app/Contents/MacOS/"
+        "CrimsonDesert_Steam"])])
+    assert gm.find_game_process() == 42
+
+
+def test_finds_native_build_without_steam_suffix(monkeypatch):
+    _force_unix(monkeypatch, [_FakeProc(43, [
+        "/Applications/Crimson Desert.app/Contents/MacOS/CrimsonDesert"])])
+    assert gm.find_game_process() == 43
+
+
+def test_native_macos_helper_process_not_matched(monkeypatch):
+    # A differently-named sibling (e.g. a Steam helper) must not match.
+    _force_unix(monkeypatch, [_FakeProc(1, [
+        "/Users/x/.../MacOS/CrimsonDesert_SteamHelper"])])
+    assert gm.find_game_process() is None
+
+
 def test_returns_none_when_absent(monkeypatch):
     _force_unix(monkeypatch, [_FakeProc(1, ["/usr/bin/foo"])])
     assert gm.find_game_process() is None


### PR DESCRIPTION
Five self-contained fixes from my community fork, cherry-picked cleanly onto `master` (v3.6.0). Each carries its own tests. Community version/changelog bumps are intentionally excluded so nothing downgrades v3.6.0 — net diff is 6 source files + 5 test files (+525/-13).

## 1. Register `prefab_data_list` for validation — Equip Everything / AXIOM QoL apply (Refs #285)
The native writer has decoded and written `iteminfo.prefab_data_list` since the #285 decode landed, but the field was never added to `LIST_WRITERS`. So `validate_intents` refused every whole-list write ("this table doesn't have a list writer yet"), reported the mod "ready", then wrote nothing — Equip Everything (Nexus 2571) and AXIOM QoL (2508) applied **0** of their ~2,548 intents. One-line registration, plus a test that pins **both** sides (registered for validation AND writable) so an accept always implies a real write.

## 2. Long-path zip import on Windows (Refs #191)
DMM-exported zips nest the mod JSON inside a same-named ~100-char wrapper directory. On Windows without long paths enabled that overflows `MAX_PATH` (260) and import fails with ENOENT. Collapse a single top-level wrapper dir **only** when its name equals the archive stem (never a 4-digit PAZ dir), path-traversal guarded. A regression test pins that a meaningful inner folder (e.g. `ui/`) is never stripped.

## 3. Variant packs import as one switchable mod (Refs #191)
A Format-3 variant pack — 2+ JSONs sharing a name prefix and target (e.g. Fat Stacks' 8 stack sizes) — previously dead-ended with an error on the zip/extract import paths. It now imports via `import_multi_variant` as a single configurable mod with one variant enabled, matching the drag-drop picker path.

## 4. macOS Find Culprit + Apply-guard detect `CrimsonDesert_Steam` (Fixes #299)
The native macOS Steam build's process is `CrimsonDesert_Steam` (its `CFBundleExecutable`), not `CrimsonDesert.exe`. Find Culprit's bisection and the running-game Apply guard only matched the Windows name, so on macOS every bisection round scored a false crash and could blame an innocent mod. Both now match a shared `NON_WINDOWS_GAME_EXE_NAMES` set; a `CrimsonDesert_SteamHelper` sibling must **not** match.

## 5. Notification copy / log / dark-theme contrast (Refs #191)
Skipped-file notifications are now (a) written to the app log, (b) selectable/copyable, and (c) readable in dark theme — the row stylesheet was cascading a pill background behind the text.

## Verification
- 37 new/updated tests across the 5 areas, green on the v3.6.0 base.
- `prefab_data_list` table writes are byte-exact round-trip verified.
- Full suite runs in CI on this PR.