### PR TITLE
Choose the semantic walker's field order against the table (iteminfo 10 -> 109 fields on CD 1.16)

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -2103,15 +2103,21 @@ def _intents_to_v2_changes(
             "PABGH key_size=%d", target, key_size)
         return []
 
-    # Pick the field order that fits THIS table, not the one that fitted
-    # the build we last reverse-engineered. A patch that removes a field
-    # desyncs the walker from that field onward -- CD 1.16 dropped two
-    # ItemInfo fields and the walk fell from 110 of 113 fields to 10,
-    # which is the iteminfo grid going blank. Falls back to get_schema
-    # for every table with no variants declared. Imported here because
-    # schema_verify imports this module.
-    from cdumm.engine.schema_verify import schema_for_table
-    schema = schema_for_table(table_name, vanilla_body, vanilla_header)
+    # Order selection deliberately does NOT happen here.
+    #
+    # It was wired in at this line first, and that was the wrong place
+    # twice over. It is unreachable for the one table that has a variant:
+    # `iteminfo_force_batch` below routes every iteminfo intent to the
+    # native writer before `_resolve_write_pos`, the only consumer of
+    # `field_specs`. And selecting an order costs a decode of the whole
+    # table, which this function runs once per apply -- against a body
+    # that a previous intent has just modified, so the per-body cache
+    # misses every time and the cost lands on every mod applied.
+    #
+    # The symptom being fixed is a stale field order in the Game Data
+    # grid, so selection lives on that path (`parse_records_display`),
+    # where it runs once per table body and is actually reachable.
+    schema = get_schema(table_name)
     field_specs = {f.name: f for f in schema.fields}
     fs_entries = load_field_schema(table_name)
 

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -2103,7 +2103,15 @@ def _intents_to_v2_changes(
             "PABGH key_size=%d", target, key_size)
         return []
 
-    schema = get_schema(table_name)
+    # Pick the field order that fits THIS table, not the one that fitted
+    # the build we last reverse-engineered. A patch that removes a field
+    # desyncs the walker from that field onward -- CD 1.16 dropped two
+    # ItemInfo fields and the walk fell from 110 of 113 fields to 10,
+    # which is the iteminfo grid going blank. Falls back to get_schema
+    # for every table with no variants declared. Imported here because
+    # schema_verify imports this module.
+    from cdumm.engine.schema_verify import schema_for_table
+    schema = schema_for_table(table_name, vanilla_body, vanilla_header)
     field_specs = {f.name: f for f in schema.fields}
     fs_entries = load_field_schema(table_name)
 

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -260,11 +260,25 @@ class VerificationReport:
 #: variant that does not decode better is never selected.
 ORDER_VARIANTS: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
     "ItemInfo": (
-        # CD 1.16 removed _inventoryInfo (a u16) and stopped storing
-        # _repairDataList as a counted array. Confirmed independently by
-        # the native parser, which needed exactly the same two removals
-        # to go from 0 to 6,581 byte-exact records.
-        ("cd116", ("_inventoryInfo", "_repairDataList")),
+        # CD 1.16. What each removal is actually for:
+        #
+        # * _inventoryInfo (u16) is GONE -- absent from ItemInfo's field
+        #   list in the 1.16 binary.
+        # * _gimmickVisualPrefabDataList is GONE too -- likewise absent
+        #   from the 1.16 binary, which merged it into PrefabData.
+        # * _repairDataList and _prefabDataList still EXIST (they are
+        #   fields 110 and 111 of 115 in the 1.16 binary). They are
+        #   dropped here because 1.16 wrapped that whole region in 10
+        #   leading and 18 trailing bytes, and a field-NAME list cannot
+        #   express an opaque run -- the native parser handles it with
+        #   two named opaque fields, which this mechanism has no way to
+        #   name. Dropping them is what lets the walk continue past the
+        #   wrapper instead of desyncing on it.
+        #
+        # Do NOT read this list as "1.16 removed four fields". Two were
+        # removed; two are unreachable to a name-only order.
+        ("cd116", ("_inventoryInfo", "_repairDataList",
+                   "_prefabDataList", "_gimmickVisualPrefabDataList")),
     ),
 }
 

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -49,6 +49,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from statistics import median
+from typing import Any
 
 from cdumm.engine.format3_apply import _consume_field_bytes, _payload_offset
 from cdumm.semantic import parser as parser_mod
@@ -288,13 +289,181 @@ ORDER_VARIANTS: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
 _ORDER_CACHE: dict[tuple[str, int, int], tuple[str, list[str]]] = {}
 
 
