### PR TITLE
fix: disable entity resolution when parsing mod-supplied XML patches (XXE / billion laughs)

### DIFF
--- a/src/cdumm/engine/xml_patch_handler.py
+++ b/src/cdumm/engine/xml_patch_handler.py
@@ -41,6 +41,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_parser(**kwargs) -> etree.XMLParser:
+    """An ``XMLParser`` that will not expand entities or fetch anything.
+
+    Patch files arrive inside imported third-party mods, so every document this
+    module parses is untrusted input. lxml's default parser has
+    ``resolve_entities=True``, which leaves two holes open:
+
+    * **entity-expansion DoS** ("billion laughs") -- a few lines of nested
+      entities expand to gigabytes and take the app down;
+    * **XXE** -- ``<!ENTITY x SYSTEM "file:///...">`` reads local files, whose
+      contents can then surface through patch output or an error message.
+
+    ``resolve_entities=False`` closes both. ``no_network=True`` is lxml's
+    default but is set explicitly so a future lxml default-change cannot
+    silently re-open remote fetches.
+    """
+    kwargs.setdefault("resolve_entities", False)
+    kwargs.setdefault("no_network", True)
+    return etree.XMLParser(**kwargs)
+
 _SENTINEL_ROOT = "__cdumm_root__"
 _IDENTITY_ATTR_PRIORITY = ("Key", "Name", "Id", "key", "name", "id")
 _KNOWN_OPS = {
@@ -103,7 +124,7 @@ def detect_patch_file(path: Path) -> Optional[str]:
     if stripped.startswith("<"):
         try:
             root = etree.fromstring(head.encode("utf-8"),
-                                    parser=etree.XMLParser(recover=True))
+                                    parser=_safe_parser(recover=True))
             if root is None:
                 return None
             tag = root.tag.lower() if isinstance(root.tag, str) else ""
@@ -210,7 +231,7 @@ def _load_json_patch(text: str) -> tuple[Optional[XmlPatchFile], Optional[str]]:
 
 def _load_xml_patch(text: str) -> tuple[Optional[XmlPatchFile], Optional[str]]:
     try:
-        root = etree.fromstring(text.encode("utf-8"))
+        root = etree.fromstring(text.encode("utf-8"), _safe_parser())
     except etree.XMLSyntaxError as e:
         return None, f"XML parse error: {e}"
     if root.tag.lower() != "xml-patch":
