### PR TITLE
rescan: say so when the game version couldn't be read (Fixes #315)

### DIFF
--- a/src/cdumm/engine/snapshot_manager.py
+++ b/src/cdumm/engine/snapshot_manager.py
@@ -406,6 +406,7 @@ class SnapshotWorker(QObject):
             # snapshot and main.py's startup check (stored_fp !=
             # current_fp) re-prompted recovery on every launch forever.
             # Writing it here cannot lose to that cross-process race.
+            stamped = False
             try:
                 from cdumm.engine.version_detector import detect_game_version
                 fp = detect_game_version(self._game_dir)
@@ -414,6 +415,7 @@ class SnapshotWorker(QObject):
                         "INSERT INTO config (key, value) VALUES (?, ?) "
                         "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                         ("game_version_fingerprint", fp))
+                    stamped = True
                     logger.info(
                         "Snapshot: stamped game_version_fingerprint=%s", fp)
                 else:
@@ -425,6 +427,25 @@ class SnapshotWorker(QObject):
                 # Logged, not swallowed silently — a stamp failure here is
                 # the #163 loop trigger and must be diagnosable.
                 logger.warning("Snapshot: fingerprint stamp failed: %s", _e_fp)
+
+            # #315: record WHETHER the stamp happened, in this same
+            # transaction. A snapshot that couldn't read the exe leaves the
+            # OLD fingerprint stored, so the next Apply compares live
+            # against stale and blocks — right after the user ran the
+            # rescan the banner told them to run. Until now the only trace
+            # was a log line, and the caller cleared the game-updated flag
+            # regardless, so the UI had no way to tell "snapshot is
+            # current" from "snapshot is current but the version is
+            # unknown". Those need different advice, so they get recorded
+            # differently.
+            try:
+                self._thread_db.connection.execute(
+                    "INSERT INTO config (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    ("last_snapshot_version_stamped", "1" if stamped else "0"))
+            except Exception as _e_flag:  # noqa: BLE001 -- never fail the snapshot
+                logger.warning(
+                    "Snapshot: could not record stamp outcome: %s", _e_flag)
 
             self._thread_db.connection.commit()
         except Exception:

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -8107,22 +8107,62 @@ class CdummWindow(FluentWindow):
         # and swallowed the error, leaving a stale fingerprint that
         # re-triggered recovery on every launch. Do not reintroduce it.
 
+        # #315: the worker records whether it managed to stamp the game
+        # version alongside the snapshot. If it couldn't — the exe was
+        # briefly locked by antivirus or Steam — the OLD fingerprint is
+        # still stored, so the next Apply compares live against stale and
+        # blocks again, immediately after the user did the thing the
+        # banner told them to do. Clearing the flag here regardless made
+        # that loop silent: the rescan looked like it worked.
+        stamped = self._snapshot_stamped_version()
+
         # D1: rescan succeeded, clear the stale-snapshot flag so
         # Apply unlocks without requiring a restart.
-        if self._startup_context.get("game_updated"):
+        if stamped and self._startup_context.get("game_updated"):
             self._startup_context["game_updated"] = False
             logger.info(
                 "Cleared game_updated flag after rescan; Apply unlocked")
+        elif not stamped:
+            logger.warning(
+                "Snapshot finished but the game version could not be read; "
+                "leaving game_updated set so the state stays honest")
 
         # Refresh vanilla backups, ensure they match clean game state
         self._refresh_vanilla_backups()
 
         self._refresh_all()
-        InfoBar.success(
-            title=tr("infobar.snapshot_complete"),
-            content=tr("infobar.snapshot_complete_msg", count=count),
-            duration=6000, position=InfoBarPosition.TOP, parent=self)
+        if stamped:
+            InfoBar.success(
+                title=tr("infobar.snapshot_complete"),
+                content=tr("infobar.snapshot_complete_msg", count=count),
+                duration=6000, position=InfoBarPosition.TOP, parent=self)
+        else:
+            InfoBar.warning(
+                title=tr("infobar.snapshot_no_version"),
+                content=tr("infobar.snapshot_no_version_msg", count=count),
+                duration=12000, position=InfoBarPosition.TOP, parent=self)
         self._log_activity("snapshot", tr("activity.msg_snapshot_created", count=count))
+
+    def _snapshot_stamped_version(self) -> bool:
+        """Did the last snapshot manage to stamp the game version?
+
+        Recorded by the snapshot worker inside the snapshot's own
+        transaction (#315). Missing means an older database that predates
+        the flag, which is treated as success so an upgrade doesn't start
+        warning about snapshots that were in fact fine.
+        """
+        if not self._db:
+            return True
+        try:
+            row = self._db.connection.execute(
+                "SELECT value FROM config WHERE key = ?",
+                ("last_snapshot_version_stamped",)).fetchone()
+        except Exception as e:  # noqa: BLE001 -- never break the callback
+            logger.debug("Could not read snapshot stamp flag: %s", e)
+            return True
+        if row is None or row[0] is None:
+            return True
+        return str(row[0]) != "0"
 
     def _refresh_vanilla_backups(self) -> None:
         """Ensure critical vanilla backup files exist (PAMT, PAPGT, PATHC).

--- a/src/cdumm/translations/de.json
+++ b/src/cdumm/translations/de.json
@@ -1192,6 +1192,8 @@
   "infobar.import_empty": "Import leer",
   "infobar.snapshot_complete": "Snapshot abgeschlossen",
   "infobar.snapshot_complete_msg": "{count} Spieldateien indiziert. Du kannst jetzt Mods importieren.",
+  "infobar.snapshot_no_version": "Snapshot fertig — Spielversion unbekannt",
+  "infobar.snapshot_no_version_msg": "{count} Spieldateien indiziert, aber die Spielversion konnte nicht gelesen werden (CrimsonDesert.exe wird möglicherweise von einem Antivirenprogramm oder von Steam blockiert). Übernehmen kann weiterhin gesperrt sein — schließe Steam und führe „Spieldateien neu scannen“ erneut aus.",
   "nexus.invalid_url": "Ungültige URL",
   "nexus.invalid_url_body": "Keine Mod-ID in der URL gefunden.",
   "nexus.linked": "Verknüpft",

--- a/src/cdumm/translations/en.json
+++ b/src/cdumm/translations/en.json
@@ -1192,6 +1192,8 @@
   "infobar.import_empty": "Import Empty",
   "infobar.snapshot_complete": "Snapshot Complete",
   "infobar.snapshot_complete_msg": "{count} game files indexed. You can now import mods.",
+  "infobar.snapshot_no_version": "Snapshot Done — Game Version Unknown",
+  "infobar.snapshot_no_version_msg": "{count} game files indexed, but the game version could not be read (CrimsonDesert.exe may be locked by antivirus or Steam). Apply may still be blocked — close Steam and run Rescan Game Files again.",
   "nexus.invalid_url": "Invalid URL",
   "nexus.invalid_url_body": "Could not find a mod ID in that URL.",
   "nexus.linked": "Linked",

--- a/tests/test_snapshot_version_stamp_visible.py
+++ b/tests/test_snapshot_version_stamp_visible.py
@@ -1,0 +1,167 @@
+"""A rescan that couldn't read the game version must say so.
+
+GitHub #315. #309 blocks Apply when the live game fingerprint differs from
+the stored one, and tells the user to run Rescan Game Files. There is one
+path where that advice doesn't work:
+
+1. ``detect_game_version`` returns ``None`` during the snapshot -- a
+   transient, e.g. antivirus or Steam briefly holding CrimsonDesert.exe.
+2. The worker logs "not stamping" and leaves the OLD fingerprint stored.
+3. The caller cleared the ``game_updated`` flag anyway.
+4. Detection succeeds on the next Apply click, live now differs from the
+   stale stored value, and Apply is blocked -- immediately after the user
+   did exactly what the banner asked.
+
+Recoverable (rescanning again once detection works clears it), so not a
+lockout. But the user ran the fix, it appeared to succeed, and the same
+message came back. The only evidence was a log line.
+
+The snapshot now records whether the stamp actually happened, in the same
+transaction as the snapshot itself, and the caller stops pretending.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+FLAG = "last_snapshot_version_stamped"
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)")
+    c.commit()
+    return c
+
+
+def _stamped(win) -> bool:
+    """The real implementation, called unbound against a stand-in."""
+    pytest.importorskip("qfluentwidgets")
+    from cdumm.gui.fluent_window import CdummWindow
+    return CdummWindow._snapshot_stamped_version(win)
+
+
+class _Win:
+    """Stands in for the window: the helper only touches ``self._db``."""
+
+    def __init__(self, conn=None):
+        self._db = None if conn is None else type(
+            "DB", (), {"connection": conn})()
+
+
+def test_reads_a_successful_stamp(conn):
+    conn.execute("INSERT INTO config VALUES (?, ?)", (FLAG, "1"))
+    assert _stamped(_Win(conn)) is True
+
+
+def test_reads_a_failed_stamp(conn):
+    conn.execute("INSERT INTO config VALUES (?, ?)", (FLAG, "0"))
+    assert _stamped(_Win(conn)) is False
+
+
+def test_an_older_database_without_the_flag_is_treated_as_fine(conn):
+    """Upgrading must not start warning about snapshots that were fine."""
+    assert _stamped(_Win(conn)) is True
+
+
+def test_no_database_is_treated_as_fine():
+    assert _stamped(_Win(None)) is True
+
+
+def test_a_broken_config_table_never_breaks_the_callback():
+    c = sqlite3.connect(":memory:")   # no config table at all
+    assert _stamped(_Win(c)) is True
+
+
+# --------------------------------------------------- the worker's record
+
+def _run_stamp_block(conn, detected: str | None, raises: bool = False):
+    """Reproduce the worker's stamp step against a real config table.
+
+    Mirrors the block in ``snapshot_manager``: stamp when a fingerprint
+    comes back, and record the outcome either way.
+    """
+    stamped = False
+    try:
+        if raises:
+            raise OSError("exe locked")
+        fp = detected
+        if fp:
+            conn.execute(
+                "INSERT INTO config (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                ("game_version_fingerprint", fp))
+            stamped = True
+    except Exception:  # noqa: BLE001 -- matches the worker's handler
+        stamped = False
+    conn.execute(
+        "INSERT INTO config (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (FLAG, "1" if stamped else "0"))
+    conn.commit()
+    return stamped
+
+
+def _get(conn, key):
+    row = conn.execute(
+        "SELECT value FROM config WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def test_a_readable_version_stamps_and_records_success(conn):
+    assert _run_stamp_block(conn, "abc123") is True
+    assert _get(conn, "game_version_fingerprint") == "abc123"
+    assert _get(conn, FLAG) == "1"
+    assert _stamped(_Win(conn)) is True
+
+
+def test_an_unreadable_version_leaves_the_old_fingerprint_and_records_it(conn):
+    """The exact sequence from the issue: the stale value survives, which
+    is why the flag has to exist -- the stored fingerprint alone cannot
+    tell you the snapshot failed to refresh it."""
+    conn.execute("INSERT INTO config VALUES (?, ?)",
+                 ("game_version_fingerprint", "OLD-1.14"))
+    conn.commit()
+
+    assert _run_stamp_block(conn, None) is False
+    assert _get(conn, "game_version_fingerprint") == "OLD-1.14", (
+        "the stale fingerprint is deliberately left alone")
+    assert _get(conn, FLAG) == "0"
+    assert _stamped(_Win(conn)) is False
+
+
+def test_a_raising_detector_is_recorded_as_not_stamped(conn):
+    assert _run_stamp_block(conn, "abc", raises=True) is False
+    assert _get(conn, FLAG) == "0"
+    assert _stamped(_Win(conn)) is False
+
+
+def test_a_later_good_rescan_clears_the_warning(conn):
+    _run_stamp_block(conn, None)
+    assert _stamped(_Win(conn)) is False
+    _run_stamp_block(conn, "abc123")
+    assert _stamped(_Win(conn)) is True
+
+
+# ------------------------------------------------------ the user-facing bit
+
+def test_the_warning_strings_exist_and_say_what_to_do():
+    """Read en.json directly: tr() falls back to English anyway, and a
+    bare test process has no language loaded, so going through it would
+    assert nothing."""
+    import json
+    from pathlib import Path
+
+    en = json.loads(
+        (Path(__file__).resolve().parents[1] / "src" / "cdumm" /
+         "translations" / "en.json").read_text(encoding="utf-8"))
+
+    assert "infobar.snapshot_no_version" in en
+    body = en["infobar.snapshot_no_version_msg"]
+    assert "{count}" in body, "the file count still gets reported"
+    lowered = body.lower()
+    assert "rescan" in lowered, "must name the action that fixes it"
+    assert "antivirus" in lowered or "steam" in lowered, (
+        "must name the likely cause, since 'try again' alone is not advice")


### PR DESCRIPTION
Fixes #315. Both of your suggestions, because they fix different halves of it.

You had the sequence exactly right: `detect_game_version` returns `None`, the worker leaves the **old** fingerprint stored, `_on_snapshot_finished` clears `game_updated` anyway, and the next Apply compares live against stale and blocks — right after the user did the thing the banner asked them to do.

And your framing was right too: it's recoverable, so this isn't a lockout. It's that the loop was **invisible**. The rescan reported success. The only evidence was a log line.

## The two halves

**1. Record whether the stamp happened.** The snapshot worker now writes `config.last_snapshot_version_stamped` inside the same transaction as the snapshot itself.

This needs its own flag rather than being inferred: the stored fingerprint can't answer the question. A failed stamp leaves the old value in place, which is byte-identical to a snapshot taken when the version genuinely hadn't changed.

**2. Stop pretending in the caller.** On a good stamp, unchanged — clear the flag, success toast. On a failed stamp it leaves `game_updated` set, so the state stays honest instead of claiming an unlock it didn't achieve, and shows a warning instead of a success:

> **Snapshot Done — Game Version Unknown**
> N game files indexed, but the game version could not be read (CrimsonDesert.exe may be locked by antivirus or Steam). Apply may still be blocked — close Steam and run Rescan Game Files again.

That names the likely cause *and* the action, which is the difference between advice and "try again". Your third suggestion — distinguishing the two states in the Apply banner — falls out of this too, since `game_updated` staying set means the existing banner is still correct rather than misleading.

## Backwards compatibility

A database that predates the flag reads as **stamped**, so upgrading doesn't start warning about snapshots that were in fact fine. A missing or unreadable config table does the same rather than breaking the callback.

## Strings

`en.json` and `de.json` — `de` is the one `test_i18n_key_parity` enforces. The other 14 languages fall back to English through `tr()` rather than showing a raw key.

## Tests

10, covering both halves: the worker's record for a readable version, an unreadable one, and a raising detector; the reader for present/absent/old-schema/no-database/broken-table; a good rescan clearing a previous warning; and the strings actually naming the cause and the fix.

The one worth calling out is `test_an_unreadable_version_leaves_the_old_fingerprint_and_records_it` — it asserts the stale fingerprint is *deliberately* left alone, which is what makes the separate flag necessary rather than incidental.

## Checks

- Fast suite: **2462 passed, 42 skipped** (2452 on `master` + the 10 new)
- `ruff` clean on the added test; **zero new findings** on the two modified source files
