### PR TITLE
buffinfo: a blocked walk may only publish what it can vouch for (Fixes #325)

### DIFF
--- a/src/cdumm/_vendor/buffinfo_parser.py
+++ b/src/cdumm/_vendor/buffinfo_parser.py
@@ -1049,6 +1049,70 @@ def walk_buff_data_items(entry_bytes: bytes) -> tuple[list[int], str]:
     return starts, (WALK_TILES if position == end else WALK_MISMATCH)
 
 
+#: Upper bound on a variant tail, from the round-3 derivation sweep
+#: (0..399). Used to sanity-check a tail size derived from a single
+#: record rather than looked up.
+_MAX_PLAUSIBLE_TAIL = 399
+
+
+def _last_item_tail_is_plausible(entry_bytes: bytes, starts: list[int]) -> bool:
+    """Can the ONE unknown tail at the end of the list be accounted for?
+
+    Only meaningful when the walk placed every item and stopped on the
+    last one, so exactly one tail size is missing. That size isn't a
+    lookup, it's forced: the list has to reach ``min_level_offset``, so
+    the missing tail must be ``min_level_offset - payload_end``.
+
+    That makes it a real check rather than an assumption. If a size
+    earlier in the record has drifted, the walk arrives at the last item
+    in the wrong place and the forced tail comes out negative (drifted
+    long) or absurdly large (drifted short). Either way it fails here.
+    """
+    entry = parse_entry(entry_bytes)
+    if not starts or len(starts) != entry.buff_data_count:
+        return False              # more than the last tail is unknown
+    try:
+        hdr = parse_item_header(entry_bytes, starts[-1])
+        if hdr.absent_flag != 0:
+            return False          # an absent item has no tail to derive
+        common = parse_payload_common(entry_bytes, hdr.payload_offset)
+    except ValueError:
+        return False
+    required = entry.min_level_offset - common.end_offset
+    return 0 <= required <= _MAX_PLAUSIBLE_TAIL
+
+
+def resolvable_item_count(
+    entry_bytes: bytes, starts: list[int], outcome: str,
+) -> int:
+    """How many of ``starts`` are safe to hand out as write targets.
+
+    GitHub #325. #313 refused only ``WALK_MISMATCH``, on the reasoning
+    that items placed before a block were each reached over known-size
+    predecessors. That reasoning is wrong when the drifted size IS one
+    of those predecessors: the walk loses its place early, then stops
+    later for an unrelated reason (an unknown tag), and reports
+    ``WALK_BLOCKED`` while holding offsets that are already wrong.
+
+    Refusing only the items at or after the block point does not help ,
+    the damage is upstream of it. Measured over every single-tag
+    perturbation of the shipped size table, that rule returns exactly as
+    many wrong offsets as no rule at all.
+
+    So a blocked walk publishes only item 0, which needs no walking and
+    is therefore correct whatever the sizes say , unless the one missing
+    tail is at the very end and can be derived and sanity-checked, which
+    is what rescues the records that block on their final item.
+    """
+    if outcome == WALK_TILES:
+        return len(starts)
+    if outcome == WALK_MISMATCH:
+        return 0                  # the sizes contradict the table
+    if _last_item_tail_is_plausible(entry_bytes, starts):
+        return len(starts)
+    return 1 if starts else 0
+
+
 def locate_buff_field(
     entry_bytes: bytes, field_path: str,
 ) -> tuple[int, int, str] | None:
@@ -1099,16 +1163,11 @@ def locate_buff_field(
         if n >= entry.buff_data_count:
             return None  # past the end of the list
         starts, outcome = walk_buff_data_items(entry_bytes)
-        if outcome == WALK_MISMATCH:
-            # Every item was stepped over with a known size, yet the walk
-            # did not finish on min_level_offset. The sizes contradict the
-            # table, so nothing derived from them can be trusted , not even
-            # item 0, because a wrong buff_data_list_offset shows up the
-            # same way. Refuse the whole record (GitHub #313).
-            return None
-        if n >= len(starts):
-            # The walk stopped before item n , an unknown variant tag or an
-            # unreadable header in between. Item n's position is unknown.
+        # Only the offsets the walk can actually vouch for are usable.
+        # A mismatch discredits the whole record; a blocked walk
+        # discredits everything past item 0 unless the single missing
+        # tail sits at the end and can be derived (GitHub #313, #325).
+        if n >= resolvable_item_count(entry_bytes, starts, outcome):
             return None
         position = starts[n]
         header = parse_item_header(entry_bytes, position)

--- a/tests/test_buffinfo_blocked_walk_prefix.py
+++ b/tests/test_buffinfo_blocked_walk_prefix.py
@@ -1,0 +1,197 @@
+"""A blocked walk may only publish what it can vouch for.
+
+GitHub #325, follow-up to #313 / #321.
+
+#321 refused ``WALK_MISMATCH`` on the reasoning that items placed before
+a block were each reached over known-size predecessors. That reasoning is
+wrong when the drifted size **is** one of those predecessors: the walk
+loses its place early, then stops later for an unrelated reason (an
+unknown tag), reports ``WALK_BLOCKED``, and hands back offsets it had
+already got wrong.
+
+The issue's own example, record 1000078 with tag 80 drifted one byte::
+
+    truth item starts = [33, 162, 291, 420, 549, 678]
+    drift item starts = [33, 163, 168]
+
+Item 1 comes back as 163 instead of 162 -- a one-byte-off write target
+returned as valid, which is exactly #313's failure mode.
+
+Refusing only the items at or **after** the block point does not help:
+the damage is upstream of it. Measured over every single-tag perturbation
+of the shipped table, that rule returns exactly as many wrong offsets as
+no rule at all.
+
+So a blocked walk publishes item 0 -- which needs no walking and is
+correct whatever the sizes say -- and nothing else, *unless* the single
+missing tail is the last one. Then it isn't a lookup at all: the list has
+to reach ``min_level_offset``, so the tail is forced, and a prefix that
+drifted makes the forced value negative or absurd. That check is what
+keeps the 34 records blocking on their final item working.
+"""
+from __future__ import annotations
+
+import zlib
+from pathlib import Path
+
+import pytest
+
+from cdumm._vendor import buffinfo_parser as bp
+from cdumm.semantic.parser import parse_pabgh_index
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "vanilla115"
+
+pytestmark = pytest.mark.skipif(
+    not (_FIXTURES / "buffinfo.pabgb.zlib").exists(),
+    reason="vanilla115 buffinfo fixture absent")
+
+#: The issue's worked example. It quotes the first six of nine items.
+DRIFT_TAG = 80
+DRIFT_RECORD = 1000078
+TRUTH_STARTS = [33, 162, 291, 420, 549, 678, 807, 936, 1065]
+DRIFTED_WALK = [33, 163, 168]
+
+#: Measured on the committed table. Pinned so a change in the size table
+#: has to account for its effect on what CDUMM is willing to write.
+BLOCKED_RECORDS = 63
+BLOCKED_ON_LAST_ITEM = 34
+
+
+def _load(name: str) -> bytes:
+    return zlib.decompress((_FIXTURES / (name + ".zlib")).read_bytes())
+
+
+def _entries() -> dict[int, bytes]:
+    body, header = _load("buffinfo.pabgb"), _load("buffinfo.pabgh")
+    _keys, offs = parse_pabgh_index(header, "buffinfo")
+    ordered = sorted(offs.items(), key=lambda kv: kv[1])
+    out = {}
+    for i, (key, off) in enumerate(ordered):
+        end = ordered[i + 1][1] if i + 1 < len(ordered) else len(body)
+        out[key] = body[off:end]
+    return out
+
+
+def _starts(eb: bytes) -> list[int]:
+    """Item starts as locate_buff_field would hand them out.
+
+    ``leading_lookup`` resolves to the item's first byte; ``absent_flag``
+    is four bytes further in, so this is the path that compares directly
+    against the walk's own offsets.
+    """
+    out = []
+    for n in range(bp.parse_entry(eb).buff_data_count):
+        got = bp.locate_buff_field(eb, f"buff_data_list[{n}].leading_lookup")
+        if got is None:
+            break
+        out.append(got[0])
+    return out
+
+
+# ------------------------------------------------- resolvable_item_count
+
+def test_a_tiling_walk_publishes_everything():
+    for eb in _entries().values():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome == bp.WALK_TILES:
+            assert bp.resolvable_item_count(eb, starts, outcome) == len(starts)
+
+
+def test_a_mismatched_walk_publishes_nothing():
+    eb = next(iter(_entries().values()))
+    starts, _o = bp.walk_buff_data_items(eb)
+    assert bp.resolvable_item_count(eb, starts, bp.WALK_MISMATCH) == 0
+
+
+def test_a_blocked_walk_publishes_item_0_at_minimum():
+    entries = _entries()
+    blocked = 0
+    for eb in entries.values():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome != bp.WALK_BLOCKED:
+            continue
+        blocked += 1
+        assert bp.resolvable_item_count(eb, starts, outcome) >= 1
+        assert bp.locate_buff_field(
+            eb, "buff_data_list[0].absent_flag") is not None
+    assert blocked == BLOCKED_RECORDS
+
+
+def test_records_blocking_on_their_last_item_keep_their_earlier_items():
+    """Issue acceptance #1. These are the records the derived-tail check
+    exists for -- without it they would drop to item 0 only."""
+    entries = _entries()
+    rescued = kept_offsets = 0
+    for eb in entries.values():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        if outcome != bp.WALK_BLOCKED:
+            continue
+        if len(starts) != bp.parse_entry(eb).buff_data_count:
+            continue
+        rescued += 1
+        n = bp.resolvable_item_count(eb, starts, outcome)
+        assert n == len(starts), "the last tail is derivable, so all resolve"
+        kept_offsets += max(0, n - 1)
+    assert rescued == BLOCKED_ON_LAST_ITEM
+    assert kept_offsets > 0
+
+
+# --------------------------------------------------- the drift it closes
+
+def test_the_issue_example_no_longer_returns_a_shifted_offset(monkeypatch):
+    """Record 1000078, tag 80 drifted by one byte. Item 1 used to come
+    back as 163 against a true 162."""
+    eb = _entries()[DRIFT_RECORD]
+    assert _starts(eb) == TRUTH_STARTS, "precondition: undrifted truth"
+
+    sizes = dict(bp._VARIANT_TAIL_SIZES)
+    sizes[DRIFT_TAG] += 1
+    monkeypatch.setattr(bp, "_VARIANT_TAIL_SIZES", sizes)
+
+    starts, outcome = bp.walk_buff_data_items(eb)
+    assert outcome == bp.WALK_BLOCKED, "precondition: this drift blocks"
+    assert starts == DRIFTED_WALK, "the walk itself still goes astray"
+
+    published = _starts(eb)
+    assert published == [33], "only item 0 may be published"
+    assert bp.locate_buff_field(
+        eb, "buff_data_list[1].absent_flag") is None
+    assert bp.locate_buff_field(
+        eb, "buff_data_list[1].leading_lookup") is None
+
+
+def test_no_drifted_offset_is_published_for_any_blocked_record(monkeypatch):
+    """Issue acceptance #2, over every tag the perturbation blocks.
+
+    Kept to a single delta so it stays a fast test; the full sweep over
+    six deltas of every tag was run offline and also reaches zero.
+    """
+    entries = _entries()
+    truth = {k: _starts(eb) for k, eb in entries.items()}
+
+    wrong = 0
+    for tag in sorted(bp._VARIANT_TAIL_SIZES):
+        sizes = dict(bp._VARIANT_TAIL_SIZES)
+        sizes[tag] += 1
+        monkeypatch.setattr(bp, "_VARIANT_TAIL_SIZES", sizes)
+        for k, eb in entries.items():
+            _s, outcome = bp.walk_buff_data_items(eb)
+            if outcome != bp.WALK_BLOCKED:
+                continue          # tiles: not this issue; mismatch: refused
+            for i, off in enumerate(_starts(eb)):
+                if i >= len(truth[k]) or truth[k][i] != off:
+                    wrong += 1
+        monkeypatch.undo()
+    assert wrong == 0
+
+
+def test_the_guard_only_ever_tightens(monkeypatch):
+    """Nothing becomes resolvable that wasn't before -- a safety check
+    that widens coverage would mean it isn't a safety check."""
+    entries = _entries()
+    before = {k: _starts(eb) for k, eb in entries.items()}
+    for k, eb in entries.items():
+        starts, outcome = bp.walk_buff_data_items(eb)
+        n = bp.resolvable_item_count(eb, starts, outcome)
+        assert len(before[k]) <= len(starts)
+        assert len(before[k]) == min(n, len(starts))


### PR DESCRIPTION
Fixes #325.


Fixes #325.

You're right, and the reasoning I wrote in #321 is the part that was
wrong. "Items already placed were reached over known-size predecessors"
does not hold when the drifted size IS one of those predecessors: the
walk loses its place early, stops later for an unrelated reason, reports
WALK_BLOCKED, and hands back offsets it had already got wrong.

Reproduced your example exactly, record 1000078 with tag 80 drifted by
one byte:

    truth walk = [33, 162, 291, 420, 549, 678, 807, 936, 1065]  (tiles)
    drift walk = [33, 163, 168]                                 (blocked)

    locate("buff_data_list[1].leading_lookup") = 163, true value 162

Your suggested direction doesn't work
-------------------------------------
Refusing only the items at or after the block point leaves the damage
untouched, because the damage is upstream of it -- in your own example
the walk blocked at item 3 while items 1 and 2 were already wrong.
Measured over every single-tag perturbation of the shipped table, that
rule returns exactly as many wrong offsets as no rule at all: 3328 vs
3328.

What actually holds
-------------------
When a walk blocks, the only offset that can be proved is item 0, which
needs no walking. Every later one rests on sizes the tiling check never
got to validate.

That alone would cost the 34 records that block on their final item, so
those get a real check rather than an assumption. When the ONE missing
tail is the last one, it isn't a lookup -- the list has to reach
min_level_offset, so the tail is forced:

    required = min_level_offset - payload_end

A prefix that drifted long makes that negative; one that drifted short
makes it absurd. Requiring 0 <= required <= 399 (the round-3 sweep bound)
is therefore evidence, not an assumption, and it keeps those 34 working.

Measured
--------
Model-level, sweeping every tag by +/-1, 2, 3, 4, 8, 16:

    today (merged #321)           3328 wrong offsets
    refuse at/after block point    3328
    item 0 only                      67
    item 0 + derived last tail        67

Both safe rules reach the same floor, so the derived-tail rescue is free.
Those 67 are not a BLOCKED problem: all of them are in records that TILE
under the drifted table, a compensating error that lands on
min_level_offset anyway. Tiling is a checksum and checksums collide; no
rule about blocked walks can touch them. Worth writing down as the
technique's real limit.

Through locate_buff_field itself, on the committed table:

    offsets resolved, merged #321 : 2829
    offsets resolved, this branch : 2683
      values changed  : 0
      newly resolved  : 0
      newly refused   : 146

The 146 are the unprovable ones. Your acceptance point 3 asks for no
regression in what resolves today, and that cannot hold together with
point 2 -- closing the hole means refusing offsets that currently
resolve, because those are the ones that go wrong under drift. 30 of the
176 exposed slots are recovered by the derived-tail check; the other 146
are refusals by design.

Acceptance
----------
  * the 34 records blocking on their final item still resolve their
    earlier items -- pinned
  * no offset from a blocked walk survives a +1 drift of any tag, run
    through locate_buff_field over all 290 records -- 0
  * item 0 of all 63 blocked records still resolves -- pinned
  * nothing became resolvable that wasn't before

Fast suite: 2573 passed, 42 skipped. ruff clean on the added test, zero
new findings on the parser.