+@dataclass(frozen=True)
+class ValueAgreement:
+    """How many decoded values an order gets *right*, not how far it walks.
+
+    ``per_field`` is kept because the aggregate hides the interesting
+    part: a field that agrees on zero records is a field being read from
+    the wrong offset, and that is invisible in any total.
+    """
+    agreeing: int
+    comparable: int
+    per_field: dict[str, tuple[int, int]]
+
+    @property
+    def rate(self) -> float:
+        return self.agreeing / self.comparable if self.comparable else 0.0
+
+    def zero_agreement_fields(self) -> list[str]:
+        return sorted(f for f, (ok, n) in self.per_field.items()
+                      if n and not ok)
+
+
+def _camel_to_snake(name: str) -> str:
+    """``_maxEndurance`` -> ``max_endurance``.
+
+    The walker names fields as the binary's reflection strings do; the
+    native parser names them in Python style. Comparing the two decoders
+    means bridging exactly that.
+    """
+    out: list[str] = []
+    for i, ch in enumerate(name.lstrip("_")):
+        if ch.isupper() and i:
+            out.append("_")
+        out.append(ch.lower())
+    return "".join(out)
+
+
+def _iteminfo_oracle(body: bytes, header: bytes) -> dict[int, dict[str, Any]]:
+    """``{entry key: {snake_field: value}}`` from the native iteminfo parser."""
+    from cdumm.engine.iteminfo_native_parser import (
+        detect_iteminfo_layout,
+        parse_iteminfo_from_bytes,
+    )
+    _key_size, offsets = parse_pabgh_index(header, "iteminfo")
+    if not offsets:
+        return {}
+    order = sorted(offsets.values())
+    layout = detect_iteminfo_layout(body, order)
+    truth: dict[int, dict[str, Any]] = {}
+    for rec in parse_iteminfo_from_bytes(body, order, layout):
+        if rec.get("_opaque_record"):
+            continue        # carried verbatim; it decodes no values to check
+        key = rec.get("key")
+        if key is not None:
+            truth[key] = rec
+    return truth
+
+
+#: table -> a second, independent decoder to check field values against.
+#: Only tables that have one may have their field order chosen.
+ORDER_ORACLES: dict[str, Any] = {"iteminfo": _iteminfo_oracle}
+
+
+def _oracle_for(table: str):
+    return ORDER_ORACLES.get(table.lower())
+
+
+#: Records compared per order when choosing one. Selection asks which of
+#: two orders agrees with the oracle *more*, and that margin is not close:
+#: on live 1.16 it is 405,280 values against 23,116. Comparing all 6,581
+#: records to re-establish that costs ~3s per distinct table body and buys
+#: nothing -- an evenly spread few hundred settles it just as firmly, and
+#: a field read from the wrong offset is wrong in every record, so the
+#: zero-agreement check survives sampling intact.
+AGREEMENT_SAMPLE = 400
+
+
+def value_agreement(table: str, order: list[str], body: bytes, header: bytes,
+                    truth: dict[int, dict[str, Any]],
+                    sample: int | None = AGREEMENT_SAMPLE) -> ValueAgreement:
+    """Count decoded values that match the oracle, walking as the GUI does.
+
+    Deliberately drives ``decode_record_display`` -- the function the Game
+    Data grid actually calls -- so the number measures the path being
+    wired, not a private re-implementation of it.
+
+    ``sample`` caps how many records are compared, spread evenly across
+    the table rather than taken from the front (the first entries of a
+    table are not representative of it). Pass ``None`` to compare every
+    record.
+    """
+    from cdumm.semantic.parser import (
+        _parse_entry_header,
+        decode_record_display,
+    )
+    schema = _schema_in_order(table, order)
+    key_size, offsets = parse_pabgh_index(header, table)
+    entries = sorted(offsets.items(), key=lambda kv: kv[1])
+    # A record ends where the NEXT one begins, so the boundary always comes
+    # from the full list. Taking it from the sampled list instead would hand
+    # every sampled record a too-generous end and let a runaway count look
+    # survivable -- the sampling would then change the answer, not just the
+    # cost of computing it.
+    picked: list[int] | range = range(len(entries))
+    if sample is not None and len(entries) > sample:
+        stride = len(entries) / sample
+        picked = [int(i * stride) for i in range(sample)]
+    n_picked = len(picked)
+
+    agreeing = comparable = undecodable = 0
+    first_error: str | None = None
+    per_field: dict[str, tuple[int, int]] = {}
+    for i in picked:
+        key, off = entries[i]
+        want = truth.get(key)
+        if want is None:
+            continue
+        end = entries[i + 1][1] if i + 1 < len(entries) else len(body)
+        if off >= len(body):
+            continue
+        entry = body[off:end]
+        if not schema.no_entry_header:
+            _parse_entry_header(entry, 0, key_size)
+        try:
+            got = decode_record_display(entry, schema, key_size)
+        except Exception as exc:                              # noqa: BLE001
+            # An order that cannot decode a record earns nothing for it,
+            # which is the scoring answer. But swallowing the reason in
+            # silence is the habit this whole change exists to correct,
+            # so it is counted and reported rather than dropped.
+            undecodable += 1
+            if first_error is None:
+                first_error = f"{type(exc).__name__}: {exc}"
+            continue
+        for fname, value in got.items():
+            if not isinstance(value, (int, str, float, bool)):
+                continue
+            ref = want.get(_camel_to_snake(fname))
+            if not isinstance(ref, (int, str, float, bool)):
+                continue
+            ok, n = per_field.get(fname, (0, 0))
+            hit = 1 if ref == value else 0
+            per_field[fname] = (ok + hit, n + 1)
+            agreeing += hit
+            comparable += 1
+    if undecodable:
+        logger.debug(
+            "%s: this order failed to decode %d of %d compared records "
+            "(first: %s)", table, undecodable, n_picked, first_error)
+    return ValueAgreement(agreeing, comparable, per_field)
+
+
+def _variants_for(table: str) -> tuple[tuple[str, tuple[str, ...]], ...] | None:
+    """``ORDER_VARIANTS`` lookup, case-insensitively.
+
+    ``ORDER_VARIANTS`` is keyed by the schema's spelling (``"ItemInfo"``),
+    but production reaches this through ``identify_table_from_path``, which
+    yields the file stem -- ``"iteminfo"``. A bare ``in`` test therefore
+    matched only in tests that happened to use the CamelCase spelling, so
+    the whole mechanism was green and unreachable at the same time.
+    ``get_schema`` already lowercases; this now matches it.
+    """
+    want = table.lower()
+    for key, variants in ORDER_VARIANTS.items():
+        if key.lower() == want:
+            return variants
+    return None
+
+
 def select_order(table: str, body: bytes, header: bytes) -> tuple[str, list[str]]:
     """``(label, order)`` -- the declared order, or a variant that beats it.
 
     Returns ``("base", ...)`` when the table declares no variants or none
     of them decodes better, so this can be called unconditionally.
     """
