### PR TITLE
Alias iteminfo sharpness_data.stat_data.stat_list_static (1452 dropped intents)

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -165,6 +165,21 @@ def _lookup_record_field(rec: dict, field: str):
     if "." not in field:
         return None
 
+    # Accept the same DMM-dialect nested spellings the WRITER accepts.
+    # Without this a mod can name sharpness_data.stat_data.stat_list_static
+    # in `field` and have it resolve, while the identical spelling in
+    # `match` resolves to None -- so the intent selects nothing, writes
+    # nothing, and reports no error. That is precisely the half-working
+    # asymmetry this module's _match_field_name docstring exists to
+    # prevent, arriving through the nested path instead of the flat name.
+    # Same function the writer uses, so the two cannot drift apart.
+    from cdumm.engine.iteminfo_writer import _canonical_nested_path
+    canonical = _canonical_nested_path(field)
+    if canonical != field:
+        got = _lookup_record_field(rec, canonical)
+        if got is not None:
+            return got
+
     cur: object = rec
     for seg in field.split("."):
         if isinstance(cur, dict):

--- a/src/cdumm/engine/iteminfo_writer.py
+++ b/src/cdumm/engine/iteminfo_writer.py
@@ -246,6 +246,46 @@ def is_nested_path(field: str) -> bool:
     return "." in field or "[" in field
 
 
+# DMM's schema models sharpness stats as a nested
+# ``sharpness_data.stat_data.stat_list_static``; CDUMM's native parser
+# decodes the same bytes as a flat ``sharpness_data.stat_list``. Same
+# field, two names -- the characterinfo ``character_weight`` /
+# ``default_action_action_index`` situation again (GitHub #302).
+#
+# Measured on live 1.15 rather than inferred from the name:
+#   * sharpness_data decodes as a dict on 6508/6508 records, with keys
+#     {craft_tool_info, max_sharpness, p_prefix, shape, stat_list, tail,
+#      w_trailing, w_unk_a} -- there is no stat_data, and _read_ItemInfo
+#     SharpnessData reads a single flat ``u32 stat_count + N*12 stats``,
+#     so stat_list is the ONLY stat list the DMM path could mean.
+#   * its elements are ``('change_mb', 'stat')`` -- exactly the shape
+#     ExtensiveItemBuffs writes.
+#   * the same record proves it: key 14510 Marni_Devotee_PlateArmor_Helm
+#     decodes [{stat: 1000003, change_mb: 1000}] and the mod sets that
+#     same stat to 8000. All 1269 records it targets have a non-empty
+#     stat_list (945 with one entry, 324 with two), all shape W.
+#
+# Without this, 1452 real intents were dropped as "unresolved".
+_NESTED_PATH_ALIASES = (
+    ("sharpness_data.stat_data.stat_list_static", "sharpness_data.stat_list"),
+)
+
+
+def _canonical_nested_path(path: str) -> str:
+    """Rewrite a DMM-dialect nested path to CDUMM's decoded shape.
+
+    Prefix-scoped so an indexed or deeper suffix survives:
+    ``sharpness_data.stat_data.stat_list_static[0].change_mb`` becomes
+    ``sharpness_data.stat_list[0].change_mb``.
+    """
+    for dmm, ours in _NESTED_PATH_ALIASES:
+        if path == dmm:
+            return ours
+        if path.startswith((dmm + ".", dmm + "[")):
+            return ours + path[len(dmm):]
+    return path
+
+
 def _resolve_path_target(
     item: dict, path: str,
 ) -> Optional[tuple]:
