### PR TITLE
Validate a game folder by what is in it, not what it is called (#343, unblocks #342)

### DIFF
--- a/src/cdumm/storage/game_finder.py
+++ b/src/cdumm/storage/game_finder.py
@@ -616,14 +616,24 @@ def validate_game_directory(path: Path) -> bool:
     archives live under ``Contents/Resources/packages/``. Accept any
     path that resolves (directly or by walking into a .app) to a
     directory containing the PAZ structural markers.
+
+    The PAZ test stands on its own (GitHub #343). It used to be ANDed
+    with ``is_xbox_install``, which is a **path-string** test — it looks
+    for ``xboxgames``, ``windowsapps``, ``modifiablewindowsapps`` or the
+    publisher hash somewhere in the path. That made acceptance depend on
+    what the folder is *called* rather than what is *in* it, so a real
+    game root was rejected whenever the exe wasn't at ``bin64/`` and the
+    path happened not to carry one of those tokens — an Xbox install
+    moved to a custom library, or any layout nobody had tokenised yet.
+    ``_looks_like_game_root`` requires ``0008/0.paz`` **and**
+    ``meta/0.papgt`` together, which is the thing CDUMM actually needs
+    and is not a shape an unrelated folder falls into by accident.
     """
     if IS_MACOS:
         return _resolve_macos_game_dir(path) is not None
     if (path / GAME_EXE).exists():
         return True
-    if is_xbox_install(path) and _looks_like_game_root(path):
-        return True
-    return False
+    return _looks_like_game_root(path)
 
 
 def resolve_game_directory(path: Path) -> Path | None:

--- a/tests/test_xbox_validation.py
+++ b/tests/test_xbox_validation.py
@@ -89,23 +89,51 @@ def test_xbox_install_without_paz_or_exe_is_invalid(tmp_path):
     assert validate_game_directory(game) is False
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="On macOS, validate_game_directory accepts any path with the "
-           "PAZ structural layout (0008/0.paz + meta/0.papgt) so users "
-           "can point CDUMM at the inner Contents/Resources/packages of "
-           "an opaque .app bundle. The Windows-only 'must be xboxgames-"
-           "marked' constraint doesn't apply.")
-def test_non_xbox_path_without_exe_is_invalid_even_with_paz(tmp_path):
-    # Generic path (no XboxGames / WindowsApps marker) without the exe
-    # must NOT be accepted — could be a partial manual copy.
+def test_a_real_game_root_is_valid_whatever_the_path_is_called(tmp_path):
+    """GitHub #343 — this test used to assert the opposite.
+
+    It required a generic path to be REJECTED even with the full PAZ
+    layout present, on the reasoning that it "could be a partial manual
+    copy". That made acceptance depend on what the folder is called
+    rather than what is in it: ``validate_game_directory`` ANDed the
+    content test with ``is_xbox_install``, which only searches the path
+    STRING for ``xboxgames`` / ``windowsapps`` / the publisher hash.
+
+    The cost showed up in #342 — an Xbox App user whose install is
+    genuinely a game root could not get CDUMM to accept it, because his
+    path carried none of the tokens anyone had thought to list. The
+    hypothetical partial copy never did; and a folder holding both
+    ``0008/0.paz`` and ``meta/0.papgt`` is a game data root, which is
+    exactly what CDUMM needs to mod.
+    """
     game = tmp_path / "SomeOtherFolder"
     (game / "0008").mkdir(parents=True)
     (game / "0008" / "0.paz").write_bytes(b"x")
     (game / "meta").mkdir()
     (game / "meta" / "0.papgt").write_bytes(b"x")
-    assert not is_xbox_install(game)
-    assert validate_game_directory(game) is False
+    assert not is_xbox_install(game), "no path token — that is the point"
+    assert validate_game_directory(game) is True
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS validation walks into .app bundles, so a bare folder "
+           "takes a different path through _resolve_macos_game_dir.")
+def test_a_folder_without_the_markers_is_still_rejected(tmp_path):
+    """Loosening the path check must not loosen the content check: the
+    two markers together are what acceptance now rests on entirely."""
+    for layout in ("nothing", "paz_only", "papgt_only"):
+        game = tmp_path / layout
+        game.mkdir()
+        if layout in ("nothing", "papgt_only"):
+            pass
+        if layout == "paz_only":
+            (game / "0008").mkdir()
+            (game / "0008" / "0.paz").write_bytes(b"x")
+        if layout == "papgt_only":
+            (game / "meta").mkdir()
+            (game / "meta" / "0.papgt").write_bytes(b"x")
+        assert validate_game_directory(game) is False, layout
 
 
 def test_custom_xbox_path_with_publisher_hash_detected(tmp_path):


### PR DESCRIPTION
Closes #343. Should also resolve #342.

## The bug

`validate_game_directory` accepted a folder when:

```python
if (path / GAME_EXE).exists():                          # bin64/CrimsonDesert.exe
    return True
if is_xbox_install(path) and _looks_like_game_root(path):
    return True
return False
```

`_looks_like_game_root` is the real test — `0008/0.paz` **and** `meta/0.papgt`. Its own docstring already said so:

> The PAZ layout itself is what the mod manager cares about ... If those exist we can mod the game regardless of where the exe lives on disk.

`is_xbox_install` is a **path-string** test — it searches the path for `xboxgames`, `windowsapps`, `modifiablewindowsapps` or the publisher hash. ANDing the two made acceptance depend on what the folder is *called* rather than what is *in* it.

So a real game root is rejected whenever the exe isn't at `bin64/` **and** the path happens to carry none of those tokens. That is exactly #342 — an Xbox App user whose install genuinely is a game root, on a path nobody had tokenised.

The token list can only describe layouts already seen, so it will keep failing this way as new ones turn up. Widening it is chasing; the content test doesn't need it.

## The fix

```python
if (path / GAME_EXE).exists():
    return True
return _looks_like_game_root(path)
```

Both markers are still required together, which is what CDUMM needs to mod the game and not a shape an unrelated folder falls into by accident. `is_xbox_install` keeps its other callers — labelling the install in the launcher, bug report and UI — where a path-string guess is the right tool.

## Tests

`test_non_xbox_path_without_exe_is_invalid_even_with_paz` asserted the old behaviour, justified as guarding against "a partial manual copy". It is replaced by `test_a_real_game_root_is_valid_whatever_the_path_is_called`, which states why that reasoning was wrong — the hypothetical partial copy never turned up in an issue, the rejection did.

Added `test_a_folder_without_the_markers_is_still_rejected` covering nothing / paz-only / papgt-only, since acceptance now rests entirely on the content test.

44 passed, 2 skipped across the four game-finder test files; 79 passed, 2 skipped across the wider finder/wizard/recovery/launcher sweep. Ruff: `game_finder.py` 13 -> 12 findings (one fewer, none added), test file 0 -> 0.

## For #342

Once this lands, pointing CDUMM at the folder that contains `0008` and `meta` should work regardless of where the Xbox App put it. To check before a release: the folder you pick needs `0008/0.paz` and `meta/0.papgt` directly inside it.
