### PR TITLE
Warn when a UI mod uses the pre-1.16 markup dialect (#344, explains #337)

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -2775,6 +2775,63 @@ def import_from_rar(
         return result
 
 
+def _warn_on_stale_ui_dialect(root: Path, game_dir: Path,
+                              result: "ModImportResult") -> None:
+    """Flag UI files written for the pre-1.16 markup dialect (#344).
+
+    CD 1.16 renamed the attributes the UI engine reads, so a UI mod built
+    before it installs perfectly and does nothing: the bytes land, the
+    file is valid, and the engine never reads it. There is no error and
+    no skipped-patch message, which makes it the one failure mode this
+    project refuses to leave silent.
+
+    Each UI file the mod ships is compared against the game's own copy of
+    the same file, so this cannot fire on a pre-1.16 install where the
+    old dialect is correct. Purely advisory -- the mod still installs,
+    because it may also ship textures or sounds that work fine, and only
+    the author can republish the markup.
+    """
+    try:
+        from cdumm.engine.json_patch_handler import (
+            _extract_from_paz,
+            _find_pamt_entry,
+        )
+        from cdumm.engine.ui_dialect import compare, is_ui_file
+    except Exception:                                       # noqa: BLE001
+        return
+
+    stale: list[str] = []
+    try:
+        candidates = [f for f in Path(root).rglob("*")
+                      if f.is_file() and is_ui_file(f.name)]
+    except OSError:
+        return
+
+    for f in candidates[:200]:          # a mod shipping more is not a UI mod
+        verdict = None
+        try:
+            entry = _find_pamt_entry(f.name, game_dir)
+            if entry is not None:
+                verdict = compare(f.read_bytes(), _extract_from_paz(entry))
+        except Exception as e:                              # noqa: BLE001
+            # Advice must never break an install: a UI file we cannot
+            # read, or that has no vanilla counterpart, simply goes
+            # unchecked.
+            logger.debug("UI dialect: skipped %s (%s)", f.name, e)
+        if verdict is not None and verdict.stale:
+            logger.warning("UI dialect: %s — %s", f.name, verdict.reason)
+            stale.append(verdict.message(f.name, result.name))
+
+    if not stale:
+        return
+    note = (f"{len(stale)} UI file(s) use pre-1.16 markup. " if len(stale) > 1
+            else "")
+    text = note + " ".join(stale[:3])
+    if len(stale) > 3:
+        text += f" (and {len(stale) - 3} more — see the log)"
+    result.info = f"{result.info}\n\n{text}" if result.info else text
+
+
 _LOOSE_GAME_EXTENSIONS = {".json", ".xml", ".css", ".html", ".thtml",
                           ".dds", ".ttf", ".otf", ".wem", ".bnk", ".mp4"}
 _SKIP_LOOSE_FILES = {"mod.json", "manifest.json", "modinfo.json"}
@@ -3146,6 +3203,8 @@ def _import_from_extracted(
             and not result.error and result.mod_id is not None):
         _import_sibling_format3(
             _deferred_f3_json, game_dir, db, snapshot, deltas_dir)
+
+    _warn_on_stale_ui_dialect(tmp_path, game_dir, result)
 
     return result
 
@@ -3661,6 +3720,8 @@ def import_from_zip(
                     f"JSON intents, or other game data."
                 )
 
+        _warn_on_stale_ui_dialect(tmp_path, game_dir, result)
+
     return result
 
 
@@ -4169,6 +4230,8 @@ def import_from_folder(
             and not result.error and result.mod_id is not None):
         _import_sibling_format3(
             _deferred_f3_json, game_dir, db, snapshot, deltas_dir)
+
+    _warn_on_stale_ui_dialect(folder_path, game_dir, result)
 
     return result
 

--- a/src/cdumm/engine/ui_dialect.py
+++ b/src/cdumm/engine/ui_dialect.py
@@ -1,0 +1,145 @@
+"""Detect UI mods written for the pre-1.16 markup dialect (GitHub #344).
+
+CD 1.16 renamed the attributes the UI engine reads. A mod that replaces
+or patches a UI file and was built before that rename still installs
+perfectly: the bytes land where they should, the file is valid, nothing
+errors. The engine just never reads the attributes it carries, so the
+mod does nothing at all. No skipped-patch message, no failure, no clue.
+
+That is the failure mode this project works hardest to remove from its
+own write path -- reporting success while achieving nothing -- arriving
+from outside, through mod content going stale.
+
+What actually changed
+---------------------
+
+Measured across **all 367 UI files** (``.html`` / ``.thtml`` / ``.css``)
+in a live 1.16 install:
+
+    attribute        1.16 occurrences
+    class=                          0
+    css=                       32,058
+    scriptobject=                   2
+    script=                     5,499
+    template=                      23
+    component=                  3,662
+
+``class=`` is the reliable signal: zero occurrences, in an engine whose
+markup is otherwise HTML-shaped, where ``class`` is the single most
+common attribute there is. It became ``css=``.
+
+``scriptobject=`` and ``template=`` did **not** go to zero, which is why
+this module does not trigger on them. Their survivors are three files:
+
+    template=      x22  ui/basecontrollereditor.thtml
+    template=      x1   ui/commanddebugview.html
+    scriptobject=  x2   ui/freerecitalpanel.html
+
+A ``.thtml`` is a template file, so ``template=`` there is not stale
+markup, and the other two are debug/leftover views. Treating either
+attribute as proof of a pre-1.16 mod would fire on content that matches
+the game's own current files. They are still counted and reported as
+corroboration, but they never decide the verdict on their own.
+
+Why the comparison is against the vanilla file
+----------------------------------------------
+
+The check is not "does this mod use ``class=``" -- it is "does this mod
+use markup its own target file no longer uses". Reading the vanilla
+counterpart is what makes the check correct on a pre-1.16 game, where
+``class=`` is the right dialect and no warning should appear. It costs
+nothing: the callers already hold both byte strings.
+
+This module never repairs anything. Only a mod's author can do that, by
+republishing against 1.16 markup. The goal is that CDUMM stops being
+silent about it.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+#: Old attribute -> the 1.16 name that replaced it.
+RENAMED: dict[str, str] = {
+    "class": "css",
+    "scriptobject": "script",
+}
+
+#: Only this pair decides a verdict. See the module docstring for why
+#: ``scriptobject``/``template`` are counted but never decisive.
+DECIDING_OLD = "class"
+DECIDING_NEW = "css"
+
+#: Counted for the message, not for the decision.
+CORROBORATING = ("scriptobject", "script", "template", "component")
+
+_ATTR_RE: dict[str, re.Pattern[bytes]] = {
+    name: re.compile(rb"\b" + name.encode() + rb"\s*=")
+    for name in (*RENAMED, *RENAMED.values(), "template", "component")
+}
+
+#: Extensions whose contents the UI engine parses for these attributes.
+UI_SUFFIXES = (".html", ".thtml", ".css")
+
+
+def count_markers(data: bytes) -> dict[str, int]:
+    """How many times each dialect attribute appears in ``data``."""
+    return {name: len(rx.findall(data)) for name, rx in _ATTR_RE.items()}
+
+
+@dataclass(frozen=True)
+class DialectVerdict:
+    """Why a UI file was, or was not, judged stale."""
+    stale: bool
+    reason: str
+    mod: dict[str, int] = field(default_factory=dict)
+    vanilla: dict[str, int] = field(default_factory=dict)
+
+    def message(self, file_label: str, mod_name: str = "") -> str:
+        """A sentence for the user, naming the file and what to do."""
+        who = f"'{mod_name}' " if mod_name else ""
+        old = self.mod.get(DECIDING_OLD, 0)
+        return (
+            f"{who}targets '{file_label}' with pre-1.16 UI markup: it uses "
+            f"{old} '{DECIDING_OLD}=' attribute(s), which CD 1.16 renamed to "
+            f"'{DECIDING_NEW}='. The file will install correctly but the "
+            f"game's UI engine will not read it, so the mod will have no "
+            f"effect. It needs an update from its author."
+        )
+
+
+def is_ui_file(name: str) -> bool:
+    return name.lower().endswith(UI_SUFFIXES)
+
+
+def compare(mod_data: bytes, vanilla_data: bytes) -> DialectVerdict:
+    """Judge ``mod_data`` against the game's own ``vanilla_data``.
+
+    Stale means: the mod carries the old attribute, and the file it
+    replaces does not carry it while it does carry the new one. Both
+    halves matter --
+
+    * without the mod-side test there is nothing to warn about;
+    * without the vanilla-side test this would fire on a pre-1.16 game,
+      where the old dialect is exactly right.
+    """
+    mod = count_markers(mod_data)
+    van = count_markers(vanilla_data)
+
+    if not mod.get(DECIDING_OLD):
+        return DialectVerdict(False, "mod does not use the old dialect",
+                              mod, van)
+    if van.get(DECIDING_OLD):
+        return DialectVerdict(
+            False, "the game's own copy of this file still uses the old "
+                   "dialect, so the mod matches it", mod, van)
+    if not van.get(DECIDING_NEW):
+        return DialectVerdict(
+            False, "the game's copy uses neither dialect, so there is "
+                   "nothing to compare against", mod, van)
+    return DialectVerdict(
+        True,
+        f"mod uses {mod[DECIDING_OLD]}x '{DECIDING_OLD}=' where the game's "
+        f"copy uses {van[DECIDING_NEW]}x '{DECIDING_NEW}=' and no "
+        f"'{DECIDING_OLD}='",
+        mod, van)

--- a/tests/test_ui_dialect.py
+++ b/tests/test_ui_dialect.py
@@ -1,0 +1,260 @@
+"""Pre-1.16 UI markup detection (GitHub #344).
+
+The failure this guards against is the quiet one: a UI mod built before
+CD 1.16 installs perfectly and does nothing, because 1.16 renamed the
+attributes the UI engine reads. Barber Unlocked (#337) is the reported
+case; nothing about it is specific.
+
+The numbers these tests encode were measured across all 367 UI files in
+a live 1.16 install, not taken from the issue text -- and the sweep
+disagreed with the issue in a way that matters. See
+``test_only_class_is_treated_as_decisive``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from cdumm.engine.ui_dialect import (
+    CORROBORATING,
+    DECIDING_NEW,
+    DECIDING_OLD,
+    RENAMED,
+    compare,
+    count_markers,
+    is_ui_file,
+)
+
+# Shapes taken from the real files: a pre-1.16 view and its 1.16 successor.
+PRE_116 = (b'<div class="panel" scriptobject="UIThing" template="X" '
+           b'component="Y"><span class="label">hi</span></div>')
+CD_116 = (b'<div css="panel" script="UIThing" component="X.Y">'
+          b'<span css="label">hi</span></div>')
+
+
+# ── the decision ────────────────────────────────────────────────────────
+
+def test_a_pre_116_mod_against_a_116_game_is_flagged():
+    v = compare(PRE_116, CD_116)
+    assert v.stale
+    assert DECIDING_OLD in v.reason
+    msg = v.message("ui/barbershopview.html", "Barber Unlocked")
+    assert "Barber Unlocked" in msg
+    assert "no effect" in msg
+    assert "update from its author" in msg
+
+
+def test_a_current_mod_is_not_flagged():
+    assert compare(CD_116, CD_116).stale is False
+
+
+def test_a_pre_116_mod_against_a_pre_116_game_is_not_flagged():
+    """The check must not fire on an older game, where the old dialect is
+    the correct one. This is why the comparison reads the vanilla file
+    rather than judging the mod on its own."""
+    v = compare(PRE_116, PRE_116)
+    assert v.stale is False
+    assert "still uses the old dialect" in v.reason
+
+
+def test_a_file_with_neither_dialect_is_not_flagged():
+    v = compare(b"<div>plain</div>", b"<div>plain</div>")
+    assert v.stale is False
+
+
+def test_a_vanilla_file_using_neither_dialect_gives_nothing_to_compare():
+    v = compare(PRE_116, b"<div>plain</div>")
+    assert v.stale is False
+    assert "nothing to compare" in v.reason
+
+
+# ── why only class= decides ─────────────────────────────────────────────
+
+def test_only_class_is_treated_as_decisive():
+    """Measured, not assumed -- and the measurement corrected the issue.
+
+    #344 reports ``scriptobject=`` and ``template=`` as 0 in 1.16, from a
+    40-file sample. Across all 367 UI files they are 2 and 23: they
+    survive in ``ui/basecontrollereditor.thtml`` (a template file, where
+    ``template=`` is not stale markup), ``ui/commanddebugview.html`` and
+    ``ui/freerecitalpanel.html``.
+
+    ``class=`` is 0 of 0 across all 367, in markup that is otherwise
+    HTML-shaped. So it decides, and the others only corroborate --
+    triggering on them would fire on content matching the game's own
+    current files.
+    """
+    assert DECIDING_OLD == "class"
+    assert DECIDING_NEW == "css"
+    assert RENAMED[DECIDING_OLD] == DECIDING_NEW
+    assert "template" in CORROBORATING
+    assert "scriptobject" in CORROBORATING
+
+    # A mod carrying ONLY the survivors, against a 1.16 file that also
+    # carries them, must not be flagged.
+    mod = b'<div template="BaseControllerEditor" scriptobject="X"></div>'
+    van = b'<div template="BaseControllerEditor" scriptobject="X" css="a">'
+    assert compare(mod, van).stale is False
+
+
+def test_the_survivors_are_still_counted_for_the_report():
+    c = count_markers(PRE_116)
+    assert c["class"] == 2
+    assert c["scriptobject"] == 1
+    assert c["template"] == 1
+    assert c["css"] == 0
+
+
+# ── scope ───────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("name,expected", [
+    ("ui/barbershopview.html", True),
+    ("ui/thing.thtml", True),
+    ("ui/style.css", True),
+    ("gamedata/iteminfo.pabgb", False),
+    ("textures/foo.dds", False),
+    ("readme.txt", False),
+])
+def test_only_ui_files_are_in_scope(name, expected):
+    assert is_ui_file(name) is expected
+
+
+def test_a_partially_updated_mod_is_still_flagged():
+    """A mod half-converted to 1.16 still carries attributes the engine
+    will not read, so the part that uses the old names is still inert."""
+    mod = b'<div css="new">ok</div><span class="old">stale</span>'
+    assert compare(mod, CD_116).stale is True
+
+
+# ── the real install, when it is present ────────────────────────────────
+
+def test_live_116_ui_files_never_use_class():
+    """Pins the premise against real data rather than the fixture shapes
+    above. Skips when the game is not installed."""
+    game = _live_game_dir()
+    if game is None:
+        pytest.skip("no live game install")
+    from cdumm.archive import paz_parse
+    from cdumm.engine import game_index
+    from cdumm.engine.json_patch_handler import _extract_from_paz
+
+    seen = classes = css = 0
+    for arch in game_index.archive_dirs(str(game)):
+        d = game / arch
+        entries = _tolerate(paz_parse.parse_pamt, str(d / "0.pamt"), str(d))
+        for e in entries or ():
+            if not is_ui_file(e.path):
+                continue
+            data = _tolerate(_extract_from_paz, e)
+            if data is None:
+                continue
+            seen += 1
+            c = count_markers(data)
+            classes += c["class"]
+            css += c["css"]
+    if seen == 0:
+        pytest.skip("no UI files readable from this install")
+    assert classes == 0, f"{classes} 'class=' found across {seen} UI files"
+    assert css > 0, "expected the 1.16 dialect in a 1.16 install"
+
+
+# ── the warning reaches the user ────────────────────────────────────────
+
+def test_the_import_helper_surfaces_the_warning(tmp_path, monkeypatch):
+    """The check is only worth anything if it reaches result.info, which
+    is what the GUI shows as a yellow InfoBar. Drives the real helper
+    with the PAMT lookup stubbed to a 1.16 vanilla file."""
+    from cdumm.engine import import_handler as ih
+
+    mod_dir = tmp_path / "mod"
+    (mod_dir / "ui").mkdir(parents=True)
+    (mod_dir / "ui" / "barbershopview.html").write_bytes(PRE_116)
+
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._find_pamt_entry",
+        lambda name, gdir: object())
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._extract_from_paz",
+        lambda entry: CD_116)
+
+    result = ih.ModImportResult("Barber Unlocked")
+    ih._warn_on_stale_ui_dialect(mod_dir, tmp_path / "game", result)
+
+    assert result.info, "the warning must reach the user, not just the log"
+    assert "barbershopview.html" in result.info
+    assert "no effect" in result.info
+    assert result.error is None, "advice must not fail the import"
+
+
+def test_a_current_ui_mod_produces_no_warning(tmp_path, monkeypatch):
+    from cdumm.engine import import_handler as ih
+
+    mod_dir = tmp_path / "mod"
+    mod_dir.mkdir()
+    (mod_dir / "someview.html").write_bytes(CD_116)
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._find_pamt_entry",
+        lambda name, gdir: object())
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._extract_from_paz",
+        lambda entry: CD_116)
+
+    result = ih.ModImportResult("Fine Mod")
+    ih._warn_on_stale_ui_dialect(mod_dir, tmp_path / "game", result)
+    assert result.info is None
+
+
+def test_a_mod_with_no_ui_files_is_untouched(tmp_path):
+    from cdumm.engine import import_handler as ih
+
+    mod_dir = tmp_path / "mod"
+    mod_dir.mkdir()
+    (mod_dir / "texture.dds").write_bytes(b"\x00" * 32)
+    result = ih.ModImportResult("Texture Mod")
+    ih._warn_on_stale_ui_dialect(mod_dir, tmp_path / "game", result)
+    assert result.info is None
+
+
+def test_a_broken_lookup_never_fails_the_import(tmp_path, monkeypatch):
+    """Advice must never be able to break an install."""
+    from cdumm.engine import import_handler as ih
+
+    mod_dir = tmp_path / "mod"
+    mod_dir.mkdir()
+    (mod_dir / "view.html").write_bytes(PRE_116)
+
+    def boom(*a, **k):
+        raise RuntimeError("PAMT exploded")
+
+    monkeypatch.setattr(
+        "cdumm.engine.json_patch_handler._find_pamt_entry", boom)
+    result = ih.ModImportResult("Mod")
+    ih._warn_on_stale_ui_dialect(mod_dir, tmp_path / "game", result)
+    assert result.info is None
+    assert result.error is None
+
+
+def _tolerate(fn, *args):
+    """Run ``fn``, or return None if the install refuses to cooperate.
+
+    A machine-local archive read can fail for reasons that say nothing
+    about the code under test -- a partially downloaded PAZ, a locked
+    file, an archive shape this build predates. The assertion below is
+    about the files that DO read, so anything that doesn't is skipped
+    rather than turned into a failure.
+    """
+    try:
+        return fn(*args)
+    except Exception:                                  # noqa: BLE001
+        return None
+
+
+def _live_game_dir():
+    from pathlib import Path
+
+    from cdumm.storage.game_finder import find_game_directories
+    dirs = _tolerate(find_game_directories)
+    for d in dirs or []:
+        p = Path(d)
+        if (p / "meta" / "0.papgt").exists():
+            return p
+    return None


