### PR TITLE
buffinfo: refuse the record when the item walk doesn't add up (Fixes #313)

### DIFF
--- a/src/cdumm/_vendor/buffinfo_parser.py
+++ b/src/cdumm/_vendor/buffinfo_parser.py
@@ -981,6 +981,74 @@ _WRAPPER_FIELDS: dict[str, tuple[str, int, str]] = {
 }
 
 
+#: Outcomes of :func:`walk_buff_data_items`.
+WALK_TILES = "tiles"        # every item placed, ended exactly on min_level
+WALK_BLOCKED = "blocked"    # stopped early: unknown tag or unreadable bytes
+WALK_MISMATCH = "mismatch"  # every size known, yet the region didn't add up
+
+
+def walk_buff_data_items(entry_bytes: bytes) -> tuple[list[int], str]:
+    """Locate the ``buff_data_list`` items, and report how the walk ended.
+
+    Returns ``(starts, outcome)``:
+
+    * ``starts`` , the byte offset of each item the walk could place.
+      Item 0 needs no walking at all (it begins at
+      ``buff_data_list_offset``), so it is always placed; each later item
+      is placed only after stepping over every item before it. The walk
+      stops at the first item it cannot step over, so ``len(starts)`` can
+      be shorter than ``buff_data_count``.
+    * ``outcome`` , one of ``WALK_TILES``, ``WALK_BLOCKED``,
+      ``WALK_MISMATCH``.
+
+    ``WALK_MISMATCH`` is the case this function exists for (GitHub #313).
+    The variant sizes in ``_VARIANT_TAIL_SIZES`` were derived from one
+    game version's table, and Pearl Abyss does change these layouts
+    between versions , equipslotinfo's record block moved 66 -> 63 across
+    1.10 -> 1.15. If a size drifts, the walk lands mid-record and every
+    offset it produces points at the wrong bytes, silently. The region
+    carries its own check: ``buff_data_count`` items must fill
+    ``[buff_data_list_offset, min_level_offset)`` with no slack and no
+    remainder. Every step was a known size and the total still didn't
+    land , so the sizes no longer describe this table, and nothing
+    derived from them is safe to write.
+
+    ``WALK_BLOCKED`` is deliberately NOT the same thing. Stopping on a
+    tag that isn't in the size table is a gap in coverage, not evidence
+    of drift, and it says nothing about the items already placed , each
+    of those was reached over known-size predecessors. Collapsing the two
+    would refuse writes that are provably correct: on the real 1.15 table
+    63 of 290 records stop on an unknown tag, and 34 of those stop on the
+    LAST item, which leaves ``starts`` full-length and would look
+    identical to a mismatch if only the length were checked.
+    """
+    entry = parse_entry(entry_bytes)
+    end = entry.min_level_offset
+    position = entry.buff_data_list_offset
+    starts: list[int] = []
+    for _ in range(entry.buff_data_count):
+        if position + _ITEM_HEADER_BYTES > end:
+            return starts, WALK_BLOCKED
+        try:
+            hdr = parse_item_header(entry_bytes, position)
+        except ValueError:
+            return starts, WALK_BLOCKED
+        starts.append(position)
+        if hdr.absent_flag != 0:
+            # Absent items have no payload, just the 5-byte header.
+            position += _ITEM_HEADER_BYTES
+            continue
+        try:
+            common = parse_payload_common(entry_bytes, hdr.payload_offset)
+        except ValueError:
+            return starts, WALK_BLOCKED
+        tag_size = _VARIANT_TAIL_SIZES.get(common.tag)
+        if tag_size is None:
+            return starts, WALK_BLOCKED   # can't step over an unknown variant
+        position = common.end_offset + tag_size
+    return starts, (WALK_TILES if position == end else WALK_MISMATCH)
+
+
 def locate_buff_field(
     entry_bytes: bytes, field_path: str,
 ) -> tuple[int, int, str] | None:
