### PR TITLE
Block Apply after a mid-session game update (live fingerprint re-check) (Fixes #307)

### DIFF
--- a/src/cdumm/gui/apply_watchdog.py
+++ b/src/cdumm/gui/apply_watchdog.py
@@ -82,6 +82,39 @@ def is_apply_blocked_by_stale_snapshot(startup_context) -> bool:
     return bool(startup_context.get("game_updated"))
 
 
+def is_apply_blocked_by_live_game_change(
+    *, current_fingerprint: str | None, snapshot_fingerprint: str | None
+) -> bool:
+    """Return True iff the *live* game version fingerprint no longer
+    matches the one the vanilla snapshot was captured against.
+
+    :func:`is_apply_blocked_by_stale_snapshot` only reads the one-shot
+    ``game_updated`` flag that ``main.py`` computes at launch. A Steam
+    auto-update (or a file verify) that lands *while CDUMM is already
+    open* is therefore invisible to it: the flag stays False, Apply is
+    not blocked, and the user patches onto a stale vanilla baseline —
+    which is exactly the crash-on-launch reported in GitHub #307
+    (game exe modified 18:57, after the 17:51 snapshot, then applied).
+
+    Re-computing the fingerprint at apply time closes that window. The
+    caller passes ``current_fingerprint`` from
+    :func:`cdumm.engine.version_detector.detect_game_version` (the same
+    detector the bug report and the startup path use) and
+    ``snapshot_fingerprint`` from the stored ``game_version_fingerprint``
+    config value.
+
+    Returns False whenever either fingerprint is unknown, so a detection
+    gap can never *block* a legitimate apply (no false positives). The
+    missing-snapshot case is owned by the separate rescan-required gate,
+    and applying/reverting mods never changes the fingerprint (it is
+    derived only from the Steam build id + game exe, never from staged
+    PAZ/PAMT files), so a clean apply is never mistaken for an update.
+    """
+    if not current_fingerprint or not snapshot_fingerprint:
+        return False
+    return current_fingerprint != snapshot_fingerprint
+
+
 def is_apply_stalled(*, now: float, last_progress_ts: float,
                      threshold_s: float) -> bool:
     """Return True iff ``now - last_progress_ts`` strictly exceeds

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -6197,9 +6197,34 @@ class CdummWindow(FluentWindow):
         # the wrong bytes because our vanilla baseline no longer
         # matches the live game.
         from cdumm.gui.apply_watchdog import (
+            is_apply_blocked_by_live_game_change,
             is_apply_blocked_by_stale_snapshot,
         )
-        if is_apply_blocked_by_stale_snapshot(self._startup_context):
+        stale = is_apply_blocked_by_stale_snapshot(self._startup_context)
+        if not stale and self._game_dir:
+            # The startup game_updated flag is a one-shot computed at
+            # launch, so a Steam auto-update that lands mid-session
+            # slips past it and the user patches onto a stale vanilla
+            # baseline (crash on next launch, GitHub #307). Re-check the
+            # live game fingerprint against the snapshot's here, using
+            # the same detector the bug report and startup path use.
+            try:
+                from cdumm.engine.version_detector import detect_game_version
+                from cdumm.storage.config import Config
+                live_fp = detect_game_version(self._game_dir)
+                snap_fp = (Config(self._db).get("game_version_fingerprint")
+                           if self._db else None)
+                if is_apply_blocked_by_live_game_change(
+                        current_fingerprint=live_fp,
+                        snapshot_fingerprint=snap_fp):
+                    stale = True
+                    logger.info(
+                        "Apply blocked: live game fingerprint %s != "
+                        "snapshot %s (mid-session game update, #307)",
+                        live_fp, snap_fp)
+            except Exception as e:
+                logger.debug("live game-change apply check failed: %s", e)
+        if stale:
             InfoBar.error(
                 title=tr("apply.rescan_required_title"),
                 content=tr("apply.rescan_required_body"),

--- a/tests/test_apply_blocked_by_stale_snapshot.py
+++ b/tests/test_apply_blocked_by_stale_snapshot.py
@@ -117,3 +117,81 @@ def test_check_game_updated_surfaces_sticky_banner_on_decline():
         "when user declines the rescan prompt, _check_game_updated "
         "must show a sticky InfoBar explaining apply is now locked "
         "(not just silently close the dialog)")
+
+
+# ── Live-fingerprint gate (mid-session game update, #307) ─────────────
+#
+# The startup game_updated flag is a one-shot computed in main.py at
+# launch. A Steam auto-update that lands *while CDUMM is already open*
+# leaves the flag False, so the stale-snapshot gate above passes and
+# the user patches onto a stale vanilla baseline (crash on next launch,
+# GitHub #307). _on_apply must therefore ALSO re-check the live game
+# fingerprint against the snapshot's.
+
+def test_live_helper_exists():
+    from cdumm.gui import apply_watchdog
+    assert hasattr(apply_watchdog, "is_apply_blocked_by_live_game_change")
+
+
+def test_live_helper_blocks_on_fingerprint_mismatch():
+    """A mid-session Steam update changes the live fingerprint; against
+    a known, differing snapshot fingerprint, apply must be blocked."""
+    from cdumm.gui.apply_watchdog import is_apply_blocked_by_live_game_change
+    assert is_apply_blocked_by_live_game_change(
+        current_fingerprint="aaaa1111", snapshot_fingerprint="bbbb2222"
+    ) is True
+
+
+def test_live_helper_allows_on_fingerprint_match():
+    """A clean apply/revert never changes the exe fingerprint, so a
+    matching pair must NOT be treated as an update (no false positive)."""
+    from cdumm.gui.apply_watchdog import is_apply_blocked_by_live_game_change
+    assert is_apply_blocked_by_live_game_change(
+        current_fingerprint="aaaa1111", snapshot_fingerprint="aaaa1111"
+    ) is False
+
+
+def test_live_helper_no_false_positive_when_live_unknown():
+    """detect_game_version returned None (Xbox/custom install, missing
+    exe): a detection gap must never block a legitimate apply."""
+    from cdumm.gui.apply_watchdog import is_apply_blocked_by_live_game_change
+    assert is_apply_blocked_by_live_game_change(
+        current_fingerprint=None, snapshot_fingerprint="aaaa1111"
+    ) is False
+
+
+def test_live_helper_no_block_when_no_snapshot_fingerprint():
+    """No stored snapshot fingerprint -> the separate missing-snapshot
+    gate owns that case; this helper must stay out of it."""
+    from cdumm.gui.apply_watchdog import is_apply_blocked_by_live_game_change
+    assert is_apply_blocked_by_live_game_change(
+        current_fingerprint="aaaa1111", snapshot_fingerprint=None
+    ) is False
+
+
+def test_live_helper_both_none_is_false():
+    from cdumm.gui.apply_watchdog import is_apply_blocked_by_live_game_change
+    assert is_apply_blocked_by_live_game_change(
+        current_fingerprint=None, snapshot_fingerprint=None
+    ) is False
+
+
+def test_on_apply_gates_on_live_game_change():
+    """_on_apply must ALSO re-check the live game fingerprint (not just
+    the one-shot startup flag) before _run_qprocess, so a mid-session
+    Steam update is caught (#307)."""
+    src = _fluent_src()
+    anchor = src.find("def _on_apply(self)")
+    assert anchor != -1
+    next_def = src.find("\n    def ", anchor + 20)
+    body = src[anchor:next_def if next_def != -1 else anchor + 4000]
+    assert "is_apply_blocked_by_live_game_change" in body, (
+        "_on_apply must re-check the live game fingerprint so a "
+        "mid-session game update blocks apply (#307)")
+    assert "detect_game_version" in body, (
+        "the live re-check must use detect_game_version (the same "
+        "detector the bug report and startup path use)")
+    gate_idx = body.find("is_apply_blocked_by_live_game_change")
+    run_idx = body.find("_run_qprocess(")
+    assert gate_idx != -1 and run_idx != -1 and gate_idx < run_idx, (
+        "the live game-change gate must be checked BEFORE _run_qprocess")


### PR DESCRIPTION
## What

Closes the window where **Apply runs against a stale vanilla baseline after a mid-session game update**, which patches mods onto the wrong bytes and crashes the game on next launch (GitHub #307, lupo1190 with Fat Stacks).

## Root cause

The apply gate only consulted `startup_context["game_updated"]` via `is_apply_blocked_by_stale_snapshot`. That flag is a **one-shot** computed by `main.py` at launch. If Steam auto-updates the game (or the user verifies files) **while CDUMM is already open**, the flag stays `False`, the gate passes, and Apply lands on a stale baseline.

The #307 report shows the exact timeline: game exe modified **18:57**, *after* the snapshot at **17:51**, then Apply at **20:05** — all in one session, so the startup flag never saw the update.

## Fix

`_on_apply` now, when the startup flag is clean, **re-computes the live game fingerprint** and compares it to the stored snapshot fingerprint:

- `detect_game_version(game_dir)` — the *same* detector the bug report and the startup path already use (Steam build id + fast exe hash, LRU-cached, ~1 ms).
- vs. `Config(db).get("game_version_fingerprint")` — the value stamped when the snapshot was taken.

On mismatch, Apply is blocked with the existing `apply.rescan_required_body` banner.

New pure helper `is_apply_blocked_by_live_game_change(current_fingerprint, snapshot_fingerprint)` in `apply_watchdog.py` holds the comparison so it's unit-testable without Qt.

### Why it can't false-positive
- Returns `False` whenever **either** fingerprint is unknown (Xbox/custom install, no snapshot yet) — a detection gap never *blocks* a legit apply; the missing-snapshot case stays owned by the separate rescan gate.
- The fingerprint is derived **only** from the Steam build id + game exe, never from staged PAZ/PAMT files, so a normal apply/revert never changes it — a clean apply is never mistaken for an update.
- The live check is wrapped in `try/except`, falling back to the prior startup-flag behaviour on any error.

## Tests

`tests/test_apply_blocked_by_stale_snapshot.py` gains 7 tests: the pure helper in all four directions (mismatch → blocked; match → allowed; either fingerprint `None` → allowed), plus a source-inspection guard that `_on_apply` calls `is_apply_blocked_by_live_game_change` (using `detect_game_version`) **before** `_run_qprocess`.

Verified locally: 24 apply-gate tests pass; **full fast suite 2377 passed, 46 skipped, 0 failed**.

Fixes #307