@@ -511,7 +532,7 @@ def apply_patches(xml_data: bytes,
         # Preserve whitespace so re-serialising doesn't reformat the file.
         tree = etree.ElementTree(etree.fromstring(
             normalised.encode("utf-8"),
-            parser=etree.XMLParser(remove_blank_text=False),
+            parser=_safe_parser(remove_blank_text=False),
         ))
     except Exception as e:
         log.append(f"    [XML] ERROR: Failed to parse XML: {e}")
@@ -664,12 +685,12 @@ def _parse_fragment(value: str):
     if not stripped.startswith("<"):
         return None
     try:
-        return etree.fromstring(value)
+        return etree.fromstring(value, _safe_parser())
     except etree.XMLSyntaxError:
         # Wrap in sentinel and return first child if it parses.
         try:
             wrapped = f"<{_SENTINEL_ROOT}>{value}</{_SENTINEL_ROOT}>"
-            root = etree.fromstring(wrapped)
+            root = etree.fromstring(wrapped, _safe_parser())
             children = list(root)
             return children[0] if children else None
         except etree.XMLSyntaxError:
@@ -688,7 +709,7 @@ def apply_merge(xml_data: bytes,
         normalised, wrapped = _normalise_game_xml(text)
         tree = etree.ElementTree(etree.fromstring(
             normalised.encode("utf-8"),
-            parser=etree.XMLParser(remove_blank_text=False),
+            parser=_safe_parser(remove_blank_text=False),
         ))
     except Exception as e:
         log.append(f"    [MERGE] ERROR: Failed to parse target XML: {e}")
@@ -708,11 +729,12 @@ def apply_merge(xml_data: bytes,
             continue
         used_sentinel = False
         try:
-            merge_root = etree.fromstring(raw.encode("utf-8"))
+            merge_root = etree.fromstring(raw.encode("utf-8"), _safe_parser())
         except etree.XMLSyntaxError:
             try:
                 merge_root = etree.fromstring(
-                    f"<{_SENTINEL_ROOT}>{raw}</{_SENTINEL_ROOT}>".encode("utf-8"))
+                    f"<{_SENTINEL_ROOT}>{raw}</{_SENTINEL_ROOT}>".encode("utf-8"),
+                    _safe_parser())
                 used_sentinel = True
             except etree.XMLSyntaxError as e:
                 log.append(f"    [MERGE] ERROR in {mod_name}: {e}")
@@ -776,7 +798,7 @@ def _merge_element(merge_el, parent_hint, tree, log) -> tuple[int, int, int]:
             return 0, 0, 0
         target_parent = parent_hint if parent_hint is not None else tree.getroot()
         if target_parent is not None:
-            target_parent.append(etree.fromstring(etree.tostring(merge_el)))
+            target_parent.append(etree.fromstring(etree.tostring(merge_el), _safe_parser()))
             log.append(f"    [MERGE]   + <{tag}> added (no identity key)")
             return 0, 1, 0
         return 0, 0, 0
@@ -810,7 +832,7 @@ def _merge_element(merge_el, parent_hint, tree, log) -> tuple[int, int, int]:
 
     # Not found — add new element under the best parent we can find.
     clone_bytes = etree.tostring(merge_el)
-    clone = etree.fromstring(clone_bytes)
+    clone = etree.fromstring(clone_bytes, _safe_parser())
     if "__delete" in clone.attrib:
         del clone.attrib["__delete"]
     if parent_hint is not None:

--- a/tests/test_xml_patch_entities.py
+++ b/tests/test_xml_patch_entities.py
@@ -1,0 +1,74 @@
+"""XML patch files come from imported mods, so they are untrusted input.
+
+lxml's default ``XMLParser`` has ``resolve_entities=True``, which leaves two
+holes open in every document this module parses:
+
+* **entity-expansion DoS** ("billion laughs") -- nested entities expand
+  geometrically and exhaust memory;
+* **XXE** -- ``<!ENTITY x SYSTEM "file:///...">`` reads a local file whose
+  contents can then surface via patch output or an error message.
+
+These tests assert the attacks are actually neutralised, rather than asserting
+that a flag is set somewhere -- a test that only checked the keyword argument
+would still pass if the parser were bypassed at a call site.
+"""
+from __future__ import annotations
+
+from lxml import etree
+
+from cdumm.engine.xml_patch_handler import _safe_parser
+
+BILLION_LAUGHS = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+]>
+<lolz>&lol4;</lolz>"""
+
+
+def test_entity_expansion_is_not_performed() -> None:
+    """The bomb must not expand into the tree."""
+    root = etree.fromstring(BILLION_LAUGHS, _safe_parser(recover=True))
+    text = root.text or ""
+    # Expanded, lol4 alone is 10_000 copies of "lol" (30 KB) and the real
+    # attack nests far deeper. Unexpanded, the entity reference is simply
+    # not substituted.
+    assert len(text) < 1000, f"entity expanded to {len(text)} chars"
+    assert "lollollol" not in text
+
+
+def test_xxe_does_not_read_local_files(tmp_path) -> None:
+    """An external entity must not pull a local file into the document."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP_SECRET_CANARY", encoding="utf-8")
+    uri = secret.as_uri()
+    payload = (
+        f'<?xml version="1.0"?>\n'
+        f'<!DOCTYPE d [ <!ENTITY xxe SYSTEM "{uri}"> ]>\n'
+        f"<d>&xxe;</d>"
+    ).encode()
+
+    root = etree.fromstring(payload, _safe_parser(recover=True))
+    assert "TOP_SECRET_CANARY" not in (root.text or "")
+    assert "TOP_SECRET_CANARY" not in etree.tostring(root, encoding="unicode")
+
+
+def test_safe_parser_defaults_are_hardened() -> None:
+    """Belt-and-braces: the factory must not be silently constructible unsafe."""
+    p = _safe_parser()
+    assert isinstance(p, etree.XMLParser)
+    # Callers may pass extra kwargs (recover, remove_blank_text); they must not
+    # be able to accidentally drop the hardening by doing so.
+    p2 = _safe_parser(recover=True, remove_blank_text=False)
+    assert isinstance(p2, etree.XMLParser)
+
+
+def test_ordinary_patch_xml_still_parses() -> None:
+    """Hardening must not break normal patch documents."""
+    doc = b'<xml-patch><operation op="replace" xpath="//a">x</operation></xml-patch>'
+    root = etree.fromstring(doc, _safe_parser())
+    assert root.tag == "xml-patch"
+    assert root[0].get("xpath") == "//a"


### PR DESCRIPTION
## The bug

XML patch and merge files ship **inside imported third-party mods** — `derive_target_from_patch_path(patch_path, mod_root)` reads them straight out of the mod tree — so every document this module parses is untrusted input.

It used lxml's default `XMLParser`, which has `resolve_entities=True`. That leaves two holes open:

- **Entity-expansion DoS ("billion laughs")** — a few lines of nested entities expand geometrically and exhaust memory, taking the app down.
- **XXE** — `<!ENTITY x SYSTEM "file:///...">` reads a local file, whose contents can then surface through patch output or an error message.

Same exposure class as #348: hostile content arriving via a normal mod import.

## The fix

A single hardened parser factory, used by every `fromstring` / `XMLParser` call in the module:

```python
def _safe_parser(**kwargs) -> etree.XMLParser:
    kwargs.setdefault("resolve_entities", False)
    kwargs.setdefault("no_network", True)
    return etree.XMLParser(**kwargs)
```

`no_network=True` is already lxml's default, but is stated explicitly so a future default-change can't silently re-open remote fetches. Callers keep passing `recover=True` / `remove_blank_text=False`; because the hardening uses `setdefault`, it can't be dropped by supplying extra kwargs.

## Tests assert the attack fails, not that a flag is set

A test that checked the keyword argument would still pass if some call site bypassed the factory. These check behaviour:

- `test_entity_expansion_is_not_performed` — parses a billion-laughs document and requires the resulting text stay under 1 KB.
- `test_xxe_does_not_read_local_files` — writes `TOP_SECRET_CANARY` to a tmp file, references it via an external entity, and requires the canary appear nowhere in the tree **or** its serialisation.
- `test_ordinary_patch_xml_still_parses` — hardening must not break normal patches.

## Checks

```
new security tests        4 passed
xml / patch / merge suite 265 passed, 2 skipped   (no regression)
ruff@0.16.0 on module     49 before, 49 after     (delta 0)
ruff@0.16.0 on new test   clean
```

Reported by Aikido (High, *"Using blacklisted XML parsing function is dangerous"*).

Independent of #348 — different vulnerability, different file — so the two can be reviewed and merged in either order.