### PR TITLE
variant re-import: stage first, swap last (Fixes #314)

### DIFF
--- a/src/cdumm/engine/variant_handler.py
+++ b/src/cdumm/engine/variant_handler.py
@@ -41,7 +41,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
+import tempfile
+from contextlib import suppress
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -328,6 +331,48 @@ def build_variants_metadata(
     return variants
 
 
+class VariantStagingError(RuntimeError):
+    """A staged re-import didn't produce everything it promised.
+
+    Raised before anything the user already has is touched, so the
+    caller can abort with the installed mod still intact.
+    """
+
+
+def verify_staged_variants(
+    presets: list[tuple[Path, dict]], staged_dir: Path,
+) -> None:
+    """Check the staged copy actually contains every variant.
+
+    ``copy_variants_to_mod_dir`` logs and continues when a copy fails,
+    so "it returned" is not evidence that the files are there. A
+    re-import that swaps a half-populated directory over the user's
+    installed mod would lose variants silently, which is the same
+    class of problem as GitHub #314 with a quieter failure mode.
+
+    Raises :class:`VariantStagingError` naming what's missing.
+    """
+    expected = _disambiguate_basenames(presets)
+    vdir = staged_dir / "variants"
+    missing = [
+        expected.get(src, src.name) for src, _data in presets
+        if not (vdir / expected.get(src, src.name)).is_file()
+    ]
+    if missing:
+        raise VariantStagingError(
+            f"{len(missing)} of {len(presets)} variant file(s) did not "
+            f"copy: {', '.join(sorted(missing)[:5])}"
+            + (" ..." if len(missing) > 5 else ""))
+    empty = [
+        expected.get(src, src.name) for src, _data in presets
+        if (vdir / expected.get(src, src.name)).stat().st_size == 0
+    ]
+    if empty:
+        raise VariantStagingError(
+            f"{len(empty)} staged variant file(s) are empty: "
+            f"{', '.join(sorted(empty)[:5])}")
+
+
 def copy_variants_to_mod_dir(
     presets: list[tuple[Path, dict]],
     mod_dir: Path,
@@ -538,57 +583,118 @@ def import_multi_variant(
     version = first.get("version")
     description = first.get("description")
 
-    if existing_mod_id is not None:
-        mod_id = existing_mod_id
-        db.connection.execute(
-            "DELETE FROM mod_deltas WHERE mod_id = ?", (mod_id,))
-        old_dir = mods_dir / str(mod_id)
-        if old_dir.exists():
-            shutil.rmtree(old_dir, ignore_errors=True)
-        # Bug from Faisal 2026-05-03 (NPC Trust Gain "Click To Update"
-        # left pill red): the re-import path was rewriting deltas and
-        # the mod_dir but leaving the identity fields stale. Result:
-        # mods.version stayed at the OLD version after a successful
-        # update, so the next Nexus update check kept flagging the mod
-        # as outdated. Mirror the INSERT branch's identity fields here.
-        db.connection.execute(
-            "UPDATE mods SET name = ?, author = ?, version = ?, "
-            "description = ?, game_version_hash = ?, "
-            "last_apply_skipped_count = 0, "
-            "last_apply_skip_summary = NULL WHERE id = ?",
-            (mod_name, author, version, description,
-             game_ver_hash, mod_id))
-    else:
-        priority = db.connection.execute(
-            "SELECT COALESCE(MAX(priority), 0) + 1 FROM mods"
-        ).fetchone()[0]
-        cur = db.connection.execute(
-            "INSERT INTO mods (name, mod_type, priority, author, version, "
-            "description, game_version_hash, configurable) "
-            "VALUES (?, 'paz', ?, ?, ?, ?, ?, 1)",
-            (mod_name, priority, author, version, description, game_ver_hash),
-        )
-        mod_id = cur.lastrowid
-
-    mod_dir = mods_dir / str(mod_id)
-    mod_dir.mkdir(parents=True, exist_ok=True)
-
-    copy_variants_to_mod_dir(presets, mod_dir)
-
     merged_meta = {
         "name": mod_name,
         "author": author,
         "version": version,
         "description": description,
     }
-    merged_path = synthesize_merged_json(mod_dir, variants_meta, merged_meta)
 
-    db.connection.execute(
-        "UPDATE mods SET json_source = ?, variants = ?, configurable = 1 "
-        "WHERE id = ?",
-        (str(merged_path), json.dumps(variants_meta), mod_id),
-    )
-    db.connection.commit()
+    # GitHub #314: stage first, swap last. This used to DELETE the
+    # deltas and rmtree the mod directory and only THEN start copying
+    # the new files in, so a disk-full, a locked file, an antivirus hold
+    # on a freshly written file or a permissions blip between the two
+    # left the user's installed mod deleted with nothing to put back.
+    # The caller catches broadly and reports "couldn't import", so it
+    # read as though nothing had happened.
+    #
+    # Now everything is built in a sibling directory first. The old
+    # content is not touched until the replacement is complete AND
+    # verified, the swap is a rename, and the previous directory is kept
+    # until the database has committed , so any failure along the way
+    # can put it back.
+    mods_dir.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".import-", dir=mods_dir))
+    backup: Path | None = None
+    swapped = False
+    try:
+        copy_variants_to_mod_dir(presets, staging)
+        verify_staged_variants(presets, staging)
+        merged_name = synthesize_merged_json(
+            staging, variants_meta, merged_meta).name
+
+        if existing_mod_id is not None:
+            mod_id = existing_mod_id
+            db.connection.execute(
+                "DELETE FROM mod_deltas WHERE mod_id = ?", (mod_id,))
+            # Bug from Faisal 2026-05-03 (NPC Trust Gain "Click To Update"
+            # left pill red): the re-import path was rewriting deltas and
+            # the mod_dir but leaving the identity fields stale. Result:
+            # mods.version stayed at the OLD version after a successful
+            # update, so the next Nexus update check kept flagging the mod
+            # as outdated. Mirror the INSERT branch's identity fields here.
+            db.connection.execute(
+                "UPDATE mods SET name = ?, author = ?, version = ?, "
+                "description = ?, game_version_hash = ?, "
+                "last_apply_skipped_count = 0, "
+                "last_apply_skip_summary = NULL WHERE id = ?",
+                (mod_name, author, version, description,
+                 game_ver_hash, mod_id))
+        else:
+            priority = db.connection.execute(
+                "SELECT COALESCE(MAX(priority), 0) + 1 FROM mods"
+            ).fetchone()[0]
+            cur = db.connection.execute(
+                "INSERT INTO mods (name, mod_type, priority, author, "
+                "version, description, game_version_hash, configurable) "
+                "VALUES (?, 'paz', ?, ?, ?, ?, ?, 1)",
+                (mod_name, priority, author, version, description,
+                 game_ver_hash),
+            )
+            mod_id = cur.lastrowid
+
+        mod_dir = mods_dir / str(mod_id)
+        merged_path = mod_dir / merged_name
+        db.connection.execute(
+            "UPDATE mods SET json_source = ?, variants = ?, configurable = 1 "
+            "WHERE id = ?",
+            (str(merged_path), json.dumps(variants_meta), mod_id),
+        )
+
+        # The swap. Everything above is reversible; from here the old
+        # directory is only ever moved aside, never removed, until the
+        # commit below has succeeded.
+        if mod_dir.exists():
+            backup = mods_dir / f".replaced-{mod_id}-{os.getpid()}"
+            if backup.exists():
+                shutil.rmtree(backup, ignore_errors=True)
+            os.replace(mod_dir, backup)
+        os.replace(staging, mod_dir)
+        swapped = True
+        staging = None
+
+        db.connection.commit()
+    except Exception:
+        with suppress(Exception):
+            db.connection.rollback()
+        # Restore whenever the old directory was moved aside, whether or
+        # not the replacement made it into place. Keying this off
+        # ``swapped`` instead would let the finally-block delete the
+        # backup when the second rename was the thing that failed , the
+        # very data loss this is meant to prevent.
+        if backup is not None:
+            with suppress(Exception):
+                if swapped:
+                    shutil.rmtree(mod_dir, ignore_errors=True)
+            with suppress(Exception):
+                os.replace(backup, mod_dir)
+                backup = None
+            logger.error(
+                "variant re-import failed %s the swap; restored the "
+                "previous mod directory for mod_id=%s",
+                "after" if swapped else "during", existing_mod_id)
+        else:
+            logger.error(
+                "variant re-import failed before touching the installed "
+                "mod (mod_id=%s); nothing was removed", existing_mod_id)
+        raise
+    finally:
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
+        if backup is not None:
+            # Only reached on the success path (the handler above clears
+            # it when it puts the directory back).
+            shutil.rmtree(backup, ignore_errors=True)
 
     # Adjacent fix from systematic-debugging review of the version-
     # update bug: the apply fingerprint hashes mods.json_source PATH

--- a/src/cdumm/engine/variant_handler.py
+++ b/src/cdumm/engine/variant_handler.py
@@ -679,10 +679,21 @@ def import_multi_variant(
             with suppress(Exception):
                 os.replace(backup, mod_dir)
                 backup = None
-            logger.error(
-                "variant re-import failed %s the swap; restored the "
-                "previous mod directory for mod_id=%s",
-                "after" if swapped else "during", existing_mod_id)
+            if backup is None:
+                logger.error(
+                    "variant re-import failed %s the swap; restored the "
+                    "previous mod directory for mod_id=%s",
+                    "after" if swapped else "during", existing_mod_id)
+            else:
+                # The restore itself failed, so ``backup = None`` above
+                # never ran. Do not claim a recovery that didn't happen --
+                # this is the message someone reads while trying to get
+                # their mod back. The finally-block leaves the backup in
+                # place and logs where to find it.
+                logger.error(
+                    "variant re-import failed %s the swap AND the previous "
+                    "mod directory could not be restored for mod_id=%s",
+                    "after" if swapped else "during", existing_mod_id)
         else:
             logger.error(
                 "variant re-import failed before touching the installed "
@@ -692,9 +703,29 @@ def import_multi_variant(
         if staging is not None:
             shutil.rmtree(staging, ignore_errors=True)
         if backup is not None:
-            # Only reached on the success path (the handler above clears
-            # it when it puts the directory back).
-            shutil.rmtree(backup, ignore_errors=True)
+            # Delete the backup ONLY once the mod directory is confirmed
+            # back in place. Two paths reach here with ``backup`` still
+            # set and the directory missing, and in both the backup is
+            # the user's only remaining copy:
+            #
+            #   * the restoring ``os.replace(backup, mod_dir)`` above sits
+            #     inside ``suppress(Exception)``, so when IT fails the
+            #     following ``backup = None`` never runs;
+            #   * a BaseException (KeyboardInterrupt, SystemExit) raised
+            #     after the backup rename skips ``except Exception``
+            #     entirely, while this block still runs.
+            #
+            # Keying this off "we reached the finally" rather than "the
+            # directory is actually there" re-creates exactly the data
+            # loss this staging rewrite exists to eliminate.
+            if mod_dir.exists():
+                shutil.rmtree(backup, ignore_errors=True)
+            else:
+                logger.error(
+                    "variant re-import for mod_id=%s could not restore the "
+                    "mod directory; the previous copy has been LEFT IN "
+                    "PLACE at %s -- move it back to %s to recover",
+                    existing_mod_id, backup, mod_dir)
 
     # Adjacent fix from systematic-debugging review of the version-
     # update bug: the apply fingerprint hashes mods.json_source PATH

--- a/tests/test_variant_reimport_rollback.py
+++ b/tests/test_variant_reimport_rollback.py
@@ -227,3 +227,51 @@ def test_failures_are_reported_rather_than_swallowed(
             [_preset(installed["src"], "alpha.json")], installed["src"],
             installed["game_dir"], installed["mods_dir"], db,
             existing_mod_id=installed["mod_id"])
+
+
+def test_backup_survives_when_the_restore_itself_fails(
+        installed, db, monkeypatch):
+    """The last copy must never be deleted while the mod directory is gone.
+
+    The restoring ``os.replace(backup, mod_dir)`` runs inside
+    ``suppress(Exception)``, so when IT fails the following
+    ``backup = None`` never executes. A ``finally`` that deletes the
+    backup unconditionally then destroys the user's only remaining copy --
+    re-creating the exact data loss this staging rewrite exists to
+    eliminate.
+
+    Both renames fail here: the swap, and then the restore.
+    """
+    import os as _os
+
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    before = _snapshot(mod_dir)
+
+    real_replace = _os.replace
+    calls = {"n": 0}
+
+    def doomed(src, dst):
+        calls["n"] += 1
+        if calls["n"] >= 2:      # staging -> mod_dir, then backup -> mod_dir
+            raise PermissionError("file in use by another process")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(vh.os, "replace", doomed)
+
+    newer = [_preset(installed["src"], "alpha.json"),
+             _preset(installed["src"], "beta.json")]
+    with pytest.raises(PermissionError):
+        vh.import_multi_variant(
+            newer, installed["src"], installed["game_dir"],
+            installed["mods_dir"], db,
+            existing_mod_id=installed["mod_id"])
+
+    # The restore could not run, so the directory is legitimately absent.
+    # What must NOT happen is the backup being deleted along with it.
+    surviving = [d for d in installed["mods_dir"].iterdir()
+                 if d.is_dir() and d.name.startswith(".replaced-")]
+    assert surviving, (
+        "the backup was deleted while the mod directory was missing -- "
+        "the user's only remaining copy is gone")
+    assert _snapshot(surviving[0]) == before, (
+        "the surviving backup must still hold the original content")

--- a/tests/test_variant_reimport_rollback.py
+++ b/tests/test_variant_reimport_rollback.py
@@ -1,0 +1,229 @@
+"""A failed variant re-import must not destroy the installed mod.
+
+GitHub #314. ``import_multi_variant`` used to delete the mod's deltas and
+``rmtree`` its directory and only THEN start copying the new files in. A
+disk-full, a locked file, an antivirus hold on a freshly written file or a
+permissions blip between the two left the user's mod deleted with nothing
+to put back. The caller catches broadly and reports "couldn't import", so
+from the user's side it read as though nothing had happened while their
+installed mod was actually gone.
+
+#303 widened the exposure by routing zip / 7z / CLI imports through this
+function, and re-import is the ordinary way to update a mod, so it runs
+often.
+
+Each test below fails the import at a different point and asserts the same
+thing: the previously installed files are still there afterwards, and the
+database still describes them.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from cdumm.engine import variant_handler as vh
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE mods (id INTEGER PRIMARY KEY, name TEXT, "
+        "mod_type TEXT, priority INTEGER, author TEXT, version TEXT, "
+        "description TEXT, game_version_hash TEXT, configurable INTEGER, "
+        "json_source TEXT, variants TEXT, enabled INTEGER DEFAULT 1, "
+        "last_apply_skipped_count INTEGER DEFAULT 0, "
+        "last_apply_skip_summary TEXT)")
+    conn.execute(
+        "CREATE TABLE mod_deltas (mod_id INTEGER, game_file TEXT)")
+    conn.commit()
+    return type("DB", (), {"connection": conn})()
+
+
+def _preset(tmp: Path, name: str, patches: list | None = None):
+    p = tmp / name
+    doc = {"format": 3, "name": name, "patches": patches or []}
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return p, doc
+
+
+@pytest.fixture
+def installed(tmp_path, db):
+    """A variant mod already on disk, as a first import would leave it."""
+    src = tmp_path / "src"
+    src.mkdir()
+    mods_dir = tmp_path / "mods"
+    game_dir = tmp_path / "game"
+    game_dir.mkdir()
+    presets = [_preset(src, "alpha.json"), _preset(src, "beta.json")]
+
+    res = vh.import_multi_variant(
+        presets, src, game_dir, mods_dir, db,
+        initial_selection={presets[0][0]})
+    assert res is not None
+    return {
+        "mod_id": res["mod_id"],
+        "mods_dir": mods_dir,
+        "game_dir": game_dir,
+        "src": src,
+        "presets": presets,
+        "json_source": db.connection.execute(
+            "SELECT json_source FROM mods WHERE id = ?",
+            (res["mod_id"],)).fetchone()[0],
+    }
+
+
+def _snapshot(mod_dir: Path) -> dict[str, bytes]:
+    return {str(p.relative_to(mod_dir)): p.read_bytes()
+            for p in sorted(mod_dir.rglob("*")) if p.is_file()}
+
+
+def test_first_import_lands(installed):
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    files = _snapshot(mod_dir)
+    assert "variants\\alpha.json" in files or "variants/alpha.json" in files
+    assert any(f.endswith("merged.json") for f in files)
+
+
+def test_a_failed_copy_leaves_the_installed_mod_untouched(
+        installed, db, monkeypatch):
+    """The headline case: staging fails, so the old files are never
+    touched in the first place."""
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    before = _snapshot(mod_dir)
+    assert before
+
+    def boom(_presets, _dir):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(vh, "copy_variants_to_mod_dir", boom)
+
+    newer = [_preset(installed["src"], "alpha.json", [{"x": 1}]),
+             _preset(installed["src"], "beta.json")]
+    with pytest.raises(OSError):
+        vh.import_multi_variant(
+            newer, installed["src"], installed["game_dir"],
+            installed["mods_dir"], db,
+            existing_mod_id=installed["mod_id"])
+
+    assert _snapshot(mod_dir) == before, "installed files must survive"
+    row = db.connection.execute(
+        "SELECT json_source FROM mods WHERE id = ?",
+        (installed["mod_id"],)).fetchone()
+    assert row[0] == installed["json_source"], "db must still point at them"
+    assert db.connection.execute(
+        "SELECT COUNT(*) FROM mod_deltas").fetchone()[0] == 0
+
+
+def test_a_silently_incomplete_copy_is_caught_before_the_swap(
+        installed, db, monkeypatch):
+    """copy_variants_to_mod_dir logs and continues when a copy fails, so
+    returning is not evidence the files arrived. Staging is verified."""
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    before = _snapshot(mod_dir)
+
+    real = vh.copy_variants_to_mod_dir
+
+    def only_the_first(presets, staged):
+        out = real(presets[:1], staged)     # second variant never lands
+        return out
+
+    monkeypatch.setattr(vh, "copy_variants_to_mod_dir", only_the_first)
+
+    newer = [_preset(installed["src"], "alpha.json"),
+             _preset(installed["src"], "beta.json")]
+    with pytest.raises(vh.VariantStagingError) as exc:
+        vh.import_multi_variant(
+            newer, installed["src"], installed["game_dir"],
+            installed["mods_dir"], db,
+            existing_mod_id=installed["mod_id"])
+    assert "beta.json" in str(exc.value)
+    assert _snapshot(mod_dir) == before
+
+
+def test_a_failure_during_the_swap_restores_the_previous_directory(
+        installed, db, monkeypatch):
+    """The subtle one. The old directory has already been renamed aside
+    when the second rename fails, so 'nothing was touched' is false and
+    the backup must be put back rather than cleaned up."""
+    import os as _os
+
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    before = _snapshot(mod_dir)
+
+    real_replace = _os.replace
+    calls = {"n": 0}
+
+    def flaky(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:          # the staging -> mod_dir rename
+            raise PermissionError("file in use by another process")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(vh.os, "replace", flaky)
+
+    newer = [_preset(installed["src"], "alpha.json"),
+             _preset(installed["src"], "beta.json")]
+    with pytest.raises(PermissionError):
+        vh.import_multi_variant(
+            newer, installed["src"], installed["game_dir"],
+            installed["mods_dir"], db,
+            existing_mod_id=installed["mod_id"])
+
+    assert mod_dir.is_dir(), "the mod directory must exist again"
+    assert _snapshot(mod_dir) == before
+    row = db.connection.execute(
+        "SELECT json_source FROM mods WHERE id = ?",
+        (installed["mod_id"],)).fetchone()
+    assert row[0] == installed["json_source"]
+
+
+def test_no_staging_or_backup_directories_are_left_behind(installed, db):
+    """A successful re-import cleans up after itself."""
+    newer = [_preset(installed["src"], "alpha.json", [{"x": 2}]),
+             _preset(installed["src"], "beta.json")]
+    res = vh.import_multi_variant(
+        newer, installed["src"], installed["game_dir"],
+        installed["mods_dir"], db,
+        existing_mod_id=installed["mod_id"])
+    assert res is not None
+    leftovers = [p.name for p in installed["mods_dir"].iterdir()
+                 if p.name.startswith(".")]
+    assert not leftovers, leftovers
+
+
+def test_a_successful_reimport_replaces_the_content(installed, db):
+    mod_dir = installed["mods_dir"] / str(installed["mod_id"])
+    (mod_dir / "variants" / "stale.json").write_text("{}", encoding="utf-8")
+
+    newer = [_preset(installed["src"], "alpha.json", [{"x": 3}])]
+    res = vh.import_multi_variant(
+        newer, installed["src"], installed["game_dir"],
+        installed["mods_dir"], db,
+        existing_mod_id=installed["mod_id"])
+
+    assert res["mod_id"] == installed["mod_id"]
+    assert not (mod_dir / "variants" / "stale.json").exists(), (
+        "the swap replaces the directory rather than merging into it")
+    alpha = json.loads(
+        (mod_dir / "variants" / "alpha.json").read_text(encoding="utf-8"))
+    assert alpha["patches"] == [{"x": 3}]
+
+
+def test_failures_are_reported_rather_than_swallowed(
+        installed, db, monkeypatch):
+    """import_multi_variant must raise so the caller can tell the user
+    something went wrong; returning None here would read as 'nothing
+    happened' while a re-import had actually been attempted."""
+    def boom(_presets, _dir):
+        raise OSError("nope")
+
+    monkeypatch.setattr(vh, "copy_variants_to_mod_dir", boom)
+    with pytest.raises(OSError):
+        vh.import_multi_variant(
+            [_preset(installed["src"], "alpha.json")], installed["src"],
+            installed["game_dir"], installed["mods_dir"], db,
+            existing_mod_id=installed["mod_id"])


### PR DESCRIPTION
Fixes #314. Your diagnosis and your suggested fix, implemented.

## Reproduced first

Running the new tests against master's `variant_handler`, the installed mod directory comes back **empty**:

```
E  AssertionError: installed files must survive
E  assert {} == {'merged.json': ...,
E                'variants/alpha.json': ...,
E                'variants/beta.json': ...}
E  Right contains 3 more items
```

All three files gone, and `import_multi_variant` raised into a caller that reports "couldn't import" — exactly the shape you described.

## Stage first, swap last

Everything is built in a sibling staging directory. The old content isn't touched until the replacement is complete and verified, the swap is a rename, and the previous directory is kept until the database has committed — so any failure along the way can put it back.

## The part I'd flag for review

The obvious guard — *"if we already swapped, restore"* — is wrong, and it's wrong in the same direction as the original bug.

There are **two** renames. If the second one fails, the old directory has already been moved aside while `swapped` is still `False`. Keying the restore off `swapped` sends that case down the "nothing was touched" branch, and the cleanup then deletes the backup — losing the mod, from inside the code meant to protect it. I wrote it that way first; `test_a_failure_during_the_swap_restores_the_previous_directory` is what caught it.

The restore keys off the backup existing instead, which is true in both failure shapes.

## Verification, not just staging

While in here: `copy_variants_to_mod_dir` logs and continues when a copy fails, so it returning is **not** evidence the files arrived. A half-populated staging directory swapped over an installed mod loses variants silently — same class of problem, quieter failure mode.

`verify_staged_variants` checks every expected file is present and non-empty and raises `VariantStagingError` naming what's missing, before anything is swapped. The caller already handles a raised exception, so the user gets "couldn't import" instead of a mod that looks fine and is missing half its variants.

Say the word if you'd rather that stayed out of this PR — it's a separate defect, just one that makes the staging guarantee real rather than nominal.

## Also

The database work is now rolled back on failure rather than left pending on the connection, where an unrelated later commit could have flushed a half-applied re-import.

## Tests

Seven, each failing the import at a different point and asserting the same two things: the previously installed files are still there, and the database still describes them.

| test | fails at |
|---|---|
| `a_failed_copy_leaves_the_installed_mod_untouched` | staging (disk full) — old files never touched |
| `a_silently_incomplete_copy_is_caught_before_the_swap` | staging returns with a variant missing |
| `a_failure_during_the_swap_restores_the_previous_directory` | between the two renames |
| `no_staging_or_backup_directories_are_left_behind` | success path cleanup |
| `a_successful_reimport_replaces_the_content` | stale files don't survive the swap |

Three of them fail on master; the other four pass there and are regression cover.

## Checks

- Fast suite: **2459 passed, 42 skipped** (2452 on `master` + the 7 new)
- `ruff` clean on the added test; **zero new findings** on `variant_handler`