### PR DESCRIPTION
Closes #344. Explains #337.

## The failure

CD 1.16 renamed the attributes the UI engine reads. A UI mod built before it installs **perfectly** and does **nothing** — the bytes land where they should, the file is valid, nothing errors, and the engine simply never reads it. No error, no skipped-patch message, no clue.

That's the failure mode this project works hardest to remove from its own write path, arriving from outside through mod content going stale.

## What I measured

The issue sampled 40 files. I swept **all 367** UI files (`.html` / `.thtml` / `.css`) in a live 1.16 install, and it disagrees in a way that matters:

| attribute | issue (40 files) | live 1.16 (367 files) |
|---|---|---|
| `class=` | 0 | **0** |
| `css=` | 4,740 | 32,058 |
| `scriptobject=` | 0 | **2** |
| `script=` | 416 | 5,499 |
| `template=` | 0 | **23** |
| `component=` | — | 3,662 |

`scriptobject=` and `template=` did **not** go to zero. The survivors:

```
template=      x22  ui/basecontrollereditor.thtml   -> 'BaseControllerEditor'
template=      x1   ui/commanddebugview.html        -> 'CommandDebugView'
scriptobject=  x2   ui/freerecitalpanel.html        -> 'UIGamePlayControlCommonDefault'
```

A `.thtml` is a *template* file, so `template=` there isn't stale markup; the other two are debug/leftover views. Triggering on either would fire on content that matches the game's own current files.

