### PR TITLE
import: surface variant packs that ship unpacked NNNN trees (Refs #329)

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -537,6 +537,33 @@ from cdumm.engine.texture_mod_handler import detect_texture_mod, convert_texture
 _GAME_FILE_RE = re.compile(r'^(\d{4}/\d+\.(?:paz|pamt)|meta/\d+\.(?:papgt|pathc))$')
 
 
+def _nnnn_holds_game_content(nnnn: "Path") -> bool:
+    """True when a 4-digit game directory carries content in either form.
+
+    Mods ship a ``NNNN`` directory's payload two ways:
+
+    * **packed** -- ``NNNN/0.paz`` or ``NNNN/0.pamt``, the archive form
+      matched by :data:`_GAME_FILE_RE`.
+    * **loose** -- ``NNNN/<root>/...`` an unpacked tree, e.g. Character
+      Creator 7.7's ``0009/character/...`` and ``0012/ui/...``.
+
+    The loose arm deliberately requires a **subdirectory** rather than
+    just a non-empty directory. A loose game tree is always
+    ``NNNN/<root>/<file>``, so insisting on one directory level keeps
+    this from firing on a stray ``NNNN`` folder that happens to hold a
+    couple of loose files, and it cannot overlap the packed arm because
+    ``0.paz``/``0.pamt`` are files rather than directories.
+
+    Callers already establish that ``nnnn.name`` is four digits.
+    """
+    try:
+        if (nnnn / "0.paz").exists() or (nnnn / "0.pamt").exists():
+            return True
+        return any(child.is_dir() for child in nnnn.iterdir())
+    except OSError:
+        return False
+
+
 def _verify_and_fix_pamt_crc(pamt_bytes: bytes, rel_path: str) -> bytes:
     """Verify PAMT CRC and fix it if wrong.
 
@@ -1604,16 +1631,29 @@ def _find_loose_file_candidates(path: Path, max_depth: int = 5) -> list[dict]:
         if base_key in seen_bases:
             return None
         # Pattern 5: mod.json at this folder + 2+ sibling subfolders
-        # each carrying a NNNN/0.paz OR NNNN/0.pamt layout. Surface
-        # one candidate per sibling so the GUI's variant picker fires.
+        # each carrying a NNNN/ game-file directory. Surface one
+        # candidate per sibling so the GUI's variant picker fires.
         # Used by Character Creator (mod 837): CharacterCreator/mod.json
         # alongside HumanFemale/0036/..., GoblinMale/0036/..., etc.
+        #
+        # A NNNN dir counts when it holds game content in EITHER form,
+        # per _nnnn_holds_game_content:
+        #
+        #   packed  NNNN/0.paz  or  NNNN/0.pamt
+        #   loose   NNNN/<root>/...        (e.g. 0009/character/...)
+        #
         # v6.3+ ships each body type as 0036/0.pamt (no 0.paz), so the
-        # marker check accepts either archive form — both are valid game
-        # files per _GAME_FILE_RE (GitHub #189). Must run BEFORE Pattern
-        # 2 because Pattern 2 would otherwise match the top-level
-        # mod.json + sibling json/asi files at root and stop the walk
-        # before the body-type subfolders get a chance.
+        # packed form accepts either archive — both are valid game files
+        # per _GAME_FILE_RE (GitHub #189). Character Creator 7.7 then
+        # stopped packing altogether and ships loose trees instead
+        # (0009/character/..., 0012/ui/...) with ZERO .paz/.pamt in the
+        # whole archive, so a packed-only marker matched none of the
+        # race folders, variant_subdirs came back empty and the picker
+        # silently never fired (GitHub #329).
+        #
+        # Must run BEFORE Pattern 2 because Pattern 2 would otherwise
+        # match the top-level mod.json + sibling json/asi files at root
+        # and stop the walk before the body-type subfolders get a chance.
         mod_json = candidate / "mod.json"
         if mod_json.exists():
             try:
@@ -1638,11 +1678,11 @@ def _find_loose_file_candidates(path: Path, max_depth: int = 5) -> list[dict]:
                         continue
                     try:
                         for d in sub.iterdir():
-                            if (d.is_dir()
+                            if not (d.is_dir()
                                     and d.name.isdigit()
-                                    and len(d.name) == 4
-                                    and ((d / "0.paz").exists()
-                                         or (d / "0.pamt").exists())):
+                                    and len(d.name) == 4):
+                                continue
+                            if _nnnn_holds_game_content(d):
                                 variant_subdirs.append(sub)
                                 break
                     except OSError:

--- a/tests/test_variant_pack_with_modjson_at_root.py
+++ b/tests/test_variant_pack_with_modjson_at_root.py
@@ -177,3 +177,113 @@ def test_pamt_only_variants_surface(tmp_path):
         f"each variant's _base_dir must be its body-type subfolder; "
         f"got: {sorted(bases)}"
     )
+
+
+_RACES_77 = ("Human Female", "Human Male", "Goblin Female", "Goblin Male",
+             "Orc Female", "Orc Male", "Dwarf Female", "Dwarf Male")
+
+
+def _make_loose_tree_variant_pack(tmp_path: Path) -> Path:
+    """Character Creator 837 as shipped in 7.7 (GitHub #329).
+
+    The third packaging change to this mod. 6.3 swapped ``0.paz`` for
+    ``0.pamt`` (#189); 7.7 stops packing altogether and ships each body
+    type as an UNPACKED tree -- ``0009/character/...`` and
+    ``0012/ui/...``. Verified against the real Nexus file 13119: it
+    contains **zero** ``0.paz`` or ``0.pamt`` entries anywhere.
+
+    The NNNN dirs are still there and still correctly named, so the
+    packed-only marker check found no variant subdirs, Pattern 5 was
+    skipped, and the body-type picker silently never fired.
+    """
+    root = tmp_path / "Character Creator"
+    root.mkdir()
+    (root / "mod.json").write_text(
+        '{"modinfo": {"title": "Character Creator", "version": "7.7"}}',
+        encoding="utf-8")
+    (root / "Female Animations.field.json").write_bytes(b"{}")
+    (root / "CharacterCreatorHead.asi").write_bytes(b"\x00")
+    for variant in _RACES_77:
+        # 0009 -> character/, 0012 -> ui/ : loose trees, no archive.
+        for nnnn, game_root in (("0009", "character"), ("0012", "ui")):
+            leaf = root / variant / nnnn / game_root / "descriptors"
+            leaf.mkdir(parents=True)
+            (leaf / "player_001.xml").write_text("<x/>", encoding="utf-8")
+    return tmp_path
+
+
+def test_loose_tree_variants_surface(tmp_path):
+    """7.7 ships unpacked NNNN/<root>/ trees with no .paz/.pamt at all.
+    Every body type must still surface (GitHub #329)."""
+    from cdumm.engine.import_handler import find_loose_file_variants
+
+    _make_loose_tree_variant_pack(tmp_path)
+    variants = find_loose_file_variants(tmp_path)
+
+    ids = sorted(v["id"] for v in variants)
+    assert len(variants) == len(_RACES_77), (
+        f"expected {len(_RACES_77)} loose-tree body-type variants, "
+        f"got {len(variants)}: {ids}"
+    )
+    bases = {Path(v["_base_dir"]).name for v in variants}
+    assert bases == set(_RACES_77), (
+        f"each variant's _base_dir must be its body-type subfolder; "
+        f"got: {sorted(bases)}"
+    )
+
+
+def test_loose_marker_needs_a_directory_not_just_files(tmp_path):
+    """The loose arm requires a SUBDIRECTORY inside NNNN, not merely a
+    non-empty NNNN. A body-type folder whose NNNN holds only loose files
+    is not a game tree, and widening the marker to "non-empty" would
+    start classifying such shapes as variant packs."""
+    from cdumm.engine.import_handler import find_loose_file_variants
+
+    root = tmp_path / "Character Creator"
+    root.mkdir()
+    (root / "mod.json").write_text(
+        '{"modinfo": {"title": "Character Creator"}}', encoding="utf-8")
+    for variant in ("Human Female", "Human Male", "Orc Female"):
+        d = root / variant / "0009"
+        d.mkdir(parents=True)
+        # files only -- no subdirectory, no archive
+        (d / "readme.txt").write_text("notes", encoding="utf-8")
+        (d / "preview.png").write_bytes(b"\x89PNG")
+
+    variants = find_loose_file_variants(tmp_path)
+    assert len(variants) < 2, (
+        f"NNNN dirs holding only loose files must not be treated as "
+        f"game trees; got {len(variants)}: {[v['id'] for v in variants]}"
+    )
+
+
+def test_nnnn_holds_game_content_arms(tmp_path):
+    """The predicate itself: packed archive, loose subdirectory, and the
+    two negatives."""
+    from cdumm.engine.import_handler import _nnnn_holds_game_content
+
+    packed_paz = tmp_path / "a" / "0009"
+    packed_paz.mkdir(parents=True)
+    (packed_paz / "0.paz").write_bytes(b"\x00")
+    assert _nnnn_holds_game_content(packed_paz) is True
+
+    packed_pamt = tmp_path / "b" / "0009"
+    packed_pamt.mkdir(parents=True)
+    (packed_pamt / "0.pamt").write_bytes(b"\x00")
+    assert _nnnn_holds_game_content(packed_pamt) is True
+
+    loose = tmp_path / "c" / "0009"
+    (loose / "character").mkdir(parents=True)
+    assert _nnnn_holds_game_content(loose) is True
+
+    files_only = tmp_path / "d" / "0009"
+    files_only.mkdir(parents=True)
+    (files_only / "readme.txt").write_text("x", encoding="utf-8")
+    assert _nnnn_holds_game_content(files_only) is False
+
+    empty = tmp_path / "e" / "0009"
+    empty.mkdir(parents=True)
+    assert _nnnn_holds_game_content(empty) is False
+
+    missing = tmp_path / "f" / "0009"
+    assert _nnnn_holds_game_content(missing) is False


### PR DESCRIPTION
Character Creator's body-type picker stopped firing because the mod stopped packing. 7.7 ships each race/gender as an **unpacked** tree — `0009/character/...`, `0012/ui/...` — and the archive contains **zero** `.paz`/`.pamt` entries. Pattern 5's marker only accepted the packed forms, so the four-digit name test passed and the archive test failed on every race folder; `variant_subdirs` came back empty, Pattern 5 was skipped, and the picker silently never fired.

## Measured against the real Nexus file

Mod 837, file 13119, extracted through `_extractall_collapsing_wrapper` both ways:

| | before | after |
|---|---|---|
| real Nexus filename (`Character Creator-837-7-7-…`) | 1 → no picker | **8 → picker fires** |
| stem == wrapper name | 1 → no picker | **8 → picker fires** |

All eight surface: Dwarf/Goblin/Human/Orc × Female/Male.

Worth noting it fixes both extraction paths. A real Nexus filename's stem doesn't equal the `Character Creator/` wrapper, so the #191 collapse doesn't fire and everything sits a level deeper — I initially assumed that was the cause. It isn't: the picker failed at *both* depths, so the marker was the whole story. Recorded on the issue so the wrapper theory doesn't get re-run.

## Blast radius

Pulled the current trending / latest-updated / latest-added lists and classified every archive before and after:

```
14 other real Nexus mods   loose=0 f3=0  ->  loose=0 f3=0   (identical)
mod837 Character Creator   loose=1       ->  loose=8
```

Only the broken mod moves.

## Why a shared predicate rather than a third special case

This is the third packaging change to the same mod — 6.3 swapped `0.paz` for `0.pamt` (#189), 7.7 unpacks entirely. The marker now goes through `_nnnn_holds_game_content`, which accepts either shape:

```
packed   NNNN/0.paz  or  NNNN/0.pamt
loose    NNNN/<root>/...
```

The loose arm requires a **subdirectory**, not merely a non-empty `NNNN`. A loose game tree is always `NNNN/<root>/<file>`, so one directory level is the real signal — and widening to "non-empty" would start treating a body-type folder whose `NNNN` holds a readme and a preview image as a variant pack, which is exactly the mis-classification the original narrow check existed to prevent. It also can't overlap the packed arm, since `0.paz`/`0.pamt` are files.

Both arms are pinned from opposite sides:

```
revert the loose arm (recreate #329)  -> test_loose_tree_variants_surface fails
widen to any non-empty NNNN          -> test_loose_marker_needs_a_directory fails
```

Plus the predicate's own arms directly: both packed forms, loose subdirectory, and three negatives (files-only, empty, missing path). Tests are synthetic — no Nexus download — so they run in CI.

## What this does not fix

The crash in #329. A detector returning one candidate instead of eight is a quiet wrong-path, not a crash, and I haven't reproduced the crash — so I'm not claiming these are the same bug. @lurkser's per-component import test is still the thing that would narrow it.

Full suite 2618 passed, 42 skipped. Ruff: 97 findings on the touched files before, 97 after, no new codes.

Refs #329
