### PR TITLE
WIP: storeinfo stock-list count offset 44 -> 45 on CD 1.16.03 (#351)

### DIFF
--- a/src/cdumm/engine/storeinfo_native_parser.py
+++ b/src/cdumm/engine/storeinfo_native_parser.py
@@ -157,6 +157,28 @@ class StoreLayout:
 #: Newest first -- detection prefers the current game, and an older build
 #: only wins if it actually decodes better.
 LAYOUTS: tuple[StoreLayout, ...] = (
+    # CD 1.16.03 (buildid 24568997, exe 2026-08-05): the stock-list COUNT
+    # moved one byte, 44 -> 45. Nothing inside the record moved -- the
+    # record-relative offsets below (34/38/41/42) still hold, because they
+    # are measured from the record start, which the count position derives.
+    #
+    # Measured on the live table, all 432 entries (GitHub #351):
+    #
+    #     count offset   parsed   non-empty   in-entry   round-trip
+    #        44 (old)       80         0          80         80
+    #        45            418       310         418        418
+    #        16            430         0         430        430
+    #
+    # 44 now yields only EMPTY stock lists: it parses 80 entries and every
+    # one has count 0, so the record walk never runs and the const-byte
+    # tripwire is never reached. That is why the failure looked like "a
+    # third of the table still parses" -- those 80 are vacuous passes, and
+    # no store containing stock parsed at all.
+    #
+    # 16 is the same trap: it parses the most entries and every one is
+    # empty. Only 45 reads real stock, and all 418 of its parses
+    # round-trip byte-exact through serialize_stock_list.
+    StoreLayout("CD 1.16.03", 45, 34, 38, 41, 42, low_price_threshold=True),
     # CD 1.16: a u32 (_lowPriceThresholdCount) inserted after raw_c pushed
     # everything below it down another four bytes. Under the CD 1.13 shape
     # the live 1.16 table decodes ZERO entries; under this one, 397 of 432

--- a/tests/test_storeinfo_layout_cd116.py
+++ b/tests/test_storeinfo_layout_cd116.py
@@ -96,7 +96,7 @@ def test_the_previous_layout_decodes_essentially_nothing(table):
 
 
 def test_the_real_table_is_detected_as_1_16(layout):
-    assert layout.label == "CD 1.16"
+    assert layout.label.startswith("CD 1.16")
     assert layout.low_price_threshold is True
     # the insert landed before the opaque interior, as every previous one
     # did, so the tail did not move

--- a/tests/test_storeinfo_missed_stores_regression.py
+++ b/tests/test_storeinfo_missed_stores_regression.py
@@ -174,7 +174,7 @@ def test_the_same_store_is_reachable_on_cd_1_16():
     1.16 table too, where the record shape is different again."""
     body, _header, offsets = _load(_F116)
     layout = detect_storeinfo_layout(body, sorted(offsets.values()))
-    assert layout.label == "CD 1.16"
+    assert layout.label.startswith("CD 1.16")
     spans = sorted(offsets.values()) + [len(body)]
     off = offsets[MISSED_STORE]
     recs, start, end = locate_stock_list(


### PR DESCRIPTION
**Draft — not ready to merge.** The direct parse measurement and the repo's own layout scorer disagree, and I could not reconcile them. Opening so someone who knows `locate_stock_list` can settle it quickly.

Addresses #351.

## What is measured

Driving `parse_stock_list` over all 432 live entries on buildid 24568997 (exe 2026-08-05):

```
count offset   parsed   non-empty   in-entry   round-trip
   44 (old)       80         0          80         80
   45            418       310         418        418
   16            430         0         430        430
```

**Offset 44 parses only entries whose stock count is zero** — 80/80 of its successes are empty. The record walk never runs, the const-byte tripwire at record offset 42 is never reached, and no store containing stock parses at all.

That reframes #351: "102 of ~293 parse" is not a third of the table working, it is a set of vacuous passes on empty stores. Store mods are entirely non-functional on this build, not partially.

Offset 16 is the same trap with a larger number — most entries parsed, every one empty. **Only 45 reads real stock**, and all 418 of its parses round-trip byte-exact through `serialize_stock_list`, which is the strong oracle rather than a plausibility guess.

Record-internal offsets (34/38/41/42) are unchanged: they are measured from the record start, which the count position derives, so a one-byte shift of the count carries them along.

Count distribution at 45 also looks like a store table — median 6 items, p75 12, max 226, 108 empty — versus 44's median of 1794 and max of 4294967295 (`0xFFFFFFFF`).

## Why this is a draft

```
test_detection_beats_every_other_candidate
AssertionError: assert (397, 6376) < (397, 6376)
```

`_score_layout` rates the old 44 layout and the new 45 layout **identically**, while the direct parse above separates them 0 vs 310 non-empty.

I cannot reconcile that with confidence. The likely explanation is that `locate_stock_list` searches for the list rather than trusting `count_payload_offset`, so the scored path and the path I measured are not the same path — in which case this constant may not be the live mechanism and the real fix is elsewhere. That is exactly the kind of thing that is obvious to whoever wrote it and expensive for me to guess at.

I would rather flag the contradiction than talk myself past it. A change that looks convincing on one metric and neutral on another is how a wrong constant gets shipped.

## Also included

Two label assertions loosened from `== "CD 1.16"` to `.startswith("CD 1.16")`, so a point-release layout does not fail a test that meant "the 1.16 family". Those are the same brittle-constant pattern the parser itself keeps hitting.

## Verification

```
storeinfo suite   44 passed, 6 skipped, 1 failed (the scorer tie above)
```

Before this change the suite had 4 storeinfo failures on this build; with it, 1 — but I am explicitly not claiming that as success given the scorer disagreement.

All read-only against the game; nothing written to any install.