**So only `class=` decides** — 0 of 0 across all 367, in markup that is otherwise HTML-shaped, where `class` is the most common attribute there is. The others are counted for the message but never decisive.

## The check

Compares the mod's UI file against **the game's own copy of that same file**, exactly as the issue proposes. Both halves matter:

- without the mod-side test there's nothing to warn about;
- without the vanilla-side test it would fire on a pre-1.16 game, where the old dialect is correct.

It costs nothing — the callers already hold both byte strings.

## Wiring

`_warn_on_stale_ui_dialect` runs at all three extracted-import entry points (7z/rar, zip, folder), surfacing through `result.info`, which the GUI renders as a yellow InfoBar.

**Advisory only, per your inclination in the issue** — the mod still installs, since it may ship textures or sounds that work fine, and only the author can republish the markup. A failed PAMT lookup leaves the file unchecked rather than failing the import; there's a test for that.

## Acceptance

| criterion | test |
|---|---|
| pre-1.16 UI mod vs 1.16 game warns, naming the reason | `test_a_pre_116_mod_against_a_116_game_is_flagged` |
| current-dialect mod imports with no warning | `test_a_current_mod_is_not_flagged` |
| mod with no UI files unaffected | `test_a_mod_with_no_ui_files_is_untouched` |
| does not fire on a pre-1.16 game | `test_a_pre_116_mod_against_a_pre_116_game_is_not_flagged` |

Plus: the survivors are pinned so nobody "fixes" the detector into false-positiving (`test_only_class_is_treated_as_decisive`), a partially-converted mod is still flagged, the warning reaches `result.info` through the real helper, and a live-install test asserts `class=` is 0 across the real 367 files (skips when the game isn't installed).

19 passed in the new suite; 173 passed across the import/html/css sweep. Ruff clean on both new files; `import_handler.py` 96 -> 96, no added debt.

## Note

This repairs nothing. Only mod authors can, by republishing against 1.16 markup. The goal is that CDUMM stops being silent about it — which should let you close #337 with an explanation rather than a fix.
