### PR TITLE
Cover characterinfo call_mercenary_spawn_duration (No CD Mount mods half-applied)

### DIFF
--- a/src/cdumm/engine/characterinfo_writer.py
+++ b/src/cdumm/engine/characterinfo_writer.py
@@ -96,6 +96,21 @@ _FIELD_MAP: dict[str, tuple[str, int, str, int]] = {
     # _NEW_SCHEMA_MAP so legacy-vintage mods keep it -- SUPPORTED_FIELDS
     # derives from _FIELD_MAP and picks it up automatically.
     "call_mercenary_cool_time": ("_callMercenaryCoolTime_offset", 0, "<Q", 8),
+    # The sibling slot the same mods set, and the reason "No CD Mount"
+    # QoL mods only half-worked: cool_time applied, spawn_duration was
+    # refused as an unsupported field name. The parser already decodes it
+    # (`<Q` immediately after cool_time) and publishes its offset, so this
+    # is the same length-preserving write as its sibling.
+    #
+    # Verified on live 1.15 rather than assumed from adjacency. Across all
+    # 7105 records the offset is published for every one, and the slot is
+    # nonzero on exactly 14 -- every one a summonable mount
+    # (Riding_ATAG_*, Riding_Dragon_1, Riding_WarMachine_Unique_1), values
+    # 600 and 9000, the same units and shape as cool_time's 300/600/3600/
+    # 9000. Ordinary NPCs read 0, exactly as cool_time does. All 88
+    # mercenary intents in the real QoL mod place inside their own record.
+    "call_mercenary_spawn_duration": (
+        "_callMercenarySpawnDuration_offset", 0, "<Q", 8),
 }
 
 # CURRENT DMM Mod Builder naming (Character Creator / Female Animations 7.6,

--- a/tests/test_characterinfo_writer.py
+++ b/tests/test_characterinfo_writer.py
@@ -26,7 +26,7 @@ from cdumm.engine.characterinfo_writer import build_characterinfo_changes
 def _make_record(key: int, name: str, *, upper: int, lower: int,
                  gameplay: int, appearance: int, prefab: int,
                  skeleton: int, skelvar: int, flag_c: int,
-                 cooldown: int = 0) -> bytes:
+                 cooldown: int = 0, spawn_duration: int = 0) -> bytes:
     """Build one characterinfo record matching the parser walk in
     characterinfo_full_parser.parse_entry."""
     nb = name.encode("latin-1")
@@ -42,7 +42,7 @@ def _make_record(key: int, name: str, *, upper: int, lower: int,
     r += b"\x00" * 4 + b"\x00" * 4            # two u32
     r += struct.pack("<H", 0)                 # _vehicleInfo u16
     r += struct.pack("<Q", cooldown)          # _callMercenaryCoolTime
-    r += struct.pack("<Q", 0)                 # _callMercenarySpawnDuration
+    r += struct.pack("<Q", spawn_duration)    # _callMercenarySpawnDuration
     r += b"\x00"                              # _mercenaryCoolTimeType u8
     r += b"\x00" * 6                          # u32 + u16
     r += b"\x00" * 6                          # u32 + u16
@@ -243,3 +243,66 @@ def test_call_mercenary_cool_time_in_supported_fields():
     _CHARACTERINFO_FIELDS), so validation and the write can't drift apart."""
     from cdumm.engine.characterinfo_writer import SUPPORTED_FIELDS
     assert "call_mercenary_cool_time" in SUPPORTED_FIELDS
