### PR TITLE
Add coverage scanner: find Format-3 intents CDUMM can't apply yet (Refs #285)

### DIFF
--- a/scripts/coverage_scan.py
+++ b/scripts/coverage_scan.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Coverage scanner: which Format-3 mod intents can CDUMM not apply yet?
+
+Runs every intent of every Format-3 mod under the given paths through
+``validate_intents`` -- the exact classifier the import path uses -- and
+reports the intents it *skips*, grouped by ``(table, field)`` with the
+engine's own reason.
+
+Crucially this needs **no game install**: ``validate_intents`` decides
+coverage from the shipped ``schemas/pabgb_complete_schema.json`` +
+``field_schema/`` + the registered ``LIST_WRITERS``. So it can run in CI
+over a corpus of top mods and surface a new gap the moment a game patch or
+a new mod introduces one -- finding gaps before users report them, which
+is exactly what the #285 gap scan did by hand.
+
+Usage::
+
+    python scripts/coverage_scan.py <dir-or-file> [more paths ...]
+
+Every ``*.json`` / ``*.field.json`` under each directory is scanned; files
+that aren't Format-3 mods (PAZ ``modinfo.json``, v2 byte-patches, etc.) are
+skipped silently. The exit code is the number of distinct ``(table, field)``
+gaps found (0 = everything covered), so CI can gate on it.
+"""
+from __future__ import annotations
+
+import collections
+import re
+import sys
+from pathlib import Path
+
+# Allow running straight from a checkout without an editable install.
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from cdumm.engine.format3_handler import (  # noqa: E402
+    parse_format3_mod_targets, validate_intents, _table_name_from_target,
+)
+
+Gap = collections.namedtuple("Gap", "table field reason mod")
+
+
+def _base_field(field: str) -> str:
+    """Strip list indices / nested paths: ``entries[0].etl_hashes`` -> ``entries``."""
+    return re.split(r"[.\[]", field, maxsplit=1)[0]
+
+
+def scan_file(path: Path) -> list[Gap]:
+    """Return one Gap per skipped intent in a single Format-3 mod file.
+
+    Returns [] for anything that isn't a parseable Format-3 mod.
+    """
+    try:
+        pairs = parse_format3_mod_targets(path)
+    except Exception:
+        return []  # not a Format-3 mod (PAZ metadata, v2 patch, malformed)
+    gaps: list[Gap] = []
+    for target, intents in pairs:
+        try:
+            result = validate_intents(target, intents)
+        except Exception:
+            continue
+        table = _table_name_from_target(target)
+        for intent, reason in result.skipped:
+            gaps.append(Gap(table, _base_field(intent.field), reason, path.name))
+    return gaps
+
+
+def iter_mod_files(paths: list[str]):
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file():
+            yield p
+        elif p.is_dir():
+            yield from sorted(p.rglob("*.json"))
+
+
+def scan(paths: list[str]) -> list[Gap]:
+    gaps: list[Gap] = []
+    for f in iter_mod_files(paths):
+        gaps.extend(scan_file(f))
+    return gaps
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(__doc__)
+        return 2
+
+    gaps = scan(paths)
+    by_key: collections.Counter = collections.Counter()
+    mods: dict[tuple[str, str], set[str]] = collections.defaultdict(set)
+    reason: dict[tuple[str, str], str] = {}
+    for g in gaps:
+        key = (g.table, g.field)
+        by_key[key] += 1
+        mods[key].add(g.mod)
+        reason.setdefault(key, g.reason)
+
+    if not by_key:
+        print("No uncovered Format-3 intents found across the scanned mods.")
+        return 0
+
+    print("Uncovered (table.field): intents  mods")
+    print("-" * 60)
+    for (table, field), n in by_key.most_common():
+        ms = ", ".join(sorted(mods[(table, field)])[:5])
+        print(f"  {table}.{field}: {n}  [{ms}]")
+        print(f"      reason: {reason[(table, field)]}")
+    return len(by_key)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_coverage_scan.py
+++ b/tests/test_coverage_scan.py
@@ -36,10 +36,17 @@ def _write(p: Path, target: str, field, new, op: str = "set") -> None:
 
 
 def test_unsupported_op_is_reported(tmp_path):
-    # op=scale isn't implemented yet (#71); the field itself is real+covered,
-    # so the ONLY reason this skips is the op -> a genuine surfaced gap.
-    _write(tmp_path / "scale.field.json", "buffinfo.pabgb", "min_level", 2,
-           op="scale")
+    # op=scale isn't applied yet (#71), so validate_intents skips it -> a
+    # genuine surfaced gap. The intent carries BOTH 'new' and 'factor' so the
+    # file parses regardless of the scale-parsing rules: plain master requires
+    # 'new', while the DMM scale-tolerance change (#304) requires 'factor'.
+    # With both present it's well-formed either way, keeping this test green on
+    # master and on any branch that also merges #304.
+    (tmp_path / "scale.field.json").write_text(json.dumps({
+        "format": 3, "target": "buffinfo.pabgb",
+        "intents": [{"entry": "", "key": 1, "field": "min_level",
+                     "op": "scale", "new": 2, "factor": 2}],
+    }))
     gaps = coverage_scan.scan([str(tmp_path)])
     assert ("buffinfo", "min_level") in {(g.table, g.field) for g in gaps}
     assert any("scale" in g.reason for g in gaps), gaps

--- a/tests/test_coverage_scan.py
+++ b/tests/test_coverage_scan.py
@@ -1,0 +1,79 @@
+"""scripts/coverage_scan.py surfaces the Format-3 intents CDUMM can't apply.
+
+It runs every intent through the real ``validate_intents`` classifier, so a
+covered field reports no gap while an uncovered one does -- and it needs no
+game install (coverage is decided from the shipped schema + field_schema +
+registered LIST_WRITERS). These tests pin both directions, using two kinds of
+real gap the classifier skips today:
+
+* an **unsupported op** (``scale``) on a real, covered field (#71); and
+* an **unmodelled table** (``gimmickinfo`` -- no schema, no writer).
+
+and a covered field (``buffinfo.min_level``) that must stay silent. This keeps
+the scanner from silently starting to mis-report either way. Note: the #190
+``equipslotinfo.entries[].etl_hashes`` writer means equipslotinfo is *covered*,
+so it deliberately is not used here as an "uncovered" example.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+# The scanner lives in scripts/, not the installed package, so load it by path.
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "coverage_scan.py"
+_spec = importlib.util.spec_from_file_location("coverage_scan", _SCRIPT)
+coverage_scan = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(coverage_scan)
+
+
+def _write(p: Path, target: str, field, new, op: str = "set") -> None:
+    p.write_text(json.dumps({
+        "format": 3, "target": target,
+        "intents": [{"entry": "", "key": 1, "field": field,
+                     "op": op, "new": new}],
+    }))
+
+
+def test_unsupported_op_is_reported(tmp_path):
+    # op=scale isn't implemented yet (#71); the field itself is real+covered,
+    # so the ONLY reason this skips is the op -> a genuine surfaced gap.
+    _write(tmp_path / "scale.field.json", "buffinfo.pabgb", "min_level", 2,
+           op="scale")
+    gaps = coverage_scan.scan([str(tmp_path)])
+    assert ("buffinfo", "min_level") in {(g.table, g.field) for g in gaps}
+    assert any("scale" in g.reason for g in gaps), gaps
+
+
+def test_unmodelled_table_is_reported(tmp_path):
+    # gimmickinfo has no schema, no field_schema, and no LIST_WRITER -> gap.
+    _write(tmp_path / "gim.field.json", "gimmickinfo.pabgb", "some_field", 1)
+    gaps = coverage_scan.scan([str(tmp_path)])
+    assert ("gimmickinfo", "some_field") in {(g.table, g.field) for g in gaps}
+
+
+def test_covered_field_is_not_reported(tmp_path):
+    # buffinfo.min_level with op=set is a plain schema field -> supported.
+    _write(tmp_path / "buff.field.json", "buffinfo.pabgb", "min_level", 1)
+    gaps = coverage_scan.scan([str(tmp_path)])
+    assert all(g.table != "buffinfo" for g in gaps), (
+        f"a covered field was wrongly reported as a gap: {gaps}")
+
+
+def test_mixed_corpus_reports_only_the_gap(tmp_path):
+    _write(tmp_path / "buff.field.json", "buffinfo.pabgb", "min_level", 1)
+    _write(tmp_path / "gim.field.json", "gimmickinfo.pabgb", "some_field", 1)
+    tables = {g.table for g in coverage_scan.scan([str(tmp_path)])}
+    assert "gimmickinfo" in tables and "buffinfo" not in tables
+
+
+def test_non_format3_files_are_skipped(tmp_path):
+    # A PAZ modinfo.json (or any non-Format-3 JSON) must not crash or count.
+    (tmp_path / "modinfo.json").write_text('{"name": "x", "version": "1"}')
+    assert coverage_scan.scan([str(tmp_path)]) == []
+
+
+def test_base_field_strips_indices_and_paths():
+    assert coverage_scan._base_field("entries[0].etl_hashes") == "entries"
+    assert coverage_scan._base_field("prefab_data_list") == "prefab_data_list"
+    assert coverage_scan._base_field("upper_chart.group_lookup") == "upper_chart"


### PR DESCRIPTION
## What

Adds `scripts/coverage_scan.py` — a reusable **coverage scanner** that answers "which Format-3 mod intents can CDUMM not apply yet?" without needing a game install.

It runs every intent of every Format-3 mod under the given paths through the real `validate_intents` classifier — the exact one the import path uses — and reports the intents it **skips**, grouped by `(table, field)` with the engine's own reason string:

```
Uncovered (table.field): intents  mods
------------------------------------------------------------
  buffinfo.min_level: 1  [scale.field.json]
      reason: intent uses unknown op 'scale'; CDUMM only supports 'set'. ...
```

## Why

Coverage is decided from the shipped `schemas/pabgb_complete_schema.json` + `field_schema/` + the registered `LIST_WRITERS` — **no game table required**. So this can run in CI over a corpus of top mods and surface a new gap the moment a game patch or a new mod introduces one — finding gaps before users report them. That's exactly the by-hand gap scan #285 did; this makes it repeatable and gate-able (exit code = number of distinct `(table, field)` gaps).

Usage:

```
python scripts/coverage_scan.py <dir-or-file> [more paths ...]
```

Files that aren't Format-3 mods (PAZ `modinfo.json`, v2 byte-patches, malformed JSON) are skipped silently.

## Tests

`tests/test_coverage_scan.py` pins both directions using real gaps the classifier skips **today**:
- an unsupported op (`scale`, #71) on a real *covered* field — the only reason it skips is the op;
- an unmodelled table (`gimmickinfo` — no schema, no writer);

and a covered field (`buffinfo.min_level`) that must stay silent. This keeps the scanner from silently starting to mis-report either way. (Deliberately does *not* use `equipslotinfo.entries[].etl_hashes` as an "uncovered" example — the #190 writer means it's actually covered, which this tool correctly reports.)

Refs #285