### PR TITLE
characterinfo: f36 is the gender byte, not the parser's _f36 u32

### DIFF
--- a/src/cdumm/engine/characterinfo_writer.py
+++ b/src/cdumm/engine/characterinfo_writer.py
@@ -67,7 +67,33 @@ _FIELD_MAP: dict[str, tuple[str, int, str, int]] = {
     # and is refused by name below -- never written at a guessed position.
     "default_action_action_index": (
         "_defaultActionActionIndex_offset", 0, "<I", 4),
-    "f36": ("_f36_offset", 0, "<I", 4),
+    # `f36` is the record's GENDER byte, at block+66. It is NOT the u32 the
+    # parser publishes as `_f36_offset` (GitHub #302).
+    #
+    # That earlier mapping was added for this very mod and was never
+    # confirmed in-game -- the mod has never once worked. Four independent
+    # measurements say it is the wrong slot:
+    #
+    # 1. Field correspondence. Character Creator ships the same edit twice,
+    #    as this Format 3 file and as a raw offset patch with hand-written
+    #    labels. The two agree field for field on all five records
+    #    (7/6/6/3/3). Every field matches by exact value except one; once
+    #    the rest are paired off, the leftover is `f36` here and `_gender`
+    #    there, both set to 2.
+    # 2. Position. That patch puts `_gender` one byte at block+66. On the
+    #    live table that byte still reads 01 on Kliff / Kliff_AI / Yann,
+    #    exactly the "before" value the patch expects for its 01 -> 02 edit.
+    # 3. Table-wide shape. Across all 7244 records block+66 holds only
+    #    0, 1 or 2 (1357 / 4909 / 978) -- a clean enum on every record.
+    #    `_f36_offset` is published on 142 records, i.e. 2% of the table.
+    # 4. Intent. Read as gender the mod sets 1 -> 2 on every record it
+    #    touches. Read as `_f36` it writes 2 over an existing 2 on Kliff_AI
+    #    and PlayerAll, so two of the four edits would be no-ops -- not
+    #    something a mod author writes on purpose.
+    #
+    # Block-relative also means it is placeable on every record, so records
+    # the post-block walk cannot reach are no longer refused over this field.
+    "f36": (_BLK, 66, "<B", 1),
     # `character_weight` is the SAME SLOT under a different DMM name, and
     # that is documented by the mod author rather than inferred. Character
     # Creator 7.5 shipped as raw offset patches with hand-written labels;

--- a/tests/test_characterinfo_appearance_fields.py
+++ b/tests/test_characterinfo_appearance_fields.py
@@ -240,7 +240,11 @@ def test_refusal_reason_is_reported_not_just_logged(table):
     assert len(refusals) == 1, refusals
     assert "Kliff_Clone" in refusals[0]
     # It must say what could not be placed, or it isn't actionable.
-    assert "f36" in refusals[0]
+    # Only character_weight now: `f36` is the gender byte at block+66,
+    # which is placeable on every record, so it is no longer part of why
+    # this one is abandoned.
+    assert "character_weight" in refusals[0]
+    assert "f36" not in refusals[0]
 
 
 def test_a_lone_half_writable_record_is_abandoned_too(table):
@@ -642,3 +646,77 @@ def test_a_bad_value_does_not_abandon_an_unrelated_record(table):
     labels = [c["label"] for c in changes]
     assert labels == ["Kliff_AI.appearance_name"], labels
     assert len(refusals) == 1 and "Kliff" in refusals[0]
+
+
+def test_f36_is_the_gender_byte_at_block_plus_66(table):
+    """`f36` is the record's GENDER byte, not the parser's `_f36` u32.
+
+    Character Creator ships this same edit twice: as the Format 3 file
+    under test, and as a raw offset patch whose hand-written labels name
+    the field ``_gender`` and change it from 01 to 02. The two files agree
+    field for field on all five records, and once every other field is
+    paired off by its exact value, the one left over is ``f36`` here and
+    ``_gender`` there.
+
+    That field is ONE byte at block+66, and it must be written there.
+    """
+    body, header = table
+    changes = build_characterinfo_changes(body, header, _MOD_INTENTS)
+
+    idx = parse_pabgh_index(header)
+    order = sorted(idx.items(), key=lambda kv: kv[1])
+    blocks: dict[str, int] = {}
+    for rank, (key, start) in enumerate(order):
+        end = (order[rank + 1][1]
+               if rank + 1 < len(order) else len(body))
+        rec = parse_entry(body, start, end)
+        if rec and rec.get("name"):
+            blk = rec.get("_upperActionChartPackageGroupName_offset")
+            if blk is not None:
+                blocks[rec["name"]] = blk
+
+    f36 = {c["label"].split(".")[0]: c
+           for c in changes if c["label"].endswith(".f36")}
+    assert f36, "the mod sets f36; it must produce changes"
+
+    for name, change in f36.items():
+        assert change["offset"] == blocks[name] + 66, (
+            f"{name}.f36 must land on the gender byte at block+66, "
+            f"got block+{change['offset'] - blocks[name]}")
+        # One byte wide, not four.
+        assert len(change["patched"]) == 2, change
+        assert change["patched"].lower() == "02", change
+        # And it must actually be a change, not a write of the same value.
+        assert change["original"].lower() != change["patched"].lower(), (
+            f"{name}.f36 writes its existing value -- a no-op edit is the "
+            f"signature of the wrong slot")
+
+
+def test_block_plus_66_is_an_enum_on_every_record(table):
+    """Shape check on the slot the mapping above depends on.
+
+    Gender is a small enum present on every record. Across the full live
+    table block+66 holds only 0, 1 or 2 on all 7244 records; the parser's
+    `_f36_offset`, by contrast, is published on 142 of them. Assert the
+    enum shape here so a future layout change that breaks it is caught.
+    """
+    body, header = table
+    idx = parse_pabgh_index(header)
+    order = sorted(idx.items(), key=lambda kv: kv[1])
+    seen: set[int] = set()
+    n = 0
+    for rank, (key, start) in enumerate(order):
+        end = (order[rank + 1][1]
+               if rank + 1 < len(order) else len(body))
+        rec = parse_entry(body, start, end)
+        if not rec:
+            continue
+        blk = rec.get("_upperActionChartPackageGroupName_offset")
+        if blk is None or blk + 66 >= len(body):
+            continue
+        seen.add(body[blk + 66])
+        n += 1
+
+    assert n, "no records carried a block offset"
+    assert seen <= {0, 1, 2}, (
+        f"block+66 is meant to be the gender enum, saw {sorted(seen)}")


### PR DESCRIPTION
Character Creator / Female Animations (#302) has **never worked once**, on any CDUMM version. woowoots confirmed that this week: the `.field.json` has always stopped the game from starting, while the mod's raw offset version worked perfectly until 1.16.0 broke its hardcoded offsets.

That rules out the #329 all-or-nothing refusal as the cause. The refusal is recent; the crash predates it and survived both behaviours.

Following it back, the `f36` mapping is wrong. It was added for this exact mod and was never confirmed in game.

## Evidence

**1. Field correspondence.** The mod ships the same edit twice: this Format 3 file, and a raw offset patch with hand-written labels. The two agree field for field on all five records (7/6/6/3/3). Every field pairs off by exact value except one. Once the rest are matched, the leftover is `f36` here and `_gender` there, both set to 2.

| Format 3 name | real field |
|---|---|
| appearance_name | _upperActionChartPackageGroupName |
| character_prefab_path | _lowerActionChartPackageGroupName |
| skeleton_name | _characterGamePlayDataName |
| lookup_24 | _skeletonName |
| lookup_25 | _skeletonVariationName |
| **f36** | **_gender** |

**2. Position.** That patch puts `_gender` one byte at block+66. On the live table that byte still reads `01` on Kliff, Kliff_AI and Yann, exactly the before value its `01 -> 02` edit expects.

**3. Table-wide shape.** Across all 7244 records block+66 holds only 0, 1 or 2 (1357 / 4909 / 978), an enum present on every record. `_f36_offset` is published on 142 records, 2% of the table.

**4. Intent.** Read as gender, the mod sets 1 -> 2 on every record it touches. Read as `_f36`, it writes 2 over an existing 2 on Kliff_AI and PlayerAll, making two of four edits no-ops. No author writes that on purpose.

## Effect

Before: gender was never set, so the part of the mod that actually switches the character never happened, and an unrelated u32 got 2 written into it.

After: the gender byte is written where the working patch writes it. Being block-relative also makes it placeable on every record, so records the post-block walk cannot reach are no longer refused over this field. Kliff_Clone is still abandoned, now solely for `character_weight`.

## Tests

Two added: one pins that `f36` lands at block+66 as a single byte, carries the intent value, and is never a same-value no-op (the signature of a wrong slot). One pins the enum shape of block+66 so a future layout change is caught.

Full fast suite: 2844 passed. The 5 failures on this branch reproduce identically on master and are unrelated (1 is the known `py` launcher case, 4 are storeinfo tests reading live game files, see note below).

## Not confirmed in game

I cannot launch the game, so this is not proven fixed. A test build is going to the reporter. **This should not merge until someone boots it.**

## Unrelated, but found while running this

The 4 storeinfo failures are real and not caused by this change: `const byte at record offset 42 is 0 (expected 1) ... record is not the verified disc-0 shape for layout 'CD 1.16' or the layout has drifted again`. The game updated again (exe dated 5 August) and storeinfo drifted past what the parser models. It fails safe by refusing rather than writing wrong bytes, but store mods are likely dead on the current build. CI cannot see this because it has no game install. Filing separately.