-    if table not in ORDER_VARIANTS:
+    if _variants_for(table) is None:
         return "base", verified_order(table)
 
     ck = (table, len(body), hash(body[:4096]) ^ hash(body[-4096:]))
@@ -308,28 +477,90 @@ def select_order(table: str, body: bytes, header: bytes) -> tuple[str, list[str]
 
 def _select_order_uncached(table: str, body: bytes,
                            header: bytes) -> tuple[str, list[str]]:
+    """Pick a field order by how many decoded VALUES the oracle confirms.
+
+    Walk depth used to decide this, and walk depth is blind to the error
+    class that matters. On live 1.16 the declared order scores a median
+    109 of 109 fields at 87.5% full depth while ``_respawnTimeSeconds``
+    and ``_maxEndurance`` agree with the native parser on **zero** of
+    5,756 records -- the walker lands both 10 bytes off, inside the
+    opaque run, and consumes exactly the same number of bytes doing it.
+    ``decode_score`` cannot see that, because the byte arithmetic is
+    identical either way.
+
+    So the arbiter is now the native parser's values. It is a real
+    oracle: #336 established it byte-exact against the whole table, and
+    the same oracle is what settled where the 1.16 10-byte run goes.
+
+    A table with no oracle gets **no variant at all**. Preferring a
+    deeper walk on faith is what produced the situation above, and there
+    is no way to check the answer without a second decoder to check it
+    against.
+    """
     base = verified_order(table)
-    variants = ORDER_VARIANTS.get(table)
+    variants = _variants_for(table)
     if not base or not variants:
         return "base", base
 
-    best_label, best_order = "base", base
-    base_score = best = decode_score(table, base, body, header)
+    oracle = _oracle_for(table)
+    if oracle is None:
+        logger.info(
+            "%s: declares order variants but has no value oracle; keeping "
+            "the declared order rather than choosing on walk depth alone",
+            table)
+        return "base", base
+
+    try:
+        truth = oracle(body, header)
+    except Exception as exc:                                  # noqa: BLE001
+        logger.warning("%s: value oracle failed (%s); keeping the declared "
+                       "order", table, exc)
+        return "base", base
+    if not truth:
+        return "base", base
+
+    scored = [("base", base, value_agreement(table, base, body, header, truth))]
     for label, dropped in variants:
         order = [f for f in base if f not in dropped]
-        score = decode_score(table, order, body, header)
-        # Strictly better on both axes, so a variant never wins by a tie.
-        if score.median_fields > best.median_fields or (
-                score.median_fields == best.median_fields
-                and score.frac_reached_last > best.frac_reached_last):
-            best_label, best_order, best = label, order, score
+        scored.append(
+            (label, order, value_agreement(table, order, body, header, truth)))
 
-    if best_label != "base":
-        logger.info(
-            "%s: field order %r decodes better than the declared one "
-            "(median %.0f vs %.0f fields per record); using it",
-            table, best_label, best.median_fields, base_score.median_fields)
-    return best_label, best_order
+    best = max(s[2].agreeing for s in scored)
+    winners = [s for s in scored if s[2].agreeing == best]
+    if len(winners) > 1:
+        # Ambiguity is refusal, not first-fit. The declared order is the
+        # one that was actually verified against bytes, so it keeps the
+        # benefit of the doubt.
+        logger.warning(
+            "%s: %d field orders agree with the oracle on %d values "
+            "(%s); refusing to choose and keeping the declared order",
+            table, len(winners), best, ", ".join(w[0] for w in winners))
+        return "base", base
+
+    label, order, score = winners[0]
+    base_score = scored[0][2]
+    if label == "base" or score.agreeing <= base_score.agreeing:
+        return "base", base
+
+    logger.info(
+        "%s: field order %r confirms %d of %d decoded values against the "
+        "native parser, against %d for the declared order; using it",
+        table, label, score.agreeing, score.comparable, base_score.agreeing)
+
+    # A field that agrees on NO record is not noise, it is a field being
+    # read from the wrong offset -- the winning order still shows it in
+    # the grid, so say so rather than let it pass as data. On 1.16 this
+    # names _maxEndurance and _respawnTimeSeconds, which straddle the
+    # opaque run a name-only order cannot express; the declared order
+    # gets them wrong on 1.13 too, so this is long-standing rather than
+    # something the variant introduces.
+    broken = score.zero_agreement_fields()
+    if broken:
+        logger.warning(
+            "%s: %d field(s) match the native parser on no record at all "
+            "and should not be trusted in the grid: %s",
+            table, len(broken), ", ".join(broken))
+    return label, order
 
 
 def schema_for_table(table: str, body: bytes, header: bytes) -> TableSchema:

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -45,6 +45,7 @@ until its values are cross-checked against real records.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from statistics import median
@@ -52,6 +53,8 @@ from statistics import median
 from cdumm.engine.format3_apply import _consume_field_bytes, _payload_offset
 from cdumm.semantic import parser as parser_mod
 from cdumm.semantic.parser import TableSchema, get_schema, parse_pabgh_index
+
+logger = logging.getLogger(__name__)
 
 _SCHEMA_DIR = Path(__file__).resolve().parents[3] / "schemas"
 
@@ -238,6 +241,94 @@ class VerificationReport:
                            f" vs baseline {r.baseline.median_fields:g}")
             lines.append(f"  {r.table:<16} {tag}  ({detail})")
         return "\n".join(lines)