@@ -1030,27 +1098,19 @@ def locate_buff_field(
         entry = parse_entry(entry_bytes)
         if n >= entry.buff_data_count:
             return None  # past the end of the list
-        # Walk forward through items 0..n-1 to find item n's start.
-        position = entry.buff_data_list_offset
-        for _ in range(n):
-            try:
-                hdr = parse_item_header(entry_bytes, position)
-            except ValueError:
-                return None
-            if hdr.absent_flag != 0:
-                # Absent items have no payload, just the 5-byte header.
-                position += _ITEM_HEADER_BYTES
-                continue
-            try:
-                common = parse_payload_common(
-                    entry_bytes, hdr.payload_offset)
-            except ValueError:
-                return None
-            tag_size = _VARIANT_TAIL_SIZES.get(common.tag)
-            if tag_size is None:
-                # Unknown variant , can't safely walk past it.
-                return None
-            position = common.end_offset + tag_size
+        starts, outcome = walk_buff_data_items(entry_bytes)
+        if outcome == WALK_MISMATCH:
+            # Every item was stepped over with a known size, yet the walk
+            # did not finish on min_level_offset. The sizes contradict the
+            # table, so nothing derived from them can be trusted , not even
+            # item 0, because a wrong buff_data_list_offset shows up the
+            # same way. Refuse the whole record (GitHub #313).
+            return None
+        if n >= len(starts):
+            # The walk stopped before item n , an unknown variant tag or an
+            # unreadable header in between. Item n's position is unknown.
+            return None
+        position = starts[n]
         header = parse_item_header(entry_bytes, position)
         if tail == ".absent_flag":
             return header.absent_flag_offset, 1, "u8"
@@ -1064,8 +1124,11 @@ def locate_buff_field(
             if spec is None:
                 return None
             offset_attr, width, dtype = spec
-            payload = parse_payload_common(
-                entry_bytes, header.payload_offset)
+            try:
+                payload = parse_payload_common(
+                    entry_bytes, header.payload_offset)
+            except ValueError:
+                return None     # unreadable payload -> refuse, don't raise
             return getattr(payload, offset_attr), width, dtype
         # ``data.variant.type`` resolves to the tag byte itself ,
         # the variant tag IS the type discriminator. Apply path uses
@@ -1073,8 +1136,11 @@ def locate_buff_field(
         if tail == ".data.variant.type":
             if header.absent_flag != 0:
                 return None
-            payload = parse_payload_common(
-                entry_bytes, header.payload_offset)
+            try:
+                payload = parse_payload_common(
+                    entry_bytes, header.payload_offset)
+            except ValueError:
+                return None     # unreadable payload -> refuse, don't raise
             return payload.tag_offset, 1, "u8"
         # ``data.variant.body.fXX`` resolves to the field's offset
         # inside the variant tail. Variant tail starts at the end of
@@ -1085,8 +1151,11 @@ def locate_buff_field(
             if header.absent_flag != 0:
                 return None
             leaf = tail[len(".data.variant.body."):]
-            payload = parse_payload_common(
-                entry_bytes, header.payload_offset)
+            try:
+                payload = parse_payload_common(
+                    entry_bytes, header.payload_offset)
+            except ValueError:
+                return None     # unreadable payload -> refuse, don't raise
             variant = _VARIANT_BODY_FIELDS.get(payload.tag)
             if variant is None:
                 return None

--- a/tests/test_buffinfo_walk_tiles_exactly.py
+++ b/tests/test_buffinfo_walk_tiles_exactly.py
@@ -1,0 +1,203 @@
+"""buffinfo: the item walk must prove it landed where the layout says.
+
+GitHub #313. ``locate_buff_field`` walks ``buff_data_list`` using the
+hardcoded sizes in ``_VARIANT_TAIL_SIZES``, which were derived offline
+from one game version's table. Pearl Abyss does change these layouts
+between versions -- equipslotinfo's record block moved 66 -> 63 across
+1.10 -> 1.15 -- and until now the walk returned an offset without ever
+checking it had landed somewhere sensible. A drifted size means writes
+go to the wrong bytes, silently, which is the corrupt-the-user's-game
+failure mode.
+
+The region carries its own check: ``buff_data_count`` items must fill
+``[buff_data_list_offset, min_level_offset)`` with no slack and no
+remainder.
+
+The subtlety, and why this file exists rather than a one-line assert:
+**a walk that stops early is not the same as a walk that lands wrong.**
+
+* Stopping on a tag that isn't in the size table is a coverage gap. It
+  says nothing about the items already placed, each of which was reached
+  over known-size predecessors. 63 of the 290 records on the real 1.15
+  table stop this way, and **34 of those stop on the LAST item** -- which
+  leaves the collected offsets full-length and indistinguishable from a
+  clean walk if only the count is checked. Refusing those would drop
+  writes that are provably correct.
+* Walking every item with a known size and *still* not landing on
+  ``min_level_offset`` is a contradiction: the sizes no longer describe
+  this table. Nothing derived from them is safe, not even item 0, since
+  a wrong ``buff_data_list_offset`` presents identically.
+
+So the walk reports which of the two happened, and only the second
+refuses the record.
+"""
+from __future__ import annotations
+
+import zlib
+from pathlib import Path
+
+import pytest
+
+from cdumm._vendor import buffinfo_parser as bp
+from cdumm.semantic.parser import parse_pabgh_index
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "vanilla115"
+
+pytestmark = pytest.mark.skipif(
+    not (_FIXTURES / "buffinfo.pabgb.zlib").exists(),
+    reason="vanilla115 buffinfo fixture absent")
+
+#: Measured on the committed 1.15 table. Pinned so a change to
+#: _VARIANT_TAIL_SIZES has to explain itself: a size that starts
+#: contradicting the table shows up here as records moving into
+#: `mismatch`, which is exactly the drift this guard exists to catch.
+EXPECTED_OUTCOMES = {bp.WALK_TILES: 227, bp.WALK_BLOCKED: 63}
+
+ITEM_PATHS = ("buff_data_list[{n}].absent_flag",
+              "buff_data_list[{n}].leading_lookup",
+              "buff_data_list[{n}].data.base.tag",
+              "buff_data_list[{n}].data.variant.type")
+
+
+def _load(name: str) -> bytes:
+    return zlib.decompress((_FIXTURES / (name + ".zlib")).read_bytes())
+
+
+def _entries() -> dict[int, bytes]:
+    body, header = _load("buffinfo.pabgb"), _load("buffinfo.pabgh")
+    _keys, offs = parse_pabgh_index(header, "buffinfo")
+    ordered = sorted(offs.items(), key=lambda kv: kv[1])
+    out = {}
+    for i, (key, off) in enumerate(ordered):
+        end = ordered[i + 1][1] if i + 1 < len(ordered) else len(body)
+        out[key] = body[off:end]
+    return out
+
+
+def _resolvable(entries: dict[int, bytes]) -> dict:
+    """Every (key, n, path) the parser will currently place."""
+    out = {}
+    for key, eb in entries.items():
+        try:
+            count = bp.parse_entry(eb).buff_data_count
+        except Exception:  # noqa: BLE001, S112 -- entry parsing isn't the point
+            continue
+        for n in range(min(count, 12)):
+            for p in ITEM_PATHS:
+                got = bp.locate_buff_field(eb, p.format(n=n))
+                if got is not None:
+                    out[(key, n, p)] = got
+    return out
+
+
+# ----------------------------------------------------- the walk contract
+
+def test_walk_outcomes_on_the_real_table():
+    entries = _entries()
+    assert len(entries) == 290
+    seen: dict[str, int] = {}
+    for eb in entries.values():
+        _starts, outcome = bp.walk_buff_data_items(eb)
+        seen[outcome] = seen.get(outcome, 0) + 1
+    assert seen == EXPECTED_OUTCOMES
+
+
+def test_no_record_currently_contradicts_the_size_table():
+    """The guard must cost nothing on a healthy table: a mismatch here
+    would mean CDUMM is already writing to wrong bytes somewhere."""
+    for key, eb in _entries().items():
+        _starts, outcome = bp.walk_buff_data_items(eb)
+        assert outcome != bp.WALK_MISMATCH, key
+
+
+def test_a_tiling_walk_places_every_item():
+    entries = _entries()
+    for key, eb in entries.items():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome != bp.WALK_TILES:
+            continue
+        assert len(starts) == bp.parse_entry(eb).buff_data_count, key
+        assert starts == sorted(starts), key
+        assert starts[0] == bp.parse_entry(eb).buff_data_list_offset, key
+
+
+def test_blocked_walks_still_place_the_items_they_reached():
+    """The coverage that must NOT be lost. A record blocked on a later
+    item still knows exactly where the earlier ones are."""
+    blocked = 0
+    for eb in _entries().values():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome != bp.WALK_BLOCKED:
+            continue
+        blocked += 1
+        assert starts, "item 0 needs no walking and is always placeable"
+        assert bp.locate_buff_field(
+            eb, "buff_data_list[0].absent_flag") is not None
+    assert blocked == EXPECTED_OUTCOMES[bp.WALK_BLOCKED]
+
+
+def test_blocked_on_the_last_item_is_not_treated_as_a_mismatch():
+    """The trap: 34 records stop on their final item, so the offsets
+    collected are full-length. Checking only the count would call these
+    contradictions and refuse them."""
+    full_length_but_blocked = 0
+    for eb in _entries().values():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome != bp.WALK_BLOCKED:
+            continue
+        if len(starts) == bp.parse_entry(eb).buff_data_count:
+            full_length_but_blocked += 1
+            assert bp.locate_buff_field(
+                eb, "buff_data_list[0].absent_flag") is not None
+    assert full_length_but_blocked == 34
+
+
+# --------------------------------------------------- the drift it catches
+
+def test_a_drifted_size_that_still_parses_is_refused(monkeypatch):
+    """The case nothing else catches.
+
+    A wrong size usually makes the next header unreadable, so the walk
+    stops and the offsets are refused anyway. The dangerous drift is the
+    one that stays plausible to the end of the list and simply lands on
+    the wrong byte. Perturbing tag 0 by one byte produces exactly that on
+    several records: every step has a known size, and the total no longer
+    reaches ``min_level_offset``.
+
+    Before this guard the parser handed back offsets for those records.
+    It must now refuse them outright -- including item 0, whose position
+    is only trustworthy if the model of the record holds.
+    """
+    entries = _entries()
+    before = _resolvable(entries)
+    tiled_before = {k for k, eb in entries.items()
+                    if bp.walk_buff_data_items(eb)[1] == bp.WALK_TILES}
+
+    sizes = dict(bp._VARIANT_TAIL_SIZES)
+    sizes[0] = sizes[0] + 1
+    monkeypatch.setattr(bp, "_VARIANT_TAIL_SIZES", sizes)
+
+    outcomes = {k: bp.walk_buff_data_items(eb)[1]
+                for k, eb in entries.items()}
+    drifted = {k for k, o in outcomes.items() if o == bp.WALK_MISMATCH}
+    assert drifted, "the perturbation must actually reach the mismatch case"
+
+    after = _resolvable(entries)
+    assert not [k for k in after if k[0] in drifted], (
+        "a record whose sizes contradict the table must resolve nothing")
+
+    # Records the perturbation didn't disturb at all -- still tiling -- must
+    # keep every offset they had. (Records that merely *block* on the
+    # drifted tag are expected to lose the items past it; that is the walk
+    # refusing to step over something it can no longer measure.)
+    untouched = {k for k in tiled_before
+                 if outcomes[k] == bp.WALK_TILES}
+    assert len(untouched) > 200, "the blast radius should be small"
+    lost = [k for k in before if k[0] in untouched and k not in after]
+    assert not lost, "records that still tile must be unaffected"
+
+    # and item 0 specifically, which needs no walking and would otherwise
+    # look safe
+    for key in drifted:
+        assert bp.locate_buff_field(
+            entries[key], "buff_data_list[0].absent_flag") is None, key


### PR DESCRIPTION
Fixes #313.

`locate_buff_field` walked `buff_data_list` with the hardcoded sizes in `_VARIANT_TAIL_SIZES` and returned an offset without ever checking the walk had landed where the layout says it should. You're right that this predates #312, and right that #310 is the proof it matters — equipslotinfo's record block moved 66 → 63 across 1.10 → 1.15.

The region carries its own check, exactly as you described: `buff_data_count` items must fill `[buff_data_list_offset, min_level_offset)` with no slack and no remainder.

## One thing I'd add to the diagnosis: it needs two outcomes, not one

The obvious implementation — walk, refuse unless it tiles — is wrong, and the table says so. A walk can end early for a reason that has nothing to do with drift:

| outcome | meaning | action |
|---|---|---|
| **BLOCKED** | stopped on a tag not in the size table, or unreadable bytes | coverage gap — says nothing about the items already placed, each reached over known-size predecessors |
| **MISMATCH** | stepped over **every** item with a known size and still didn't land on `min_level_offset` | contradiction — the sizes don't describe this table, so nothing derived from them is safe |

Only MISMATCH refuses the record.

Collapsing them would have cost real coverage. On the committed 1.15 table **227 of 290 records tile and 63 stop on an unknown tag — and 34 of those 63 stop on the LAST item**, which leaves the collected offsets full-length and indistinguishable from a clean walk if only the count is compared. Those 34 would have started refusing writes that are provably correct.

## Measured, not assumed

Resolving every item-level path across all 290 records, master vs this branch:

```
master resolves : 6236 field paths
branch resolves : 6236 field paths
  lost    : 0
  gained  : 0
  CHANGED : 0
```

And no record on the current table reports MISMATCH — so the guard costs nothing today and fires only on real drift.

## The drift it actually catches

Worth being precise, because most drift never reaches this check: a wrong size usually makes the *next* header unreadable, so the walk stops and the offsets are refused anyway. The dangerous case is the drift that stays plausible to the end of the list and simply lands on the wrong byte.

Perturbing tag 0 by a single byte produces exactly that on several records — every step has a known size, the total no longer reaches `min_level_offset`. Master hands back offsets for those. This refuses them, **item 0 included** (a wrong `buff_data_list_offset` presents identically, so item 0 is only trustworthy if the model of the record holds), and leaves every record that still tiles untouched. Both halves are pinned in `test_a_drifted_size_that_still_parses_is_refused`.

## A second defect the test surfaced

Under a drifted table `locate_buff_field` **raised** `ValueError` out of the leaf payload parses instead of returning `None`. Drift is supposed to become a clean refusal, not an exception thrown at the caller, so the three bare `parse_payload_common` calls are guarded.

## Shape of the change

The walk is now one function, `walk_buff_data_items`, instead of being open-coded inside `locate_buff_field`. As you noted, `_walk` in `tests/test_buffinfo_variant_tail_round3.py` had been doing the tiling check all along — this puts it where it protects users rather than tests.

## Checks

- Fast suite: **2458 passed, 42 skipped** (2452 on `master` + the 6 new)
- `ruff` clean on the added test; **zero new findings** on the parser
