### PR TITLE
Don't half-write a characterinfo record (#329 crash)

### DIFF
--- a/src/cdumm/engine/characterinfo_writer.py
+++ b/src/cdumm/engine/characterinfo_writer.py
@@ -214,11 +214,6 @@ def build_characterinfo_changes(
                 "characterinfo: field %r is not supported, skipping",
                 field)
             continue
-        if isinstance(new_value, bool) or not isinstance(new_value, int):
-            logger.warning(
-                "characterinfo: intent %s on %r has non-integer value "
-                "%r, skipping", field, entry_name, new_value)
-            continue
         key = name_to_key.get(entry_name)
         if key is None and raw_key:
             key = raw_key
@@ -234,6 +229,18 @@ def build_characterinfo_changes(
         # unbalances the record.
         off_key, delta, fmt, width = spec
         modelled.setdefault(entry_name, {})[field] = off_key
+        # The type check sits BELOW the registration above deliberately. A
+        # bad value is still a field the mod asked this record to carry, so
+        # dropping it must abandon the record like any other unwritable
+        # field. Checking before registration let a non-integer escape the
+        # all-or-nothing guard entirely: the other fields were written and
+        # the record ended up half-modded, which is exactly the crash this
+        # writer exists to prevent.
+        if isinstance(new_value, bool) or not isinstance(new_value, int):
+            logger.warning(
+                "characterinfo: intent %s on %r has non-integer value "
+                "%r, skipping", field, entry_name, new_value)
+            continue
         base: int | None = rec.get(off_key)
         if base is None:
             logger.warning(

--- a/src/cdumm/engine/characterinfo_writer.py
+++ b/src/cdumm/engine/characterinfo_writer.py
@@ -109,9 +109,13 @@ _FIELD_MAP: dict[str, tuple[str, int, str, int]] = {
 # wrote to a constant; the current schema routes lookup_24 to its real slot
 # (+20). The three post-block fields the 7.6 mod also sets
 # (default_action_action_index, character_weight, f36) sit in the stretch
-# Pearl Abyss made variable-length in 1.13; their offset drifts per record
-# and is deliberately NOT mapped -- they report "could not locate" rather
-# than being written to a guess.
+# Pearl Abyss made variable-length in 1.13, so their offset drifts per
+# record. They ARE mapped -- inherited from _FIELD_MAP above -- but only
+# to a parser offset key the walk publishes when its f32-2.0 gate confirms
+# the position, so a record whose layout can't be verified reports "could
+# not locate" rather than being written to a guess. Measured on live 1.15:
+# the walk reaches them on Damian/Kliff/Kliff_AI/PlayerAll and does not on
+# the *_Clone records, whose partial writes GitHub #329 now abandons.
 _NEW_SCHEMA_MAP: dict[str, tuple[str, int, str, int]] = {
     **_FIELD_MAP,
     "appearance_name": (_BLK, 0, "<I", 4),
@@ -133,6 +137,7 @@ def build_characterinfo_changes(
     vanilla_body: bytes,
     vanilla_header: bytes,
     intents: list[tuple[str, int, str, object]],
+    refusals_out: list[str] | None = None,
 ) -> list[dict]:
     """Resolve Format 3 characterinfo intents into v2 change dicts.
 
@@ -146,6 +151,27 @@ def build_characterinfo_changes(
     Intents whose field is unsupported, whose record cannot be found or
     parsed, or whose value does not fit the field width are dropped
     with a logged warning, never raising.
+
+    ALL-OR-NOTHING PER RECORD (GitHub #329). A character-swap mod copies
+    one character's appearance, model, skeleton and action-chart index
+    onto another as a set. If CDUMM can locate the record and models
+    every field the mod names, but the parser cannot publish a write
+    position for some of them, writing the rest leaves that record
+    holding the source character's model driven by the target's own
+    action data -- a combination neither vanilla nor the mod produces,
+    and one the game does not survive. Such a record is abandoned whole:
+    none of its fields are written and it stays vanilla, which is always
+    self-consistent.
+
+    This is deliberately scoped to fields CDUMM *models* but cannot
+    *place on this record*. A field name CDUMM doesn't model at all is a
+    property of the mod, identical on every record, so every record gets
+    the same subset -- that is the behaviour #150/#192/#302 shipped and
+    users confirmed in-game, and it is left alone.
+
+    ``refusals_out``, when given, collects one human-readable line per
+    abandoned record so a caller can surface it to the user; the reason
+    is also logged at WARNING either way.
     """
     idx = parse_pabgh_index(vanilla_header)  # {key: record offset}
     order = sorted(idx.items(), key=lambda kv: kv[1])
@@ -171,6 +197,16 @@ def build_characterinfo_changes(
                  if _NEW_SCHEMA_MARKERS & fields_present else _FIELD_MAP)
 
     changes: list[dict] = []
+    # Entry name per emitted change, index-aligned with ``changes``. Used to
+    # drop a partially-written record's changes below. Deriving the name from
+    # the ``label`` instead would be wrong: field names contain dots
+    # ('upper_chart.group_lookup'), so splitting a label can't recover the
+    # entry name unambiguously.
+    change_owner: list[str] = []
+    # Per record: {field: parser offset key} CDUMM models, and the subset of
+    # those field names it actually placed.
+    modelled: dict[str, dict[str, str]] = {}
+    placed: dict[str, set[str]] = {}
     for entry_name, raw_key, field, new_value in intents:
         spec = field_map.get(field)
         if spec is None:
@@ -193,8 +229,12 @@ def build_characterinfo_changes(
                 "parsable, skipping intent on %s",
                 entry_name, raw_key, field)
             continue
+        # From here the record exists and CDUMM models this field, so the
+        # record is expected to carry this write. Any drop past this point
+        # unbalances the record.
         off_key, delta, fmt, width = spec
-        base = rec.get(off_key)
+        modelled.setdefault(entry_name, {})[field] = off_key
+        base: int | None = rec.get(off_key)
         if base is None:
             logger.warning(
                 "characterinfo: could not locate field %r for entry "
@@ -212,10 +252,61 @@ def build_characterinfo_changes(
                 "%r (%d-byte), skipping", new_value, field, width)
             continue
         original = bytes(vanilla_body[abs_off:abs_off + width])
+        placed.setdefault(entry_name, set()).add(field)
+        change_owner.append(entry_name)
         changes.append({
             "offset": abs_off,
             "original": original.hex(),
             "patched": patched.hex(),
             "label": f"{entry_name}.{field}",
         })
+
+    # All-or-nothing per record (GitHub #329).
+    #
+    # Only a field the parser CAN publish somewhere in this table counts. A
+    # field whose offset key the parser publishes for no record at all is a
+    # table-wide gap, not per-record drift: every targeted record then gets
+    # the same subset, so none is inconsistent relative to its siblings.
+    # ``flag_c`` is the live example -- the 1.13 re-port stopped resolving
+    # ``_flagC_offset`` entirely, and #150's mod has shipped and been
+    # confirmed in-game writing the remaining four fields. Treating that as
+    # a partial record would silently stop those mods working.
+    #
+    # ``character_weight`` is why this is keyed on the parser offset key
+    # rather than the field name: it is the same slot as
+    # ``default_action_action_index`` under a different DMM name, so asking
+    # for one and placing the other still counts as the same field.
+    wanted_keys = {k for f in modelled.values() for k in f.values()}
+    publishable = {
+        k for k in wanted_keys
+        if any(r.get(k) is not None for r in parsed.values())
+    }
+    partial: dict[str, list[str]] = {}
+    for name, fields in modelled.items():
+        if not placed.get(name):
+            continue
+        missing_fields = sorted(
+            f for f, off_key in fields.items()
+            if f not in placed[name] and off_key in publishable
+        )
+        if missing_fields:
+            partial[name] = missing_fields
+    for name in sorted(partial):
+        missing = ", ".join(partial[name])
+        msg = (
+            f"characterinfo: record {name!r} left unwritten -- CDUMM could "
+            f"not locate {missing} on it, and writing only the other "
+            f"{len(placed[name])} field(s) would give it another "
+            f"character's appearance driven by its own action data, which "
+            f"crashes the game. This record stays vanilla; the mod's other "
+            f"records still apply."
+        )
+        logger.warning("%s", msg)
+        if refusals_out is not None:
+            refusals_out.append(msg)
+    if partial:
+        changes = [
+            c for c, owner in zip(changes, change_owner)
+            if owner not in partial
+        ]
     return changes

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -912,7 +912,8 @@ def expand_format3_into_aggregated(
 
                 # Convert each supported intent into a v2-style change dict
                 changes = _intents_to_v2_changes(
-                    target, vanilla_body, vanilla_header, supported)
+                    target, vanilla_body, vanilla_header, supported,
+                    warnings_out=warnings_out)
                 if not changes:
                     n_mods_skipped += 1
                     # Don't pollute aggregated with empty lists.
@@ -1772,6 +1773,8 @@ def _build_with_per_intent_refusals(
 def _intents_to_v2_changes(
     target: str, vanilla_body: bytes, vanilla_header: bytes,
     intents: list[Format3Intent],
+    *,
+    warnings_out: list[str] | None = None,
 ) -> list[dict]:
     """Produce v2-format change dicts from a list of supported intents.
 
@@ -1825,7 +1828,8 @@ def _intents_to_v2_changes(
     # (GitHub #150).
     if table_name == "characterinfo":
         return _characterinfo_intents_to_changes(
-            vanilla_body, vanilla_header, intents)
+            vanilla_body, vanilla_header, intents,
+            warnings_out=warnings_out)
 
     has_cdumm_schema = has_schema(table_name)
     # Tables without a CDUMM PABGB schema are still processable when
@@ -2583,6 +2587,8 @@ def _buffinfo_intents_to_changes(
 def _characterinfo_intents_to_changes(
     vanilla_body: bytes, vanilla_header: bytes,
     intents: list[Format3Intent],
+    *,
+    warnings_out: list[str] | None = None,
 ) -> list[dict]:
     """Resolve characterinfo intents through the clean-room
     characterinfo writer (GitHub #150).
@@ -2592,6 +2598,12 @@ def _characterinfo_intents_to_changes(
     unsupported fields, missing records, or out-of-range values are
     dropped inside the writer with a logged warning; the expand_format3
     caller surfaces a "0 byte changes" warning for whole-mod dropouts.
+
+    A record the writer can only partly write is abandoned whole rather
+    than left half-swapped (GitHub #329). That is not a whole-mod dropout
+    -- the mod's other records still apply and produce changes -- so it
+    would otherwise pass silently, which is exactly why the reporter saw
+    a crash with no message. Surface it through ``warnings_out``.
     """
     from cdumm.engine.characterinfo_writer import (
         build_characterinfo_changes,
@@ -2599,8 +2611,12 @@ def _characterinfo_intents_to_changes(
     tuples = [
         (i.entry, i.key, i.field, i.new) for i in intents
     ]
-    return build_characterinfo_changes(
-        vanilla_body, vanilla_header, tuples)
+    refusals: list[str] = []
+    changes = build_characterinfo_changes(
+        vanilla_body, vanilla_header, tuples, refusals_out=refusals)
+    if refusals and warnings_out is not None:
+        warnings_out.extend(refusals)
+    return changes
 
 
 def _build_list_writer_change(

--- a/tests/test_characterinfo_appearance_fields.py
+++ b/tests/test_characterinfo_appearance_fields.py
@@ -590,3 +590,55 @@ def test_apply_dispatch_tolerates_no_warnings_channel(table):
     ]
     assert len(_intents_to_v2_changes(
         "characterinfo.pabgb", body, header, intents)) == 19
+
+
+@pytest.mark.parametrize("bad_value", ["not-an-int", None, 3.5, True])
+def test_a_bad_value_abandons_the_record_rather_than_half_writing(
+        table, bad_value):
+    """A value CDUMM cannot encode must abandon the record too.
+
+    The all-or-nothing guard keys on fields the mod asked this record to
+    carry, so the type check has to run AFTER the record registers as
+    expecting the write. Checking it earlier let a non-integer skip
+    straight past the guard: the sibling fields were written and the
+    record came out half-modded -- the exact state
+    test_abandoned_record_keeps_every_vanilla_byte exists to prevent,
+    reached by a different route.
+
+    Out-of-range integers were already handled correctly (that check sits
+    after registration); these values took the earlier exit.
+    """
+    body, header = table
+    intents = [
+        ("Kliff", 1, "appearance_name", 111),
+        ("Kliff", 1, "character_prefab_path", 222),
+        ("Kliff", 1, "default_action_action_index", bad_value),
+        ("Kliff", 1, "lookup_25", 444),
+    ]
+    refusals: list[str] = []
+    changes = build_characterinfo_changes(
+        body, header, intents, refusals_out=refusals)
+
+    assert changes == [], (
+        f"value {bad_value!r} was rejected but the record's other fields "
+        f"were still written -- that is a half-written character record")
+    assert len(refusals) == 1, refusals
+    assert "Kliff" in refusals[0]
+
+
+def test_a_bad_value_does_not_abandon_an_unrelated_record(table):
+    """Abandonment stays per-record: a bad value on one record must not
+    stop a different record the same mod also targets."""
+    body, header = table
+    intents = [
+        ("Kliff", 1, "appearance_name", 111),
+        ("Kliff", 1, "default_action_action_index", "not-an-int"),
+        ("Kliff_AI", 1, "appearance_name", 333),
+    ]
+    refusals: list[str] = []
+    changes = build_characterinfo_changes(
+        body, header, intents, refusals_out=refusals)
+
+    labels = [c["label"] for c in changes]
+    assert labels == ["Kliff_AI.appearance_name"], labels
+    assert len(refusals) == 1 and "Kliff" in refusals[0]

--- a/tests/test_characterinfo_appearance_fields.py
+++ b/tests/test_characterinfo_appearance_fields.py
@@ -81,7 +81,8 @@ _MOD_INTENTS: list[tuple[str, int, str, int]] = [
 _NEW = {"appearance_name": 0, "character_prefab_path": 4,
         "skeleton_name": 8, "lookup_24": 20, "lookup_25": 24}
 # The three the 7.6 mod also sets that sit in the post-block variable-length
-# region (1.13 drift) and are deliberately NOT written.
+# region (1.13 drift). #302 made these writable on records whose position the
+# walk can gate-verify; they stay refused on records it cannot.
 _POST_BLOCK = {"default_action_action_index", "character_weight", "f36"}
 
 _DAMIAN_KEY = 4
@@ -124,12 +125,20 @@ def test_all_17_hash_block_intents_apply_and_match_the_source(table):
     offsets are right, not merely that a write happened."""
     body, header = table
     changes = build_characterinfo_changes(body, header, _MOD_INTENTS)
-    # 17 hash-block intents + the 6 post-block ones the walker can now
-    # locate and gate-verify (#302: default_action_action_index / f36 on
-    # Kliff, Kliff_AI, PlayerAll). Kliff_Clone fails the f32-2.0 gate and
-    # character_weight is still unmapped, so 2 remain refused.
-    assert len(changes) == 23, (
-        f"expected 23 locatable intents, got {len(changes)}")
+    # 13 hash-block intents + the 6 post-block ones the walker can locate
+    # and gate-verify (#302: default_action_action_index / f36 on Kliff,
+    # Kliff_AI, PlayerAll).
+    #
+    # Kliff_Clone contributes NOTHING (GitHub #329). It fails the f32-2.0
+    # gate, so its post-block slot can't be placed -- and since that slot IS
+    # placeable on Kliff/Kliff_AI/PlayerAll, withholding it only on this
+    # record would leave it wearing Damian's appearance while still running
+    # its own action index. That record is now abandoned whole rather than
+    # written in part, which is why this is 19 and not 23.
+    assert len(changes) == 19, (
+        f"expected 19 locatable intents, got {len(changes)}")
+    assert not [c for c in changes if c["label"].startswith("Kliff_Clone.")], (
+        "Kliff_Clone must contribute no changes at all")
 
     patched = _apply(body, changes)
     assert len(patched) == len(body), "writes must not resize the table"
@@ -144,14 +153,18 @@ def test_all_17_hash_block_intents_apply_and_match_the_source(table):
 
 
 def test_every_write_lands_its_intent_value(table):
-    """Each of the 17 writes puts its exact ``new`` value at its slot,
-    across all five target records (not just Kliff)."""
+    """Each hash-block write puts its exact ``new`` value at its slot,
+    across every target record that is written at all (not just Kliff).
+
+    Kliff_Clone is excluded because #329 abandons it whole; the test
+    immediately below pins that it keeps its vanilla bytes.
+    """
     body, header = table
     key_of = {n: k for n, k, _f, _v in _MOD_INTENTS}
     patched = _apply(body, build_characterinfo_changes(
         body, header, _MOD_INTENTS))
     for name, key, field, value in _MOD_INTENTS:
-        if field not in _NEW:
+        if field not in _NEW or name == "Kliff_Clone":
             continue
         blk = _block_offset(patched, header, key_of[name])
         got = struct.unpack_from("<I", patched, blk + _NEW[field])[0]
@@ -163,16 +176,118 @@ def test_every_write_lands_its_intent_value(table):
 def test_lookup_24_writes_its_real_slot_not_the_type_tag_constant(table):
     """The legacy map put lookup_24 at block+16, which is a table-wide
     constant type tag. The new schema must route it to +20, and +16 must be
-    left at the constant on every targeted record."""
+    left at the constant on every written record.
+
+    Kliff_Clone (1001367) is not in the list: #329 abandons it, so its +20
+    correctly still holds vanilla. ``test_abandoned_record_keeps_every_
+    vanilla_byte`` covers that record instead.
+    """
     body, header = table
     patched = _apply(body, build_characterinfo_changes(
         body, header, _MOD_INTENTS))
-    for key in (1, 1001367, 1002113, 1004085):
+    for key in (1, 1002113, 1004085):
         blk = _block_offset(patched, header, key)
         assert struct.unpack_from("<I", patched, blk + 16)[0] == \
             _TYPE_TAG_CONST, "block+16 type tag was overwritten"
         assert struct.unpack_from("<I", patched, blk + 20)[0] == \
             2831867940, "lookup_24 did not land at its real slot (+20)"
+
+
+# ── #329: a record CDUMM can only half-write stays vanilla ───────────────
+
+def test_abandoned_record_keeps_every_vanilla_byte(table):
+    """The #329 crash, pinned on the real table.
+
+    Kliff_Clone asks for six fields. The parser can place four of them
+    (the hash-block ones) and cannot place the post-block slot, because
+    the record fails the f32-2.0 position gate. Writing the four would
+    hand it Damian's appearance, model and skeleton variation while it
+    still runs its own action index -- a combination neither vanilla nor
+    the mod produces, and the state the reporter's game crashed on.
+
+    So: the whole record must come out byte-identical to vanilla.
+    """
+    body, header = table
+    changes = build_characterinfo_changes(body, header, _MOD_INTENTS)
+    patched = _apply(body, changes)
+
+    idx = parse_pabgh_index(header)
+    order = sorted(idx.items(), key=lambda kv: kv[1])
+    offs = [o for _k, o in order]
+    start = idx[1001367]
+    i = offs.index(start)
+    end = order[i + 1][1] if i + 1 < len(order) else len(body)
+
+    assert patched[start:end] == body[start:end], (
+        "Kliff_Clone was modified; a partially-written character record is "
+        "exactly what GitHub #329 crashes on")
+
+    # ...and the mod's other records still apply, so this is a per-record
+    # refusal rather than the whole mod going dead.
+    assert len(changes) == 19
+    for name in ("Kliff", "Kliff_AI", "Yann", "PlayerAll"):
+        assert [c for c in changes if c["label"].startswith(f"{name}.")], (
+            f"{name} must still be written")
+
+
+def test_refusal_reason_is_reported_not_just_logged(table):
+    """The reporter saw a crash with no message in CDUMM. The abandonment
+    has to be surfaced, so it is collected into ``refusals_out``."""
+    body, header = table
+    refusals: list[str] = []
+    build_characterinfo_changes(
+        body, header, _MOD_INTENTS, refusals_out=refusals)
+    assert len(refusals) == 1, refusals
+    assert "Kliff_Clone" in refusals[0]
+    # It must say what could not be placed, or it isn't actionable.
+    assert "f36" in refusals[0]
+
+
+def test_a_lone_half_writable_record_is_abandoned_too(table):
+    """Placeability must be read from the PARSER, not from the mod.
+
+    A character-swap mod targeting only ONE record, whose post-block slot
+    the parser can't place on that record, ends up placing that slot
+    nowhere. Judging "is this slot placeable at all" from what the mod
+    managed to write would then call it a table-wide gap and write the
+    hash-block fields anyway -- reintroducing the exact partial state
+    #329 crashes on, just for a smaller mod.
+
+    Reading it from what the parser publishes across the table (Damian
+    and thousands of others do publish this slot) gets it right.
+    """
+    body, header = table
+    intents = [
+        ("Kliff_Clone", 1001367, "appearance_name", 1767116530),
+        ("Kliff_Clone", 1001367, "character_prefab_path", 3755051597),
+        ("Kliff_Clone", 1001367, "character_weight", 1287066785),
+    ]
+    changes = build_characterinfo_changes(body, header, intents)
+    assert changes == [], (
+        "a lone half-writable record must still be abandoned, even though "
+        "the mod itself never proves the slot is placeable")
+
+
+def test_a_table_wide_gap_does_not_abandon_records(table):
+    """The guard is scoped to per-record drift, not to fields CDUMM cannot
+    place anywhere.
+
+    ``flag_c`` is modelled but the 1.13 re-port publishes ``_flagC_offset``
+    for no record at all. Every targeted record therefore gets the same
+    subset, none is inconsistent relative to its siblings, and #150's
+    shipped in-game-confirmed behaviour of writing the rest must survive.
+    """
+    body, header = table
+    intents = [
+        ("Kliff", 1, "appearance_name", 1767116530),
+        ("Kliff", 1, "lookup_24", 2831867940),
+        ("Kliff", 1, "flag_c", 2),          # unplaceable on every record
+    ]
+    changes = build_characterinfo_changes(body, header, intents)
+    assert len(changes) == 2, (
+        "a field CDUMM can place on no record must not abandon the record")
+    assert {c["label"] for c in changes} == {
+        "Kliff.appearance_name", "Kliff.lookup_24"}
 
 
 # ── the deferred fields are skipped, not guessed ────────────────────────
@@ -409,3 +524,69 @@ def test_character_weight_is_the_same_slot_as_default_action_action_index():
     from cdumm.engine.characterinfo_writer import _FIELD_MAP
     assert (_FIELD_MAP["character_weight"]
             == _FIELD_MAP["default_action_action_index"])
+
+
+# ── #329: the apply dispatch actually carries the refusal out ────────────
+
+def test_apply_dispatch_surfaces_the_refusal_to_the_user(table):
+    """The writer refusing is only half the fix.
+
+    #329's reporter saw a crash with no message, and a per-record
+    abandonment is NOT a whole-mod dropout -- the mod still produces 19
+    changes, so none of the existing "0 byte changes" warnings fire. The
+    dispatch has to carry the reason out itself or it stays invisible.
+
+    Goes through the real ``_intents_to_v2_changes`` entry point rather
+    than calling the writer again, so the wiring is what's under test.
+    """
+    from cdumm.engine.format3_apply import _intents_to_v2_changes
+    from cdumm.engine.format3_handler import Format3Intent
+
+    body, header = table
+    intents = [
+        Format3Intent(entry=n, key=k, field=f, op="set", new=v)
+        for n, k, f, v in _MOD_INTENTS
+    ]
+    warnings: list[str] = []
+    changes = _intents_to_v2_changes(
+        "characterinfo.pabgb", body, header, intents,
+        warnings_out=warnings)
+
+    assert len(changes) == 19
+    assert len(warnings) == 1, warnings
+    assert "Kliff_Clone" in warnings[0]
+
+
+def test_apply_dispatch_stays_silent_when_nothing_is_abandoned(table):
+    """No false alarms: a mod whose records all write completely must not
+    produce a warning."""
+    from cdumm.engine.format3_apply import _intents_to_v2_changes
+    from cdumm.engine.format3_handler import Format3Intent
+
+    body, header = table
+    intents = [
+        Format3Intent(entry="Kliff", key=1, field="appearance_name",
+                      op="set", new=1767116530),
+        Format3Intent(entry="Kliff", key=1, field="lookup_24",
+                      op="set", new=2831867940),
+    ]
+    warnings: list[str] = []
+    changes = _intents_to_v2_changes(
+        "characterinfo.pabgb", body, header, intents,
+        warnings_out=warnings)
+    assert len(changes) == 2
+    assert warnings == []
+
+
+def test_apply_dispatch_tolerates_no_warnings_channel(table):
+    """``warnings_out`` is optional; the default path must not raise."""
+    from cdumm.engine.format3_apply import _intents_to_v2_changes
+    from cdumm.engine.format3_handler import Format3Intent
+
+    body, header = table
+    intents = [
+        Format3Intent(entry=n, key=k, field=f, op="set", new=v)
+        for n, k, f, v in _MOD_INTENTS
+    ]
+    assert len(_intents_to_v2_changes(
+        "characterinfo.pabgb", body, header, intents)) == 19

--- a/tests/test_format3_mod_clears_skip_state.py
+++ b/tests/test_format3_mod_clears_skip_state.py
@@ -98,8 +98,10 @@ def test_expand_format3_reports_contributing_mod_ids(tmp_path):
     def _stub_validate(target, intents):
         return _ValRes(intents)
 
-    def _stub_intents_to(target, body, header, intents):
+    def _stub_intents_to(target, body, header, intents, **kwargs):
         # Fabricate one v2 change so the per-mod branch runs.
+        # ``**kwargs`` absorbs the real function's keyword-only extras
+        # (e.g. warnings_out) so adding one doesn't break this double.
         return [{"label": f"x{intents[0]['tid']}",
                  "offset": 0, "original": "00", "patched": "01"}]
 


### PR DESCRIPTION
@lurkser narrowed it to `Female Animations.field.json`, which is the answer to your "which of the three code paths" question — it's the JSON patch, not the model swap or the icons. I took that and traced what CDUMM actually writes for it. **It writes an incomplete character record.**

## What the mod asks for, and what CDUMM did

The mod copies Damian's appearance/model/skeleton/action-chart set onto five records. Measured against a live 1.15 `characterinfo` (7,105 records indexed):

```
Kliff        asked 7  wrote 7   complete
Kliff_Clone  asked 6  wrote 4   PARTIAL   <-- refused: character_weight, f36
Kliff_AI     asked 6  wrote 6   complete
Yann         asked 3  wrote 3   complete
PlayerAll    asked 3  wrote 3   complete
```

`Kliff_Clone` came out holding Damian's `appearance_name`, `character_prefab_path`, `lookup_24` and `lookup_25` while still holding **its own** action-chart index — because the post-block slot fails the f32-2.0 position gate on that record, so CDUMM correctly declined to write it and then wrote the other four anyway. A model swapped without the action data that drives it is a combination neither vanilla nor the mod produces. Every other record in the mod got the complete set, which is why disabling this one file fixed his game and enabling it alone reproduced the crash.

## The offsets themselves are fine

Worth stating since 1.13-vs-1.15 drift was the standing theory. The mod copies Damian, so Damian's record is a Rosetta stone — it must already hold every value the mod writes. On live 1.15 all eight fields check out:

```
appearance_name             @12131  holds 1767116530   MATCH
character_prefab_path       @12135  holds 3755051597   MATCH
skeleton_name               @12139  holds 3000129643   MATCH
lookup_24                   @12151  holds 2831867940   MATCH
lookup_25                   @12155  holds 3511542393   MATCH
default_action_action_index @12421  holds 1287066785   MATCH
character_weight            @12421  holds 1287066785   MATCH   (same slot)
f36                         @12425  holds 2            MATCH
```

So this isn't a wrong-offset bug and it isn't version drift. The mapping is right; the *completeness* wasn't.

I also found the writer's own comment claiming the three post-block fields are "deliberately NOT mapped" on the current-DMM schema. They are mapped — `_NEW_SCHEMA_MAP` spreads `**_FIELD_MAP` and only overrides the five block fields. Comment corrected rather than left to mislead the next reader.

## The fix

All-or-nothing per record. If CDUMM can locate a record and models every field the mod names on it, but can't place some of them, it now writes **none** of that record's fields and leaves it vanilla. Vanilla is always self-consistent.

```
Kliff_Clone   4 changes -> 0     record byte-identical to vanilla
whole mod    23 changes -> 19    the other four records unaffected
```

### Scoping, because the obvious version of this regresses your shipped work

My first cut abandoned a record whenever *any* modelled field went unplaced. That broke `#150` immediately: `flag_c` is in `_FIELD_MAP`, but the 1.13 re-port stopped publishing `_flagC_offset` for **every** record, and #150's mod ships writing the remaining four fields with in-game confirmation. Two of your existing tests caught it, which is the system working.

So the guard only fires on a field the parser *can* publish somewhere in this table but didn't publish on *this* record. A field it publishes nowhere is a table-wide gap — every record gets the same subset, none is inconsistent relative to its siblings — and is left alone.

Two details that took a measurement to get right:

- **Keyed on the parser offset key, not the field name.** `character_weight` and `default_action_action_index` are the same slot under two DMM names, so asking for one and placing the other has to count as the same field.
- **Placeability read from the parser, not from the mod.** A character-swap mod targeting a single half-writable record places the slot nowhere, so judging placeability from what the mod managed to write would call that a table-wide gap and write the hash-block fields anyway — reintroducing the same partial state for a smaller mod. `test_a_lone_half_writable_record_is_abandoned_too` pins this.

### It's also now visible

A per-record abandonment is not a whole-mod dropout — the mod still produces 19 changes, so none of the existing "0 byte changes" warnings fire. That is exactly why @lurkser saw a crash with **no message in CDUMM**. The reason is now collected through `warnings_out`, naming the record and the fields that couldn't be placed.

## Verification

Mutation-tested — each mutation killed by the test written for it:

```
remove the abandonment          -> test_abandoned_record_keeps_every_vanilla_byte  + 4 more
drop the publishable filter     -> test_a_table_wide_gap_does_not_abandon_records  + both #150 tests
placeability from the mod       -> test_a_lone_half_writable_record_is_abandoned_too
```

Three existing assertions changed from 23 to 19 and Kliff_Clone dropped out of two loops. Those are the behaviour change, not collateral — each carries the reason inline.

Blast radius: the guard only removes changes when it finds a partial record, so a mod reporting zero abandonments is unchanged by construction. Character Creator is the only characterinfo mod in my corpus that reports one.

Full fast suite green. Ruff unchanged on the touched files, clean on the new lines.

## What this does not claim

I have not seen the crash myself — I don't have his save or a way to reproduce a game launch here. What I have is: a partial character record was being written, only on the file he isolated, and only on the one record; the fix makes that record vanilla instead. That's consistent with everything he reported, but he's the one who can confirm it.

Fixes #329
