### PR TITLE
fix(import): show race/gender picker for wrapper-nested variant packs (#302)

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -4478,7 +4478,9 @@ class CdummWindow(FluentWindow):
         # picks the alphabetically-last variant and the user never sees
         # the dialog (Vaxis LoD extra-shadows vs no-extra-shadows case).
         try:
-            from cdumm.gui.preset_picker import find_folder_variants, FolderVariantDialog
+            from cdumm.gui.preset_picker import (
+                find_folder_variants, FolderVariantDialog,
+                descend_to_folder_variants)
             from cdumm.engine.import_handler import find_loose_file_variants
 
             scan_dir: Path | None = None
@@ -4660,6 +4662,17 @@ class CdummWindow(FluentWindow):
                 # loops on pathological inputs.
                 MAX_VARIANT_DEPTH = 4
                 _current = scan_dir
+                # A ZIP that nests its variant folders inside a single
+                # wrapper directory (Character Creator 837 ships 8
+                # race/gender folders under one "Character Creator/")
+                # otherwise hides them: find_folder_variants sees only the
+                # wrapper and the picker never fires (#302). Descend to the
+                # level that actually holds the variants first. No-op for
+                # non-wrapped mods (returns the path unchanged).
+                try:
+                    _current = descend_to_folder_variants(_current)
+                except Exception:
+                    pass
                 _fired_any_picker = False
                 _aborted = False
                 for _depth in range(MAX_VARIANT_DEPTH):

--- a/src/cdumm/gui/preset_picker.py
+++ b/src/cdumm/gui/preset_picker.py
@@ -195,6 +195,38 @@ def has_structural_folder_variants(path: Path, max_depth: int = 4) -> bool:
     return False
 
 
+def descend_to_folder_variants(path: Path, max_depth: int = 4) -> Path:
+    """Return the directory that actually holds 2+ variant subfolders,
+    descending single wrapper directories on the way.
+
+    A ZIP that wraps everything in one ``Character Creator/`` directory
+    otherwise hides its race/gender variant folders: the import picker
+    calls ``find_folder_variants`` on the extraction root, sees only the
+    lone wrapper (``find_folder_variants`` doesn't descend), and never
+    offers the choice (#302, mod 837). This mirrors
+    ``has_structural_folder_variants``' descent but yields the path so
+    the caller can run its picker there. Returns ``path`` unchanged when
+    no wrapped variant level exists, so non-wrapped mods are unaffected.
+    """
+    import re
+    probe = path
+    for _ in range(max_depth):
+        if not probe.is_dir():
+            break
+        if len(find_folder_variants(probe)) >= 2:
+            return probe
+        subs = [
+            d for d in probe.iterdir()
+            if d.is_dir() and not d.name.startswith(('.', '_'))
+            and not re.match(r'^\d{4}$', d.name)
+            and d.name.lower() != 'meta'
+        ]
+        if len(subs) != 1:
+            break
+        probe = subs[0]  # descend the single wrapper folder and retry
+    return path
+
+
 def folder_variant_game_files(folders: list[Path]) -> dict[Path, set[str]]:
     """For each folder, collect the set of game_file targets its JSONs
     declare. Used by the picker to decide whether the folders behave

--- a/tests/test_folder_variant_wrapper_descent.py
+++ b/tests/test_folder_variant_wrapper_descent.py
@@ -1,0 +1,83 @@
+"""Wrapper-nested folder variants must still fire the import picker (#302).
+
+Character Creator (Nexus 837) ships its 8 race/gender variant folders
+inside a single ``Character Creator/`` wrapper directory, alongside a few
+shared loose files (a ``.field.json`` animation module, an ``.asi``,
+``mod.json``). ``find_folder_variants`` only inspects the level it is
+given, so on the extraction root it saw the lone wrapper and returned 0 --
+the import variant loop then broke immediately and the race/gender picker
+never appeared (@lurkser on #302). ``descend_to_folder_variants`` walks
+single wrapper dirs down to the level that actually holds the variants.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cdumm.gui.preset_picker import (
+    find_folder_variants, descend_to_folder_variants,
+)
+
+
+def _variant(folder: Path, name: str) -> None:
+    d = folder / name / "0009"
+    d.mkdir(parents=True)
+    (d / "0.paz").write_bytes(b"\x00" * 16)
+
+
+def _cc_pack(root: Path) -> Path:
+    """The Character Creator shape: one wrapper dir with 8 race/gender
+    variant folders plus shared loose files. The wrapper name is NOT the
+    archive stem, so the long-path wrapper-collapse (#191) does not fire."""
+    wrap = root / "Character Creator"
+    wrap.mkdir(parents=True)
+    for race in ("Human Female", "Human Male", "Orc Female", "Orc Male",
+                 "Goblin Female", "Goblin Male", "Dwarf Female", "Dwarf Male"):
+        _variant(wrap, race)
+    (wrap / "mod.json").write_text('{"title": "Character Creator"}')
+    (wrap / "Female Animations.field.json").write_text(
+        '{"format": 3, "intents": []}')
+    (wrap / "CharacterCreatorHead.asi").write_bytes(b"MZ")
+    return wrap
+
+
+def test_wrapped_variants_are_hidden_at_the_extraction_root(tmp_path):
+    """The bug: the extraction root shows only the wrapper, so the picker
+    detector finds no variants and the loop breaks before offering one."""
+    _cc_pack(tmp_path)
+    assert len(find_folder_variants(tmp_path)) < 2
+
+
+def test_descend_reaches_the_variant_level(tmp_path):
+    wrap = _cc_pack(tmp_path)
+    reached = descend_to_folder_variants(tmp_path)
+    assert reached == wrap, "did not descend the single wrapper folder"
+    assert len(find_folder_variants(reached)) == 8, (
+        "all 8 race/gender variants must be visible at the descended level")
+
+
+def test_descend_is_a_noop_when_variants_sit_at_the_passed_level(tmp_path):
+    """A pack whose variants are already at the passed level is returned
+    unchanged -- no over-descending into one of the variants."""
+    _variant(tmp_path, "VariantA")
+    _variant(tmp_path, "VariantB")
+    assert descend_to_folder_variants(tmp_path) == tmp_path
+    assert len(find_folder_variants(tmp_path)) == 2
+
+
+def test_descend_is_a_noop_for_a_plain_single_folder_mod(tmp_path):
+    """A normal mod that is just one folder of game files (no sibling
+    variants) must not be descended into and mis-offered as a picker."""
+    d = tmp_path / "SomeMod" / "0009"
+    d.mkdir(parents=True)
+    (d / "0.paz").write_bytes(b"\x00" * 16)
+    assert descend_to_folder_variants(tmp_path) == tmp_path
+    assert len(find_folder_variants(tmp_path)) < 2
+
+
+def test_descend_stops_at_numbered_paz_dirs(tmp_path):
+    """The variant folders themselves contain NNNN game-data dirs; the
+    descent must not treat those as a wrapper to walk into."""
+    wrap = _cc_pack(tmp_path)
+    # Descending from the wrapper returns the wrapper (variants are here),
+    # never one of the race folders or its 0009/ data dir.
+    assert descend_to_folder_variants(wrap) == wrap


### PR DESCRIPTION
@lurkser reported on #302 that Character Creator 7.6 stopped showing the race/gender picker on zip import. Reproduced and fixed.

### Cause
The 7.6 archive nests its **8 race/gender variant folders** (`Human Female`, `Orc Male`, …) inside a single `Character Creator/` wrapper directory, alongside shared loose files (the `Female Animations.field.json` animation module, a `.asi`, `mod.json`). The import variant loop calls `find_folder_variants()` on the **extraction root** — but that function only inspects the level it's handed, so it saw the lone wrapper, returned 0, and broke before offering a picker. The archive then imported as a single mod and the user could never choose their race/gender.

Measured on the real 7.6 archive:
```
find_folder_variants(root)                 -> 0     (only sees the wrapper)
find_folder_variants(root/"Character Creator") -> 8 (the variants are one level down)
```

### Fix
Add `descend_to_folder_variants()` — a path-returning sibling of the existing `has_structural_folder_variants()` (added for the same race/gender case in #190) — that walks single wrapper directories down to the level that actually holds 2+ variant folders. The import loop descends to that level before offering the picker.

- **No-op** for non-wrapped mods and for packs whose variants already sit at the passed level (returns the path unchanged), so nothing else changes.
- Doesn't treat `NNNN`/`meta` game-data dirs as wrappers.

### Verification
- Real 7.6 archive: `descend_to_folder_variants(root)` reaches the wrapper where all 8 variants are visible.
- 5 new tests on a synthetic Character-Creator-shaped fixture (bug repro at root, descent reaches the 8, no-op cases, NNNN-dir guard). ruff clean.

Refs #302. Independent of #305 (that's the characterinfo writer; this is GUI import) and of #303/#304 — no shared files.