### PR TITLE
buffinfo: name the intents the item walk couldn't place (Ultra Hard Mode reported success, wrote nothing)

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import logging
 import struct
 from pathlib import Path
-from typing import Callable
+from typing import Callable, NamedTuple
 
 # The writer's field-name resolver, shared on purpose: a `match` key must
 # accept exactly the spellings a `field` key accepts, and copying the rule
@@ -1455,8 +1455,23 @@ def _intents_to_v2_changes(
     # Route buffinfo through the clean-room buffinfo parser instead,
     # which knows the actual on-disk layout.
     if table_name == "buffinfo":
-        return _buffinfo_intents_to_changes(
-            vanilla_body, vanilla_header, intents)
+        unresolved: list[BuffinfoUnresolved] = []
+        changes = _buffinfo_intents_to_changes(
+            vanilla_body, vanilla_header, intents, unresolved)
+        if unresolved:
+            # Say WHICH fields couldn't be placed. The caller's fallback
+            # message ("the targeted entry may not exist in this game
+            # version") is wrong for this case -- the entry exists, the
+            # item walk just stalls inside it -- and it sends mod authors
+            # chasing a version mismatch that isn't there.
+            logger.warning(
+                "Format 3 buffinfo: %d intent(s) could not be placed "
+                "because the item walk stalls inside the record; the "
+                "entry exists but that item's variant body isn't "
+                "decoded yet. Unplaced: %s",
+                len(unresolved),
+                ", ".join(f"{u.key}.{u.field}" for u in unresolved[:8]))
+        return changes
 
     # characterinfo.pabgb has a CDUMM PABGB schema, but it is a
     # positional name-less decompiled structure, so the generic walker
@@ -2002,9 +2017,17 @@ _BUFFINFO_DTYPE_PACK = {
 }
 
 
+class BuffinfoUnresolved(NamedTuple):
+    """One buffinfo intent the item walk could not reach."""
+    field: str
+    entry: str
+    key: int
+
+
 def _buffinfo_intents_to_changes(
     vanilla_body: bytes, vanilla_header: bytes,
     intents: list[Format3Intent],
+    unresolved_out: list[BuffinfoUnresolved] | None = None,
 ) -> list[dict]:
     """Resolve buffinfo intents through the clean-room buffinfo parser.
 
@@ -2016,9 +2039,21 @@ def _buffinfo_intents_to_changes(
 
     Intents whose key isn't in PABGH, whose field path isn't yet
     resolvable (e.g. items past an unknown variant), or whose new
-    value doesn't fit the declared width, are silently dropped , the
-    same shape the v2 aggregator uses. The expand_format3 caller
-    surfaces "0 byte changes" warnings for whole-mod dropouts.
+    value doesn't fit the declared width, are dropped , the same shape
+    the v2 aggregator uses.
+
+    ``unresolved_out``, when given, collects the intents whose path the
+    item walk could not reach. Resolvability is **per record**, not per
+    path shape: the same ``buff_data_list[N].data.variant.body.f01``
+    resolves on most entries but stalls at item 0 of
+    ``BuffLevel_Difficulty_Boss`` (Ultra Hard Mode), where the walk
+    can't get past that item's variant body. The validator therefore
+    cannot pre-screen these by name -- it has no table bytes -- so
+    without this list the caller only knew "0 byte changes" and told
+    the user their entry might not exist in this game version, which is
+    wrong and unactionable. See GitHub #190-era equipslotinfo for the
+    same lesson: never report success, or a misleading failure, for a
+    write we couldn't place.
     """
     from cdumm._vendor.buffinfo_parser import locate_buff_field
 
@@ -2063,6 +2098,9 @@ def _buffinfo_intents_to_changes(
                 located = hit
                 break
         if located is None:
+            if unresolved_out is not None:
+                unresolved_out.append(BuffinfoUnresolved(
+                    intent.field, intent.entry, intent.key))
             continue
         rel_in_entry, width, dtype = located
         if dtype == "cstring":

--- a/tests/test_buffinfo_unresolved_reporting.py
+++ b/tests/test_buffinfo_unresolved_reporting.py
@@ -1,0 +1,96 @@
+"""buffinfo intents the item walk can't place must be REPORTED.
+
+Ultra Hard Mode (Nexus 2295) sets
+``buff_data_list[N].data.variant.body.f01`` on
+``BuffLevel_Difficulty_Boss``. CDUMM validated all 5 intents as
+supported, wrote **zero bytes**, and the only user-facing message was
+the generic "the targeted entry may not exist in this game version" --
+which is false. The entry exists; the buffinfo item walk stalls inside
+it, at item 0's variant body.
+
+Why the validator can't screen these out by name: resolvability is
+**per record**, not per path shape. The exact same path resolves fine
+on most buffinfo entries (measured across the corpus: it resolves on
+entries used by 46 other mod intents) and stalls only on this one. The
+validator has no table bytes, so the honest place to report is the
+apply layer, which does.
+
+This module pins that ``_buffinfo_intents_to_changes`` hands back the
+intents it dropped, so the caller can name them instead of guessing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from cdumm.engine.format3_apply import (
+    BuffinfoUnresolved,
+    _buffinfo_intents_to_changes,
+)
+
+
+@dataclass
+class _Intent:
+    entry: str
+    key: int
+    field: str
+    op: str
+    new: Any
+
+
+def test_unresolved_out_is_optional():
+    """Existing callers pass three args; that must keep working."""
+    changes = _buffinfo_intents_to_changes(b"", b"", [])
+    assert changes == []
+
+
+def test_unplaceable_intent_is_reported_not_swallowed():
+    """A key that isn't even in the (empty) PABGH must not crash, and
+    with no index there is nothing to report."""
+    out: list[BuffinfoUnresolved] = []
+    changes = _buffinfo_intents_to_changes(
+        b"", b"", [_Intent("X", 1, "buff_data_list[9].data.variant."
+                           "body.f01", "set", 1)], out)
+    assert changes == []
+
+
+def test_namedtuple_carries_field_entry_and_key():
+    u = BuffinfoUnresolved("buff_data_list[4].data.variant.body.f01",
+                           "BuffLevel_Difficulty_Boss", 1000277)
+    assert u.field.endswith(".f01")
+    assert u.entry == "BuffLevel_Difficulty_Boss"
+    assert u.key == 1000277
+
+
+def test_apply_layer_names_the_unplaced_fields(caplog):
+    """The warning must name the fields, and must NOT claim the entry
+    is missing -- that was the misleading message this replaces."""
+    import logging
+
+    from cdumm.engine import format3_apply
+
+    calls: list = []
+
+    def _fake(body, header, intents, unresolved_out=None):
+        if unresolved_out is not None:
+            unresolved_out.append(BuffinfoUnresolved(
+                "buff_data_list[4].data.variant.body.f01",
+                "BuffLevel_Difficulty_Boss", 1000277))
+        calls.append(True)
+        return []
+
+    orig = format3_apply._buffinfo_intents_to_changes
+    format3_apply._buffinfo_intents_to_changes = _fake
+    try:
+        with caplog.at_level(logging.WARNING,
+                             logger="cdumm.engine.format3_apply"):
+            format3_apply._intents_to_v2_changes(
+                "buffinfo.pabgb", b"", b"", [])
+    finally:
+        format3_apply._buffinfo_intents_to_changes = orig
+
+    assert calls, "buffinfo route did not run"
+    text = caplog.text
+    assert "buff_data_list[4].data.variant.body.f01" in text
+    assert "1000277" in text
+    assert "may not exist" not in text


### PR DESCRIPTION
## The bug

**Ultra Hard Mode (Nexus 2295) validates 5 intents as supported, writes zero bytes, and tells the user their game version is wrong.**

It sets `buff_data_list[N].data.variant.body.f01` on `BuffLevel_Difficulty_Boss` (key 1000277). `validate_intents` returns `supported=5 skipped=0`, `_buffinfo_intents_to_changes` returns `[]`, and the only user-facing message is the generic fallback:

> Format 3 mod(s) produced 0 byte changes for 'buffinfo.pabgb'. The targeted entry may not exist in this game version.

That's false. The entry exists — 1537 bytes — and the walk resolves inside it fine:

```
buff_data_list[0].absent_flag      -> (42, 1, 'u8')
buff_data_list[0].data.base.tag    -> (43, 1, 'u8')
buff_data_list[0].data.base.id     -> (44, 4, 'u32')
buff_data_list[0].data.variant.body.f01 -> None      <- stalls here
buff_data_list[1].absent_flag      -> None           <- and everything after
```

The walk can't get past item 0's variant body, so every later item is unreachable. Telling a mod author to check their game version sends them after a mismatch that doesn't exist.

## The fix

`_buffinfo_intents_to_changes` takes an optional `unresolved_out` list and hands back the intents it dropped. The caller logs the actual fields and keys:

```
Format 3 buffinfo: 5 intent(s) could not be placed because the item walk
stalls inside the record; the entry exists but that item's variant body
isn't decoded yet. Unplaced: 1000277.buff_data_list[4].data.variant.body.f01, ...
```

**This does not make Ultra Hard apply.** That needs the variant body decoded, which is a separate job. It stops CDUMM reporting a success it didn't deliver — the same bar the equipslotinfo writer is held to.

## Why not fix it in the validator

Because resolvability here is **per record, not per path shape**, and the validator has no table bytes.

Measured across a 232-mod Nexus corpus, the *exact same* path `buff_data_list[N].data.variant.body.f01` resolves on the entries used by **46 other mod intents** and stalls only on this one. A name-based screen in `format3_handler` would therefore either reject mods that currently work, or keep passing this one. The apply layer is the only place that knows.

(That's why `format3_handler`'s blanket early-accept of `buff_data_list[` at L1364 isn't wrong either — its comment says "the apply helper drops intents that don't actually resolve, so a typo produces a clean 0-byte-changes warning". The premise was right; the warning just wasn't clean.)

## How it was found

A category-wide sweep of the Nexus corpus through the **real** apply path (`expand_format3_into_aggregated`, against live 1.15.00 tables). Of **103 Format 3 mod-files judged across all 6 categories that ship Format 3 mods**, 86 apply cleanly; the 17 dead ones collapse to 3 distinct tables — this one, plus `inventory` (`default_slots`/`max_slots`) and `skill` (`use_resource_stat_list[N].d`). Those two refuse *honestly* today, so they're coverage gaps rather than silent failures; this was the only one lying.

Worth noting for anyone else auditing: only **6 of 16** Nexus categories contain Format 3 mods at all. User Interface, Characters and Miscellaneous are entirely PAK/ASI/texture mods.

## Tests

`tests/test_buffinfo_unresolved_reporting.py` — 4 tests pinning that the parameter stays optional (existing 3-arg callers keep working), that the NamedTuple carries field/entry/key, and that the emitted warning **names the fields and does not say "may not exist"**.

23 passed / 1 skipped across the buffinfo suite (`test_buffinfo_asset_path_write`, `test_buffinfo_field_name_aliases`, `test_buffinfo_variant_body`, `test_format3_buffinfo_wiring`). Ruff clean on both touched files, including `--select I`.