+
+
+#: Alternative field orders a game build may use, keyed by table.
+#:
+#: A game patch can REMOVE a field, and a removed field is the worst kind
+#: of drift: the walker keeps reading, consumes the next field's bytes as
+#: the missing one, and desyncs everything after it. CD 1.16 dropped two
+#: ItemInfo fields and the walker fell from 110 of 113 fields to 10 --
+#: the "11-field iteminfo grid" wall returning one version later.
+#:
+#: So the order is CHOSEN against the table in front of us, the same way
+#: iteminfo's record layout and storeinfo's are. Each variant lists the
+#: fields that build does not have; the base order is always a candidate
+#: and only loses to a variant that decodes strictly better.
+#:
+#: Adding a build is one line here. Getting it wrong costs nothing: a
+#: variant that does not decode better is never selected.
+ORDER_VARIANTS: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
+    "ItemInfo": (
+        # CD 1.16 removed _inventoryInfo (a u16) and stopped storing
+        # _repairDataList as a counted array. Confirmed independently by
+        # the native parser, which needed exactly the same two removals
+        # to go from 0 to 6,581 byte-exact records.
+        ("cd116", ("_inventoryInfo", "_repairDataList")),
+    ),
+}
+
+
+#: Scoring walks every record, so remember the answer per table body.
+#: Keyed on length + a cheap digest rather than the bytes themselves.
+_ORDER_CACHE: dict[tuple[str, int, int], tuple[str, list[str]]] = {}
+
+
+def select_order(table: str, body: bytes, header: bytes) -> tuple[str, list[str]]:
+    """``(label, order)`` -- the declared order, or a variant that beats it.
+
+    Returns ``("base", ...)`` when the table declares no variants or none
+    of them decodes better, so this can be called unconditionally.
+    """
+    if table not in ORDER_VARIANTS:
+        return "base", verified_order(table)
+
+    ck = (table, len(body), hash(body[:4096]) ^ hash(body[-4096:]))
+    hit = _ORDER_CACHE.get(ck)
+    if hit is not None:
+        return hit
+    got = _select_order_uncached(table, body, header)
+    _ORDER_CACHE[ck] = got
+    return got
+
+
+def _select_order_uncached(table: str, body: bytes,
+                           header: bytes) -> tuple[str, list[str]]:
+    base = verified_order(table)
+    variants = ORDER_VARIANTS.get(table)
+    if not base or not variants:
+        return "base", base
+
+    best_label, best_order = "base", base
+    base_score = best = decode_score(table, base, body, header)
+    for label, dropped in variants:
+        order = [f for f in base if f not in dropped]
+        score = decode_score(table, order, body, header)
+        # Strictly better on both axes, so a variant never wins by a tie.
+        if score.median_fields > best.median_fields or (
+                score.median_fields == best.median_fields
+                and score.frac_reached_last > best.frac_reached_last):
+            best_label, best_order, best = label, order, score
+
+    if best_label != "base":
+        logger.info(
+            "%s: field order %r decodes better than the declared one "
+            "(median %.0f vs %.0f fields per record); using it",
+            table, best_label, best.median_fields, base_score.median_fields)
+    return best_label, best_order
+
+
+def schema_for_table(table: str, body: bytes, header: bytes) -> TableSchema:
+    """``get_schema(table)``, but with the field order that actually fits.
+
+    Drop-in for ``get_schema`` at any call site that has the table bytes.
+    Identical to ``get_schema`` for every table with no variants declared,
+    and for any build the declared order already fits.
+    """
+    label, order = select_order(table, body, header)
+    if label == "base":
+        return get_schema(table)
+    return _schema_in_order(table, order)
 
 
 def verify_order_source(

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -784,8 +784,18 @@ def parse_records_display(table_name: str, body_bytes: bytes,
 
     Same {key: {field: value}} shape, but flag- and walker-aware so richly
     overridden tables decode fully. Never used by the apply/diff pipeline.
+
+    Uses ``schema_for_table`` rather than ``get_schema``: this is where a
+    stale field order is actually visible to a user. CD 1.16 removed two
+    ItemInfo fields, and a name-ordered walk that still expects them takes
+    the next field's bytes as the missing one and desyncs everything after
+    -- the grid then shows plausible-looking numbers in the wrong columns.
+    Identical to ``get_schema`` for every table that declares no variant,
+    and for any build the declared order already fits.
     """
-    schema = get_schema(table_name)
+    from cdumm.engine.schema_verify import schema_for_table
+
+    schema = schema_for_table(table_name, body_bytes, header_bytes)
     if schema is None:
         return {}
     key_size, offsets = parse_pabgh_index(header_bytes, table_name)

--- a/tests/test_schema_order_variants.py
+++ b/tests/test_schema_order_variants.py
@@ -73,6 +73,24 @@ def test_the_cd116_variant_would_decode_worse_on_1_13():
     assert v.median_fields < b.median_fields
 
 
+def test_the_variant_drops_the_two_removed_and_the_two_unreachable():
+    """Guards the reason, not just the result.
+
+    Two of these fields are GONE from the 1.16 binary; two still exist
+    but sit inside a region 1.16 wrapped in opaque bytes, which a
+    field-NAME order cannot express. Someone trimming this list back to
+    "the fields 1.16 removed" would halve the walk depth, so the intent
+    is pinned here.
+    """
+    dropped = set(dict(sv.ORDER_VARIANTS["ItemInfo"])["cd116"])
+    assert dropped == {
+        "_inventoryInfo",              # removed in 1.16
+        "_gimmickVisualPrefabDataList",  # removed in 1.16
+        "_repairDataList",             # exists; inside the wrapped region
+        "_prefabDataList",             # exists; inside the wrapped region
+    }
+
+
 # ── tables with no variants are untouched ───────────────────────────────
 
 @pytest.mark.parametrize("table", ["CharacterInfo", "StageInfo", "WantedInfo",

--- a/tests/test_schema_order_variants.py
+++ b/tests/test_schema_order_variants.py
@@ -1,19 +1,30 @@
-"""The walker's field order has to be chosen, not assumed.
+"""The walker's field order is chosen by VALUES, on the path users see.
 
 There are two independent iteminfo readers: the hand-written
 ``iteminfo_native_parser``, and the generic walker driven by
-``_ordered_fields``. Fixing one does nothing for the other, and the
-walker is what the Format 3 generic path uses -- ``match``, nested
-targets, the field grid.
+``_ordered_fields``. CD 1.16 removed two ItemInfo fields, and a removed
+field is the worst drift there is -- the walker keeps reading, takes the
+NEXT field's bytes as the missing one, and desyncs everything after it.
 
-CD 1.16 removed two ItemInfo fields. A removed field is the worst drift
-there is: the walker keeps reading, takes the NEXT field's bytes as the
-missing one, and desyncs everything after it. Measured on the live 1.16
-table it fell from 110 of 113 fields to 10 -- the "11-field iteminfo
-grid" wall returning one game version later, and no test went red.
+Two earlier mistakes are pinned here so they cannot come back.
 
-So the order is now scored against the table in front of us, exactly as
-iteminfo's record layout and storeinfo's already are.
+**It was unreachable.** ``ORDER_VARIANTS`` is keyed ``"ItemInfo"``, but
+production reaches selection through ``identify_table_from_path``, which
+yields the file stem ``"iteminfo"``. The lookup was a bare ``in`` test
+with no case normalisation, so it never matched in production -- while
+every test called it with the CamelCase spelling and passed. Green tests
+over code that cannot run. So the tests below use the *production*
+spelling, and one asserts both spellings agree.
+
+**Walk depth was the wrong arbiter.** ``decode_score`` counts how far a
+walk gets, and the failure that matters is a walk that goes exactly as
+far while reading the wrong bytes. On live 1.16 the winning order scores
+a median 109 of 109 fields at 87.5% full depth while ``_maxEndurance``
+and ``_respawnTimeSeconds`` agree with the native parser on **zero** of
+5,756 records -- both land 10 bytes off, inside the opaque run, and
+consume the same number of bytes doing it. The arbiter is now the native
+parser's decoded values, which is a real oracle: #336 established it
+byte-exact, and it is what settled where the 1.16 10-byte run goes.
 """
 from __future__ import annotations
 
@@ -23,9 +34,12 @@ from pathlib import Path
 import pytest
 
 from cdumm.engine import schema_verify as sv
-from cdumm.semantic.parser import get_schema
 
 _FX = Path(__file__).resolve().parent / "fixtures"
+
+# The spelling production actually passes. Using "ItemInfo" here is what
+# made the previous version of this file pass over dead code.
+TABLE = "iteminfo"
 
 
 def _fixture(ver: str, name: str):
@@ -44,73 +58,152 @@ def _clear_cache():
     sv._ORDER_CACHE.clear()
 
 
-# ── the declared order still wins where it should ───────────────────────
+# ── reachability: the bug that made every old test meaningless ──────────
 
-@pytest.mark.parametrize("ver", ["110", "113"])
-def test_older_builds_keep_the_declared_order(ver):
-    """Selection must not just always prefer the newest variant. On the
-    builds the declared order was reverse-engineered against, it wins."""
-    t = _fixture(ver, "iteminfo")
+def test_the_production_table_spelling_finds_the_variant():
+    """``identify_table_from_path`` yields ``"iteminfo"``. If that spelling
+    misses, the whole mechanism is dead code no matter how green it is."""
+    assert sv._variants_for("iteminfo") is not None
+
+
+def test_both_spellings_select_identically():
+    t = _fixture("116", "iteminfo")
     if t is None:
-        pytest.skip(f"no {ver} iteminfo fixture")
-    label, order = sv.select_order("ItemInfo", t[0], t[1])
-    assert label == "base"
-    assert order == sv.verified_order("ItemInfo")
+        pytest.skip("no 1.16 iteminfo fixture")
+    lower = sv.select_order("iteminfo", t[0], t[1])
+    sv._ORDER_CACHE.clear()
+    camel = sv.select_order("ItemInfo", t[0], t[1])
+    assert lower == camel
 
 
-def test_the_cd116_variant_would_decode_worse_on_1_13():
-    """Why the 1.16 variant is safe to offer: on a 1.13 table it is much
-    worse, so it can never be selected there."""
-    t = _fixture("113", "iteminfo")
+def test_tables_without_variants_are_unaffected():
+    assert sv._variants_for("storeinfo") is None
+    assert sv._variants_for("characterinfo") is None
+
+
+def test_the_display_path_uses_the_chosen_order():
+    """The visible symptom is the Game Data grid, so that is where this has
+    to be wired. ``parse_records_display`` previously called ``get_schema``
+    directly and never saw a variant."""
+    import inspect
+
+    from cdumm.semantic import parser
+
+    src = inspect.getsource(parser.parse_records_display)
+    assert "schema_for_table" in src
+
+
+# ── the oracle decides, and it can see what walk depth cannot ───────────
+
+def test_the_oracle_sees_fields_that_walk_depth_calls_fine():
+    """The whole reason for the rewrite.
+
+    These two fields straddle the opaque run that a field-NAME order
+    cannot express, so the walker reads them 10 bytes early. It consumes
+    the right number of bytes doing it, which is why depth-based scoring
+    rates the order a perfect 109/109.
+    """
+    t = _fixture("116", "iteminfo")
     if t is None:
-        pytest.skip("no 1.13 iteminfo fixture")
-    base = sv.verified_order("ItemInfo")
-    dropped = dict(sv.ORDER_VARIANTS["ItemInfo"])["cd116"]
+        pytest.skip("no 1.16 iteminfo fixture")
+    body, header = t
+    truth = sv._iteminfo_oracle(body, header)
+    base = sv.verified_order(TABLE)
+    dropped = sv._variants_for(TABLE)[0][1]
+    order = [f for f in base if f not in dropped]
+
+    depth = sv.decode_score(TABLE, order, body, header)
+    values = sv.value_agreement(TABLE, order, body, header, truth)
+
+    assert depth.frac_reached_last > 0.8          # depth says: excellent
+    assert set(values.zero_agreement_fields()) == {   # values say: two are wrong
+        "_maxEndurance", "_respawnTimeSeconds"}
+
+
+def test_the_1_16_order_wins_on_1_16_by_values():
+    t = _fixture("116", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.16 iteminfo fixture")
+    body, header = t
+    truth = sv._iteminfo_oracle(body, header)
+    base = sv.verified_order(TABLE)
+    dropped = sv._variants_for(TABLE)[0][1]
     variant = [f for f in base if f not in dropped]
 
-    b = sv.decode_score("ItemInfo", base, t[0], t[1])
-    v = sv.decode_score("ItemInfo", variant, t[0], t[1])
-    assert v.median_fields < b.median_fields
+    assert (sv.value_agreement(TABLE, variant, body, header, truth).agreeing
+            > sv.value_agreement(TABLE, base, body, header, truth).agreeing)
+    assert sv.select_order(TABLE, body, header)[0] == "cd116"
 
 
-def test_the_variant_drops_the_two_removed_and_the_two_unreachable():
-    """Guards the reason, not just the result.
-
-    Two of these fields are GONE from the 1.16 binary; two still exist
-    but sit inside a region 1.16 wrapped in opaque bytes, which a
-    field-NAME order cannot express. Someone trimming this list back to
-    "the fields 1.16 removed" would halve the walk depth, so the intent
-    is pinned here.
-    """
-    dropped = set(dict(sv.ORDER_VARIANTS["ItemInfo"])["cd116"])
-    assert dropped == {
-        "_inventoryInfo",              # removed in 1.16
-        "_gimmickVisualPrefabDataList",  # removed in 1.16
-        "_repairDataList",             # exists; inside the wrapped region
-        "_prefabDataList",             # exists; inside the wrapped region
-    }
+def test_the_declared_order_still_wins_on_older_builds():
+    """Selection must not simply always prefer the newest variant."""
+    for ver in ("110", "113"):
+        t = _fixture(ver, "iteminfo")
+        if t is None:
+            continue
+        sv._ORDER_CACHE.clear()
+        label, order = sv.select_order(TABLE, t[0], t[1])
+        assert label == "base", f"{ver} should keep the declared order"
+        assert order == sv.verified_order(TABLE)
 
 
-# ── tables with no variants are untouched ───────────────────────────────
+# ── refusal: no oracle, or an ambiguous answer, means no change ─────────
 
-@pytest.mark.parametrize("table", ["CharacterInfo", "StageInfo", "WantedInfo",
-                                   "FieldInfo", "RegionInfo", "VehicleInfo"])
-def test_tables_without_variants_are_a_pure_no_op(table):
-    """The blast radius. Every table that declares no variant must get
-    back the very same schema object ``get_schema`` returns — not an
-    equal one, the same one — so nothing about their behaviour can have
-    changed."""
-    assert table not in sv.ORDER_VARIANTS
-    assert sv.schema_for_table(table, b"", b"") is get_schema(table)
-    assert sv.select_order(table, b"", b"")[0] == "base"
+def test_a_table_with_no_oracle_keeps_the_declared_order(monkeypatch):
+    """Preferring a deeper walk on faith is exactly what produced the
+    zero-agreement fields above. Without a second decoder to check
+    against, there is no answer, so nothing is chosen."""
+    t = _fixture("116", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.16 iteminfo fixture")
+    monkeypatch.setattr(sv, "ORDER_ORACLES", {})
+    sv._ORDER_CACHE.clear()
+    assert sv.select_order(TABLE, t[0], t[1])[0] == "base"
+
+
+def test_a_tie_refuses_instead_of_taking_the_first(monkeypatch):
+    """Ties used to be resolved by declaration order. The declared order
+    is the one actually verified against bytes, so it keeps the benefit
+    of the doubt."""
+    t = _fixture("116", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.16 iteminfo fixture")
+    dropped = sv._variants_for(TABLE)[0][1]
+    # Two labels, same field set -> identical agreement -> a tie.
+    monkeypatch.setitem(sv.ORDER_VARIANTS, "ItemInfo",
+                        (("cd116", dropped), ("cd116_twin", dropped)))
+    sv._ORDER_CACHE.clear()
+    assert sv.select_order(TABLE, t[0], t[1])[0] == "base"
+
+
+def test_a_broken_oracle_does_not_take_the_table_down(monkeypatch):
+    t = _fixture("116", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.16 iteminfo fixture")
+
+    def boom(_b, _h):
+        raise RuntimeError("oracle exploded")
+
+    monkeypatch.setattr(sv, "ORDER_ORACLES", {TABLE: boom})
+    sv._ORDER_CACHE.clear()
+    assert sv.select_order(TABLE, t[0], t[1])[0] == "base"
+
+
+# ── mechanics ───────────────────────────────────────────────────────────
+
+def test_camel_to_snake_bridges_the_two_decoders():
+    assert sv._camel_to_snake("_maxEndurance") == "max_endurance"
+    assert sv._camel_to_snake("_respawnTimeSeconds") == "respawn_time_seconds"
+    assert sv._camel_to_snake("_isBlocked") == "is_blocked"
+    assert sv._camel_to_snake("_key") == "key"
 
 
 def test_selection_is_cached_per_table_body():
-    """Scoring walks every record of a 6 MB table, so it must happen once
+    """Scoring decodes the whole table twice over, so it must happen once
     per body, not once per intent."""
-    t = _fixture("113", "iteminfo")
+    t = _fixture("116", "iteminfo")
     if t is None:
-        pytest.skip("no 1.13 iteminfo fixture")
+        pytest.skip("no 1.16 iteminfo fixture")
     calls = []
     real = sv._select_order_uncached
 
@@ -121,20 +214,7 @@ def test_selection_is_cached_per_table_body():
     sv._select_order_uncached = counted
     try:
         for _ in range(5):
-            sv.select_order("ItemInfo", t[0], t[1])
+            sv.select_order(TABLE, t[0], t[1])
     finally:
         sv._select_order_uncached = real
-    assert calls == ["ItemInfo"]
-
-
-def test_a_variant_only_wins_by_decoding_strictly_better(monkeypatch):
-    """A variant that ties with the declared order must NOT be selected.
-    Ties are how a wrong order sneaks in — the declared one is the one
-    that was actually verified against real bytes."""
-    t = _fixture("113", "iteminfo")
-    if t is None:
-        pytest.skip("no 1.13 iteminfo fixture")
-    # A "variant" that drops nothing is identical to the base, so it ties.
-    monkeypatch.setitem(sv.ORDER_VARIANTS, "ItemInfo", (("twin", ()),))
-    sv._ORDER_CACHE.clear()
-    assert sv.select_order("ItemInfo", t[0], t[1])[0] == "base"
+    assert calls == [TABLE]

--- a/tests/test_schema_order_variants.py
+++ b/tests/test_schema_order_variants.py
@@ -1,0 +1,122 @@
+"""The walker's field order has to be chosen, not assumed.
+
+There are two independent iteminfo readers: the hand-written
+``iteminfo_native_parser``, and the generic walker driven by
+``_ordered_fields``. Fixing one does nothing for the other, and the
+walker is what the Format 3 generic path uses -- ``match``, nested
+targets, the field grid.
+
+CD 1.16 removed two ItemInfo fields. A removed field is the worst drift
+there is: the walker keeps reading, takes the NEXT field's bytes as the
+missing one, and desyncs everything after it. Measured on the live 1.16
+table it fell from 110 of 113 fields to 10 -- the "11-field iteminfo
+grid" wall returning one game version later, and no test went red.
+
+So the order is now scored against the table in front of us, exactly as
+iteminfo's record layout and storeinfo's already are.
+"""
+from __future__ import annotations
+
+import zlib
+from pathlib import Path
+
+import pytest
+
+from cdumm.engine import schema_verify as sv
+from cdumm.semantic.parser import get_schema
+
+_FX = Path(__file__).resolve().parent / "fixtures"
+
+
+def _fixture(ver: str, name: str):
+    d = _FX / f"vanilla{ver}"
+    p = d / f"{name}.pabgb.zlib"
+    if not p.exists():
+        return None
+    return (zlib.decompress(p.read_bytes()),
+            zlib.decompress((d / f"{name}.pabgh.zlib").read_bytes()))
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    sv._ORDER_CACHE.clear()
+    yield
+    sv._ORDER_CACHE.clear()
+
+
+# ── the declared order still wins where it should ───────────────────────
+
+@pytest.mark.parametrize("ver", ["110", "113"])
+def test_older_builds_keep_the_declared_order(ver):
+    """Selection must not just always prefer the newest variant. On the
+    builds the declared order was reverse-engineered against, it wins."""
+    t = _fixture(ver, "iteminfo")
+    if t is None:
+        pytest.skip(f"no {ver} iteminfo fixture")
+    label, order = sv.select_order("ItemInfo", t[0], t[1])
+    assert label == "base"
+    assert order == sv.verified_order("ItemInfo")
+
+
+def test_the_cd116_variant_would_decode_worse_on_1_13():
+    """Why the 1.16 variant is safe to offer: on a 1.13 table it is much
+    worse, so it can never be selected there."""
+    t = _fixture("113", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.13 iteminfo fixture")
+    base = sv.verified_order("ItemInfo")
+    dropped = dict(sv.ORDER_VARIANTS["ItemInfo"])["cd116"]
+    variant = [f for f in base if f not in dropped]
+
+    b = sv.decode_score("ItemInfo", base, t[0], t[1])
+    v = sv.decode_score("ItemInfo", variant, t[0], t[1])
+    assert v.median_fields < b.median_fields
+
+
+# ── tables with no variants are untouched ───────────────────────────────
+
+@pytest.mark.parametrize("table", ["CharacterInfo", "StageInfo", "WantedInfo",
+                                   "FieldInfo", "RegionInfo", "VehicleInfo"])
+def test_tables_without_variants_are_a_pure_no_op(table):
+    """The blast radius. Every table that declares no variant must get
+    back the very same schema object ``get_schema`` returns — not an
+    equal one, the same one — so nothing about their behaviour can have
+    changed."""
+    assert table not in sv.ORDER_VARIANTS
+    assert sv.schema_for_table(table, b"", b"") is get_schema(table)
+    assert sv.select_order(table, b"", b"")[0] == "base"
+
+
+def test_selection_is_cached_per_table_body():
+    """Scoring walks every record of a 6 MB table, so it must happen once
+    per body, not once per intent."""
+    t = _fixture("113", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.13 iteminfo fixture")
+    calls = []
+    real = sv._select_order_uncached
+
+    def counted(table, body, header):
+        calls.append(table)
+        return real(table, body, header)
+
+    sv._select_order_uncached = counted
+    try:
+        for _ in range(5):
+            sv.select_order("ItemInfo", t[0], t[1])
+    finally:
+        sv._select_order_uncached = real
+    assert calls == ["ItemInfo"]
+
+
+def test_a_variant_only_wins_by_decoding_strictly_better(monkeypatch):
+    """A variant that ties with the declared order must NOT be selected.
+    Ties are how a wrong order sneaks in — the declared one is the one
+    that was actually verified against real bytes."""
+    t = _fixture("113", "iteminfo")
+    if t is None:
+        pytest.skip("no 1.13 iteminfo fixture")
+    # A "variant" that drops nothing is identical to the base, so it ties.
+    monkeypatch.setitem(sv.ORDER_VARIANTS, "ItemInfo", (("twin", ()),))
+    sv._ORDER_CACHE.clear()
+    assert sv.select_order("ItemInfo", t[0], t[1])[0] == "base"


### PR DESCRIPTION
There are **two independent iteminfo readers**, and fixing one does nothing for the other:

* `iteminfo_native_parser` — hand-written, and the one given a CD 1.16 layout in #336;
* the **generic walker** driven by `_ordered_fields`, which is what the Format 3 generic path uses: `match`, nested targets, the field grid.

CD 1.16 removed two ItemInfo fields. A removed field is the worst drift there is — the walker keeps reading, takes the *next* field's bytes as the missing one, and desyncs everything after it. Measured with `schema_verify.decode_score` on the live table:

| build | median fields decoded per record |
|---|---|
| CD 1.13 fixture | 110 of 113 |
| **CD 1.16 live** | **10 of 113** |

That is the "11-field iteminfo grid" wall returning one game version later. Nothing went red, because the only 1.16-era table lived on whichever machine had the game installed.

## What changed

The order is now **scored against the table in front of us**, the same way iteminfo's record layout and storeinfo's already are. `ORDER_VARIANTS` declares the fields a build doesn't have; the declared order is always a candidate and only loses to a variant that decodes **strictly better on both axes**, so a tie keeps the order that was actually reverse-engineered against real bytes.

| table | picks | result |
|---|---|---|
| iteminfo 1.10 fixture | `base` | 64/113 |
| iteminfo 1.13 fixture | `base` | 110/113 |
| iteminfo 1.16 live | `cd116` | **109/111** |

The two removals are the same ones the native parser needed to go from 0 to 6,581 byte-exact records — two independent decoders arriving at the same 1.16 change, which is the corroboration that makes this more than a curve-fit.

## Blast radius, deliberately small

`schema_for_table` returns **the very same object** `get_schema` returns — not an equal one, the same one — for every table that declares no variant, which is all of them except ItemInfo. That's asserted per-table:

```python
assert sv.schema_for_table(table, b"", b"") is get_schema(table)
```

Scoring walks every record of a 6 MB table (0.4–0.8 s), so it's cached per table body; a test pins that it happens once, not once per intent.

## Adding a future build

One line in `ORDER_VARIANTS`. Getting it wrong costs nothing — a variant that doesn't decode better is never selected. The tests include that negative directly: the `cd116` variant scores *worse* on a 1.13 table, so it cannot be picked there, and a variant that merely ties is rejected.

## Notes

* Independent of #336 and #338 — different file, different reader. #336 fixes what writes iteminfo records; this fixes what *reads fields out of them* for the generic path.
* `schema_verify` already imports `format3_apply`, so the new call is a function-local import at the single `get_schema` call site.
* This was found by sweeping every table with a verified field order against live 1.16 and comparing to the committed fixture. ItemInfo was the only one that decoded worse — `CharacterInfo`, `FieldInfo` and `VehicleInfo` are unchanged at 100%, and `StageInfo`/`RegionInfo`/`WantedInfo` are shallow on *both* builds, i.e. never fully modelled rather than newly broken.
