### PR TITLE
fix: remove shell=True from the live-script runner (command injection via mod filename)

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -5938,6 +5938,9 @@ def import_script_live(
 
     suffix = script_path.suffix.lower()
     if suffix == ".bat":
+        # ``cmd /c`` parses this itself, so the quotes around the path are what
+        # keep a filename containing ``&`` from splitting into a second command.
+        # Never pass this through ``shell=True`` as well -- see the Popen call.
         cmd = ["cmd", "/c", f'"{script_path}" & pause']
     elif suffix == ".py":
         cmd = ["py", "-3", str(script_path)]
@@ -5979,10 +5982,16 @@ def import_script_live(
     logger.info("Running script live: %s", script_path)
 
     try:
+        # NO ``shell=True``: ``cmd`` is already a list whose first element is an
+        # explicit interpreter, so the shell would re-join and re-parse it. A
+        # mod script called e.g. ``foo & calc.bat`` -- ``&`` is legal in Windows
+        # filenames -- survives the quoting above but NOT a second shell pass,
+        # which turned an imported mod's filename into arbitrary command
+        # execution. ``CREATE_NEW_CONSOLE`` is what gives the visible window,
+        # not the shell.
         proc = subprocess.Popen(
             cmd,
             cwd=str(script_path.parent),
-            shell=True,
             creationflags=subprocess.CREATE_NEW_CONSOLE,
         )
         proc.wait()

--- a/tests/test_no_shell_true.py
+++ b/tests/test_no_shell_true.py
@@ -1,0 +1,65 @@
+"""Guard: no ``subprocess`` call in the codebase may use ``shell=True``.
+
+``shell=True`` re-joins an argument list and hands it back to the shell for a
+second round of parsing. Every ``cmd`` CDUMM builds is already a list whose
+first element is an explicit interpreter, so the shell adds nothing except an
+injection point.
+
+This mattered concretely: the live-script runner in ``import_handler`` invoked
+``["cmd", "/c", f'"{script_path}" & pause']`` with ``shell=True``. ``&`` is a
+legal Windows filename character, so an imported mod named ``foo & calc.bat``
+survived the quoting on the first pass and split into a second command on the
+second -- turning a mod's *filename* into arbitrary command execution on the
+user's machine.
+
+Parsed with ``ast`` rather than grepped, so prose mentioning ``shell=True``
+(such as the comments explaining this) does not trip the test.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+
+def _shell_true_calls(tree: ast.AST) -> list[int]:
+    """Line numbers of calls passing a literal ``shell=True``."""
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "shell"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+            ):
+                hits.append(node.lineno)
+    return hits
+
+
+def test_no_subprocess_shell_true() -> None:
+    offenders: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - never expected in-tree
+            continue
+        for lineno in _shell_true_calls(tree):
+            offenders.append(f"{path.relative_to(SRC)}:{lineno}")
+
+    assert not offenders, (
+        "shell=True reintroduces shell parsing of an already-quoted command "
+        "list. Pass the argument list directly instead. Offenders: "
+        + ", ".join(offenders)
+    )
+
+
+def test_guard_detects_shell_true() -> None:
+    """The guard must actually fire -- otherwise it silently passes forever."""
+    tree = ast.parse("import subprocess\nsubprocess.Popen(['x'], shell=True)\n")
+    assert _shell_true_calls(tree) == [2]
+
+    safe = ast.parse("import subprocess\nsubprocess.Popen(['x'], shell=False)\n")
+    assert _shell_true_calls(safe) == []


### PR DESCRIPTION
## The bug

`run_script_live` builds an explicit argument list and then passes it to `Popen` with `shell=True`:

```python
if suffix == ".bat":
    cmd = ["cmd", "/c", f'"{script_path}" & pause']
elif suffix == ".py":
    cmd = ["py", "-3", str(script_path)]
...
proc = subprocess.Popen(cmd, cwd=..., shell=True, creationflags=CREATE_NEW_CONSOLE)
```

`shell=True` re-joins that list and hands it back to the shell for a **second** round of parsing.

`&` is a legal Windows filename character. A mod whose script is named `foo & calc.bat` survives the quoting on the first pass — `cmd /c` treats the quoted path literally — but not the second. The result is arbitrary command execution on the user's machine, reachable by importing any third-party mod.

This was the only `shell=True` in the codebase.

## The fix

Drop `shell=True`. It was redundant as well as dangerous:

- the visible console comes from `CREATE_NEW_CONSOLE`, not the shell
- the first element of `cmd` is already an explicit interpreter (`cmd` / `py`)

So this is behaviour-preserving — the `.bat` branch still gets its `& pause` because `cmd /c` parses that argument itself.

## Regression guard

`tests/test_no_shell_true.py` walks the `src` tree and fails on any call passing a literal `shell=True`.

It is parsed with `ast` rather than grepped, so the comments explaining this issue do not trip it. It also carries a self-check asserting the detector fires on a known-bad snippet — a guard that cannot fail is worse than no guard.

Verified both directions:

```
with the fix      2 passed
against the unfixed code   test_no_subprocess_shell_true FAILED
```

so it genuinely catches this bug rather than passing vacuously.

## Checks

- `ruff@0.16.0` (the CI pin): error count on `import_handler.py` is **96 before and 96 after** — no new lint. New test file: clean.
- No behaviour change to script execution; only the extra shell layer is removed.

Reported by Aikido as Critical — *"Unsafe subprocess usage can lead to remote code execution"*.

---

Two other Aikido findings look like **false positives**, noted here so they can be dismissed rather than re-investigated:

- *Potential SQL injection* (`mod_dedup.py`) — the f-string interpolates `_FIELDS`, a hardcoded literal column list; every user-supplied value in that module uses `?` parameterisation.
- *1 exposed secret* (`release-macos.yml`) — the only match is `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, the standard built-in token pattern.