+
+
+def test_writer_patches_call_mercenary_spawn_duration():
+    """The sibling slot the same 'No CD Mount' QoL mods set.
+
+    Before this was mapped, those mods half-applied: cool_time went
+    through and spawn_duration was refused as an unsupported field name,
+    so the summon delay stayed. Found by sweeping 52 real Format 3 mods
+    through the apply path -- 14 intents were being dropped this way.
+    """
+    rec = _make_record(1, "Riding_Dragon_1", cooldown=3600,
+                       spawn_duration=600, **_vanilla_kwargs())
+    pabgb, pabgh = _make_table([rec])
+    changes = build_characterinfo_changes(
+        pabgb, pabgh,
+        [("Riding_Dragon_1", 0, "call_mercenary_spawn_duration", 0)])
+    assert len(changes) == 1
+    patched = _apply(pabgb, changes)
+    assert len(patched) == len(pabgb), "writes must not resize the record"
+    from cdumm.archive.format_parsers.characterinfo_full_parser import (
+        parse_entry,
+        parse_pabgh_index,
+    )
+    r = parse_entry(patched, parse_pabgh_index(pabgh)[1], len(patched))
+    assert r["_callMercenarySpawnDuration"] == 0
+    # The mirror of the cool_time test: the neighbouring u64 must be
+    # untouched, which pins the offset and width from the other side. One
+    # slot too early would have clobbered cool_time's 3600.
+    assert r["_callMercenaryCoolTime"] == 3600
+
+
+def test_both_mercenary_fields_apply_together():
+    """The real mod sets both on the same record; neither may eat the
+    other's bytes."""
+    rec = _make_record(1, "Riding_ATAG_1", cooldown=3600,
+                       spawn_duration=600, **_vanilla_kwargs())
+    pabgb, pabgh = _make_table([rec])
+    changes = build_characterinfo_changes(pabgb, pabgh, [
+        ("Riding_ATAG_1", 0, "call_mercenary_cool_time", 1),
+        ("Riding_ATAG_1", 0, "call_mercenary_spawn_duration", 0),
+    ])
+    assert len(changes) == 2
+    assert len({c["offset"] for c in changes}) == 2, (
+        "the two fields must resolve to different offsets")
+    patched = _apply(pabgb, changes)
+    assert len(patched) == len(pabgb)
+    from cdumm.archive.format_parsers.characterinfo_full_parser import (
+        parse_entry,
+        parse_pabgh_index,
+    )
+    r = parse_entry(patched, parse_pabgh_index(pabgh)[1], len(patched))
+    assert r["_callMercenaryCoolTime"] == 1
+    assert r["_callMercenarySpawnDuration"] == 0
+    # ...and nothing downstream moved.
+    assert r["_upperActionChartPackageGroupName_key"] == 11
+
+
+def test_call_mercenary_spawn_duration_in_supported_fields():
+    """Same accept-set pin as its sibling: the validator has to let it
+    through or the writer never sees it, which is exactly how it was
+    being dropped."""
+    from cdumm.engine.characterinfo_writer import SUPPORTED_FIELDS
+    assert "call_mercenary_spawn_duration" in SUPPORTED_FIELDS


### PR DESCRIPTION
"No CD Mount" QoL mods set two fields per mount — `call_mercenary_cool_time` and `call_mercenary_spawn_duration`. Only the first was mapped, so those mods **half-applied**: the re-summon cooldown went to 0, the summon delay stayed, and the second intent was dropped as an unsupported field name with nothing surfaced to the user.

## How it was found

Not from a report. I built a fresh Nexus corpus — 192 archives, 498 JSONs, 52 real Format 3 mods — and ran every one through the **actual apply path** against a live 1.15 install, capturing the engine's own refusal log.

That matters because `scripts/coverage_scan.py` answers a different question. It asks whether `validate_intents` *claims* it can apply an intent, and on this corpus it reports full coverage:

```
No uncovered Format-3 intents found across the scanned mods.
```

The apply path was meanwhile dropping intents the classifier had waved through:

```
x1452  iteminfo: nested path 'sharpness_data.stat_data.stat_list_static' skipped (unresolved)
x14    characterinfo: field 'call_mercenary_spawn_duration' is not supported, skipping
```

This PR closes the second one. The first is the gear-stats path and is a separate, larger piece of work.

## Why this slot, verified rather than assumed

The parser already decodes it — `<Q` immediately after `cool_time` — and publishes its offset, so adjacency made it *look* obvious. I checked it against the live table instead:

| | published on | nonzero | values |
|---|---|---|---|
| `call_mercenary_cool_time` (known good) | 7105 / 7105 | 81 | 300, 3600, 600, 9000 |
| `call_mercenary_spawn_duration` | 7105 / 7105 | **14** | 600, 9000 |

The 14 nonzero records are every summonable mount — `Riding_ATAG_1..7`, `Riding_Dragon_1`, `Riding_WarMachine_Unique_1` — and ordinary NPCs read 0, exactly as `cool_time` does. Same units, same shape, same population. All 88 mercenary intents in the real mod place inside their own record bounds.

Those 14 records are also exactly the 14 dropped intents, which is the tightest confirmation available short of launching the game.

## Verification

Re-ran the sweep after the change — the 14 drops are gone.

Tests pin the offset **from both sides**: writing `spawn_duration` has to leave `cool_time`'s 3600 intact, which one slot of drift would clobber, and the existing cool_time test already pins the mirror. Plus both-together (distinct offsets, nothing downstream moved) and the accept-set, since a validator that rejects the name means the writer never sees it — which is precisely how this was being lost.

Ruff unchanged on the touched files (5 before, 5 after; the one flagged import block is pre-existing).