@@ -272,6 +312,7 @@ def _resolve_path_target(
     dialect, both sides.
     """
     import re
+    path = _canonical_nested_path(path)
     # Tokenize: identifier | [N] | bare integer segment (a.0.b).
     # Identifiers are tried first, so a name like `x2` stays a name.
     tokens: list[tuple[str, object]] = []

--- a/tests/test_iteminfo_sharpness_alias.py
+++ b/tests/test_iteminfo_sharpness_alias.py
@@ -1,0 +1,154 @@
+"""iteminfo sharpness_data path alias (DMM name vs CDUMM decoded shape).
+
+ExtensiveItemBuffs writes ``sharpness_data.stat_data.stat_list_static``.
+CDUMM's native parser decodes the same bytes as a flat
+``sharpness_data.stat_list``, so every one of those intents resolved to
+nothing -- 1452 of them across the Nexus corpus, dropped as
+"unresolved" with the mod reporting success.
+
+That the two names are the same field was measured on live 1.15, not
+inferred:
+
+  * ``sharpness_data`` decodes as a dict on 6508/6508 records, keys
+    {craft_tool_info, max_sharpness, p_prefix, shape, stat_list, tail,
+     w_trailing, w_unk_a}. No ``stat_data``.
+  * ``_read_ItemInfoSharpnessData`` reads one flat
+    ``u32 stat_count + N*12 stats``, so ``stat_list`` is the only stat
+    list under it.
+  * elements are ``('change_mb', 'stat')`` -- the shape the mod writes.
+  * same record: key 14510 Marni_Devotee_PlateArmor_Helm decodes
+    ``[{stat: 1000003, change_mb: 1000}]``; the mod sets that stat to
+    8000.
+  * writing through ``stat_list`` and re-serializing changed exactly 2
+    bytes (e803 -> 401f, i.e. 1000 -> 8000), both inside record 14510,
+    with record offsets identical to vanilla -- length-preserving, so
+    no .pabgh rebuild.
+
+These tests pin the rewrite itself. The byte-exact evidence above needed
+a live install and can't run in CI.
+"""
+from __future__ import annotations
+
+from cdumm.engine.iteminfo_writer import (
+    _canonical_nested_path,
+    _resolve_path_target,
+    apply_nested_intent,
+)
+
+
+def _item() -> dict:
+    """A record shaped like the native parser's real output."""
+    return {
+        "key": 14510,
+        "string_key": "Marni_Devotee_PlateArmor_Helm",
+        "sharpness_data": {
+            "w_unk_a": 0,
+            "max_sharpness": 100,
+            "craft_tool_info": 0,
+            "shape": "W",
+            "stat_list": [{"stat": 1000003, "change_mb": 1000}],
+            "tail": b"\x00\x00\x00",
+            "p_prefix": None,
+            "w_trailing": b"",
+        },
+    }
+
+
+# ── the rewrite itself ───────────────────────────────────────────────
+
+def test_bare_dmm_path_is_rewritten():
+    assert _canonical_nested_path(
+        "sharpness_data.stat_data.stat_list_static"
+    ) == "sharpness_data.stat_list"
+
+
+def test_indexed_suffix_survives_the_rewrite():
+    """The prefix is replaced; everything after it is preserved."""
+    assert _canonical_nested_path(
+        "sharpness_data.stat_data.stat_list_static[0].change_mb"
+    ) == "sharpness_data.stat_list[0].change_mb"
+
+
+def test_dotted_suffix_survives_the_rewrite():
+    assert _canonical_nested_path(
+        "sharpness_data.stat_data.stat_list_static.0.change_mb"
+    ) == "sharpness_data.stat_list.0.change_mb"
+
+
+def test_unrelated_paths_are_untouched():
+    """Scoped to the one prefix -- nothing else may be rewritten.
+
+    enchant_data_list genuinely IS nested as
+    enchant_stat_data.stat_list_static and already resolves, so
+    rewriting it would break 14,899 working intents.
+    """
+    for p in (
+        "enchant_data_list[4].enchant_stat_data.stat_list_static",
+        "sharpness_data.stat_list",
+        "sharpness_data.max_sharpness",
+        "drop_default_data.use_socket",
+        "max_stack_count",
+    ):
+        assert _canonical_nested_path(p) == p
+
+
+def test_a_similar_but_different_prefix_is_not_rewritten():
+    """Prefix matching must be on a path boundary, not a substring."""
+    p = "sharpness_data.stat_data.stat_list_static_extra"
+    assert _canonical_nested_path(p) == p
+
+
+# ── it actually resolves and writes ──────────────────────────────────
+
+def test_dmm_path_now_resolves_to_the_stat_list():
+    item = _item()
+    got = _resolve_path_target(
+        item, "sharpness_data.stat_data.stat_list_static")
+    assert got is not None, "the DMM path must resolve after aliasing"
+    parent, seg = got
+    assert parent is item["sharpness_data"]
+    assert seg == "stat_list"
+
+
+def test_the_mods_real_intent_applies():
+    """The exact intent from ExtensiveItemBuffs on key 14510."""
+    item = _item()
+    outcome = apply_nested_intent(
+        item, "sharpness_data.stat_data.stat_list_static",
+        [{"stat": 1000003, "change_mb": 8000}])
+    assert outcome == "ok", outcome
+    assert item["sharpness_data"]["stat_list"] == [
+        {"stat": 1000003, "change_mb": 8000}]
+
+
+def test_element_level_write_through_the_dmm_path():
+    item = _item()
+    outcome = apply_nested_intent(
+        item, "sharpness_data.stat_data.stat_list_static[0].change_mb",
+        8000)
+    assert outcome == "ok", outcome
+    assert item["sharpness_data"]["stat_list"][0]["change_mb"] == 8000
+    # the sibling key must be untouched
+    assert item["sharpness_data"]["stat_list"][0]["stat"] == 1000003
+
+
+def test_before_the_alias_this_path_was_unresolved():
+    """Pins WHY the alias is needed: the raw DMM path hits nothing.
+
+    Resolving it against the un-aliased name is what produced 1452
+    'skipped (unresolved)' warnings while the mod reported success.
+    """
+    item = _item()
+    assert _resolve_path_target(item, "sharpness_data.stat_data") is None
+    assert "stat_data" not in item["sharpness_data"]
+
+
+def test_a_record_without_sharpness_stats_still_refuses():
+    """Aliasing must not invent a target where there is none."""
+    item = _item()
+    del item["sharpness_data"]["stat_list"]
+    assert _resolve_path_target(
+        item, "sharpness_data.stat_data.stat_list_static") is None
+    assert apply_nested_intent(
+        item, "sharpness_data.stat_data.stat_list_static",
+        [{"stat": 1, "change_mb": 2}]) == "unresolved"


### PR DESCRIPTION
The last apply-time gap in the corpus. ExtensiveItemBuffs writes DMM's nested path `sharpness_data.stat_data.stat_list_static`; CDUMM's native parser decodes the same bytes as a flat `sharpness_data.stat_list`. Every one of those intents resolved to nothing — **1452 dropped as "unresolved"** while the mod reported success.

Same class as the characterinfo `character_weight` / `default_action_action_index` rename in #302: one field, two vendor names.

## I got this wrong first, so here is how it was actually established

My initial read was "the decoder never populates sharpness_data — 0 of 6508 records". **That was measured wrong.** I called `parse_iteminfo_from_bytes` without a `fields=` argument, so it used a default field list instead of the one the apply path selects via `detect_iteminfo_layout`. Under that list *both* `sharpness_data` and `enchant_data_list` read as absent — and enchant demonstrably works (14,899 intents apply), which is what exposed the error.

Measured the way the apply path decodes (`fields = detect_iteminfo_layout(body, offsets)`, 119 fields):

| | |
|---|---|
| `sharpness_data` present as a dict | **6508 / 6508** |
| its keys | `craft_tool_info, max_sharpness, p_prefix, shape, stat_list, tail, w_trailing, w_unk_a` |
| `stat_data` present | never |
| `stat_list` element keys | `('change_mb', 'stat')` |

`_read_ItemInfoSharpnessData` reads a single flat `u32 stat_count + N*12 stats`, so `stat_list` is the **only** stat list under `sharpness_data` — there is nothing else the DMM path could refer to.

The same record settles it: key 14510 `Marni_Devotee_PlateArmor_Helm` decodes `[{stat: 1000003, change_mb: 1000}]`, and the mod sets that same stat to 8000. All 1269 records it targets have a non-empty `stat_list` (945 with one entry, 324 with two), all shape `W`.

## Byte-exact before shipping

```
identity round-trip     re-serializing the untouched table reproduces
                        all 5,938,891 bytes exactly
write through stat_list exactly 2 bytes differ: e803 -> 401f (1000 -> 8000)
                        both inside record 14510, the target
record offsets          identical to vanilla -> length-preserving,
                        no .pabgh rebuild
```

## Scoping

The rewrite is prefix-scoped, so an indexed or deeper suffix survives (`...stat_list_static[0].change_mb` → `sharpness_data.stat_list[0].change_mb`), and matching is on a path boundary so `stat_list_static_extra` is untouched.

`enchant_data_list` genuinely **is** nested as `enchant_stat_data.stat_list_static` and already resolves — rewriting it would break 14,899 working intents. A test pins that it, plain `sharpness_data.stat_list`, `drop_default_data.*` and `max_stack_count` all stay untouched.

A record whose `stat_list` is missing still refuses rather than having a target invented for it.

## Verification

`apply_scan` over the 52-mod corpus: **1452 drops → 0**.

Fast suite 2628 passed, 42 skipped. Ruff unchanged on `iteminfo_writer.py` (19 before, 19 after) and clean on the new test file. The slow integration tests are the iteminfo round-trips most relevant here — running in CI on this push.

Depends on nothing; independent of #332/#333/#334.
