### PR TITLE
storeinfo tests: pin the layout, and stop gating the proof on a local snapshot (#351)

### DIFF
--- a/tests/test_storeinfo_native_parser.py
+++ b/tests/test_storeinfo_native_parser.py
@@ -6,6 +6,32 @@ byte-identical output, or applying a stock_data_list intent would
 corrupt the file (the game crashes on store open with a corrupt
 storeinfo body). The live-fixture tests skip when the extracted
 vanilla file is not present; the synthetic tests always run.
+
+Layout pinning (GitHub #351)
+----------------------------
+The fixed-offset tests below MUST pass the layout they were written
+against. ``parse_stock_list``'s layout parameter defaults to
+``DEFAULT_LAYOUT``, which is deliberately the *newest* build -- so a
+test that omits it silently re-points at whatever layout ships next.
+That is what #351 was: this file's ``issue_repro`` snapshot is from the
+CD 1.11 era, the default had moved on to CD 1.16, and a 1.11 table was
+being parsed as 1.16. CD 1.11 puts the const byte at record offset 34
+and CD 1.16 puts it at 42, which was exactly the byte in the error:
+
+    const byte at record offset 42 is 0 (expected 1)
+
+It read as a live regression -- "the format drifted, store mods are
+dead" -- and it was neither. Nothing about that snapshot changes when
+the game updates.
+
+Two things follow, and both are done here. The fixed-offset tests name
+their layout explicitly. And the coverage that actually matters no
+longer depends on an untracked snapshot at all: it runs against the
+committed ``vanilla113`` / ``vanilla116`` fixtures through
+``locate_stock_list``, which is the path production uses and which
+takes no offset constant. That is audit finding C7 again (see
+``tests/fixture_loaders``) -- a proof gated on a machine-local path is
+a proof that runs nowhere, least of all in CI.
 """
 from __future__ import annotations
 
@@ -16,17 +42,31 @@ import pytest
 
 from cdumm.engine.storeinfo_native_parser import (
     LAYOUTS,
-    LIST_COUNT_PAYLOAD_OFFSET,
     ORDER_ELEM_SIZE,
     StockRecord,
     StoreinfoParseError,
+    StoreListNotFound,
+    locate_stock_list,
     parse_stock_list,
     serialize_stock_list,
+)
+from cdumm.semantic.parser import _parse_entry_header, parse_pabgh_index
+from tests.fixture_loaders import (
+    has_vanilla113,
+    has_vanilla116,
+    load_vanilla113,
+    load_vanilla116,
 )
 
 _VANILLA_DIR = Path(__file__).resolve().parents[1] / "issue_repro" / "183" / "vanilla"
 _LIVE_BODY = _VANILLA_DIR / "storeinfo.pabgb"
 _LIVE_HEADER = _VANILLA_DIR / "storeinfo.pabgh"
+
+_BY_LABEL = {ly.label: ly for ly in LAYOUTS}
+
+#: The build the ``issue_repro/183`` snapshot was extracted from. Pinned
+#: rather than defaulted -- see the module docstring.
+_FIXTURE_LAYOUT = _BY_LABEL["CD 1.11"]
 
 
 def _have_live_fixture() -> bool:
@@ -134,16 +174,21 @@ def _entry_payload_offsets():
 @pytest.mark.skipif(not _have_live_fixture(),
                     reason="extracted vanilla storeinfo fixture not present")
 def test_live_entry_3101_round_trips_byte_exact():
-    """Entry 3101 is the #183 mod's target. On the current CD 1.11
-    build it has 38 records (one more than the pre-patch 37); they must
-    survive parse + serialize byte-identically. Also pins the 1.11
-    layout: const33==1 and is_restore_item in {0,1} for every record."""
+    """Entry 3101 is the #183 mod's target. On the CD 1.11 build this
+    snapshot came from it has 38 records (one more than the pre-patch
+    37); they must survive parse + serialize byte-identically. Also pins
+    the 1.11 layout: const33==1 and is_restore_item in {0,1} for every
+    record.
+
+    ``_FIXTURE_LAYOUT`` is passed explicitly. Omitting it is #351: the
+    default is the newest layout, not this snapshot's.
+    """
     body, entries = _entry_payload_offsets()
     payload, _end = entries[3101]
-    count_off = payload + LIST_COUNT_PAYLOAD_OFFSET
-    records, start, end = parse_stock_list(body, count_off)
+    count_off = payload + _FIXTURE_LAYOUT.count_payload_offset
+    records, start, end = parse_stock_list(body, count_off, _FIXTURE_LAYOUT)
     assert len(records) == 38
-    assert serialize_stock_list(records) == body[start:end]
+    assert serialize_stock_list(records, _FIXTURE_LAYOUT) == body[start:end]
     assert all(r.const33 == 1 for r in records)
     assert all(r.is_restore_item in (0, 1) for r in records)
 
@@ -154,22 +199,151 @@ def test_live_full_file_clean_entries_round_trip():
     """Every entry the parser accepts must round-trip byte-exact.
     Entries it cannot handle yet (disc-variant value payloads or
     non-empty effect lists) must raise — never mis-parse silently.
-    On the current CD 1.11 build, 268 of 293 entries are clean."""
+    On the CD 1.11 build this snapshot came from, 268 of 293 entries are
+    clean."""
     body, entries = _entry_payload_offsets()
     ok = failed = refused = 0
     for key, (payload, end) in entries.items():
-        count_off = payload + LIST_COUNT_PAYLOAD_OFFSET
+        count_off = payload + _FIXTURE_LAYOUT.count_payload_offset
         if count_off + 4 > end:
             refused += 1
             continue
         try:
-            records, start, lend = parse_stock_list(body, count_off)
+            records, start, lend = parse_stock_list(
+                body, count_off, _FIXTURE_LAYOUT)
         except (StoreinfoParseError, struct.error, IndexError):
             refused += 1
             continue
-        if serialize_stock_list(records) == body[start:lend]:
+        if serialize_stock_list(records, _FIXTURE_LAYOUT) == body[start:lend]:
             ok += 1
         else:
             failed += 1
     assert failed == 0, f"{failed} entries mis-round-tripped"
     assert ok >= 260, f"only {ok} entries round-tripped (expected >=260)"
+
+
+# ── Committed-fixture coverage: runs everywhere, including CI ─────────
+#
+# The two tests above are gated on an untracked snapshot, so on a fresh
+# clone and on the CI runner they skip. Everything below reads fixtures
+# that are in the repo, and goes through the production locate path, so
+# a real storeinfo regression has something that actually fails.
+
+_COMMITTED = (
+    ("vanilla113", "CD 1.13", 293, 263, 5443, 30),
+    ("vanilla116", "CD 1.16", 432, 397, 6376, 35),
+)
+
+
+def _committed_entries(load, ver: str):
+    body = load("storeinfo.pabgb")
+    header = load("storeinfo.pabgh")
+    key_size, offsets = parse_pabgh_index(header, "storeinfo")
+    spans = sorted(offsets.values()) + [len(body)]
+    out = {}
+    for key, off in offsets.items():
+        _, _, payload = _parse_entry_header(body, off, key_size)
+        out[key] = (payload, spans[spans.index(off) + 1])
+    return body, out
+
+
+def _walk_committed(ver: str, layout):
+    load = load_vanilla113 if ver == "vanilla113" else load_vanilla116
+    body, entries = _committed_entries(load, ver)
+    located = records = empty = not_found = 0
+    for key, (payload, end) in entries.items():
+        try:
+            recs, start, lend = locate_stock_list(
+                body, payload, end, key, layout)
+        except StoreListNotFound as exc:
+            # locate_stock_list distinguishes "provably empty" from
+            # "could not read", and that distinction is the point.
+            if "too" in str(exc) or "provably" in str(exc):
+                empty += 1
+            else:
+                not_found += 1
+            continue
+        located += 1
+        records += len(recs)
+        assert serialize_stock_list(recs, layout) == body[start:lend], (
+            f"{ver} store {key} did not round-trip byte-exact")
+    return located, records, empty, not_found, len(entries)
+
+
+@pytest.mark.parametrize(
+    "ver,label,n_entries,exp_located,exp_records,exp_empty",
+    _COMMITTED, ids=[c[0] for c in _COMMITTED])
+def test_committed_fixture_locates_and_round_trips(
+        ver, label, n_entries, exp_located, exp_records, exp_empty):
+    """The whole table is accounted for, and every record round-trips.
+
+    ``located + provably-empty == entries`` with ``not_found == 0`` is
+    the assertion that would have contradicted #351's "store mods are
+    dead" reading immediately: the parser reads the current table
+    completely. Counts are pinned so a real drift moves them.
+    """
+    if ver == "vanilla113" and not has_vanilla113("storeinfo.pabgb"):
+        pytest.skip("vanilla113 storeinfo fixture absent")
+    if ver == "vanilla116" and not has_vanilla116("storeinfo.pabgb"):
+        pytest.skip("vanilla116 storeinfo fixture absent")
+
+    located, records, empty, not_found, total = _walk_committed(
+        ver, _BY_LABEL[label])
+
+    assert not_found == 0, f"{not_found} entries could not be located"
+    assert located == exp_located
+    assert records == exp_records
+    assert empty == exp_empty
+    assert located + empty == total == n_entries
+
+
+@pytest.mark.parametrize(
+    "ver,label,n_entries,exp_located,exp_records,exp_empty",
+    _COMMITTED, ids=[c[0] for c in _COMMITTED])
+def test_older_layouts_lose_decisively_on_committed_fixture(
+        ver, label, n_entries, exp_located, exp_records, exp_empty):
+    """Detection is not a close call, so a wrong layout cannot win.
+
+    Every layout other than the fixture's own must locate dramatically
+    fewer entries. If a future layout ever ties, ``_score_layout`` can no
+    longer tell them apart and the tie must be resolved rather than
+    silently broken by ordering — which is precisely how the #352 no-op
+    change looked like an improvement.
+    """
+    if ver == "vanilla113" and not has_vanilla113("storeinfo.pabgb"):
+        pytest.skip("vanilla113 storeinfo fixture absent")
+    if ver == "vanilla116" and not has_vanilla116("storeinfo.pabgb"):
+        pytest.skip("vanilla116 storeinfo fixture absent")
+
+    right = _walk_committed(ver, _BY_LABEL[label])[0]
+    for other in LAYOUTS:
+        if other.label == label:
+            continue
+        got = _walk_committed(ver, other)[0]
+        assert got < right / 2, (
+            f"{ver}: layout {other.label!r} located {got} entries against "
+            f"{label!r}'s {right} — detection is no longer decisive")
+
+
+def test_parsing_an_older_shape_with_the_default_layout_refuses():
+    """The #351 bug class, pinned so it cannot come back silently.
+
+    A CD 1.11-shaped list parsed under the newest layout must RAISE, not
+    return plausible-looking records. This is what makes omitting the
+    layout argument a loud failure rather than a wrong answer — and it
+    needs no fixture, so it runs everywhere.
+    """
+    old = _BY_LABEL["CD 1.11"]
+    blob = serialize_stock_list(_sample_records(), old)
+
+    # Sanity: it round-trips under its own layout.
+    recs, _s, _e = parse_stock_list(blob, 0, old)
+    assert len(recs) == 2
+
+    # Under the newest layout the const tripwire is at a different record
+    # offset, so the walk must be refused.
+    newest = LAYOUTS[0]
+    assert newest.const_off != old.const_off, (
+        "this test needs two layouts whose const byte differs")
+    with pytest.raises((StoreinfoParseError, struct.error, IndexError)):
+        parse_stock_list(blob, 0, newest)

--- a/tests/test_storeinfo_writer.py
+++ b/tests/test_storeinfo_writer.py
@@ -33,6 +33,23 @@ _HDR = _BASE / "vanilla" / "storeinfo.pabgh"
 _MOD = _BASE / "HernandPets_v1.1.json"
 
 
+def _fixture_layout():
+    """The layout this snapshot was extracted under — CD 1.11.
+
+    Pinned rather than defaulted (GitHub #351). ``parse_stock_list``
+    defaults to the *newest* layout, so a verification step that omits it
+    parses this 1.11 snapshot as whatever ships next: CD 1.11 puts the
+    const byte at record offset 34 and CD 1.16 at 42, and the resulting
+    "const byte at record offset 42 is 0" read as a live format
+    regression when nothing had changed.
+
+    ``build_storeinfo_changes`` itself detects the layout, so this is
+    only needed where the test re-parses to check the writer's output.
+    """
+    from cdumm.engine.storeinfo_native_parser import LAYOUTS
+    return {ly.label: ly for ly in LAYOUTS}["CD 1.11"]
+
+
 def _have_fixtures() -> bool:
     return _BODY.exists() and _HDR.exists() and _MOD.exists()
 
@@ -69,12 +86,14 @@ def _apply(body: bytes, changes: list[dict]) -> bytes:
 @pytest.mark.skipif(not _have_fixtures(), reason="183 fixtures absent")
 def test_hernandpets_applies_end_to_end():
     from cdumm.engine.storeinfo_writer import build_storeinfo_changes
-    from cdumm.engine.storeinfo_native_parser import (
-        LIST_COUNT_PAYLOAD_OFFSET, parse_stock_list)
+    from cdumm.engine.storeinfo_native_parser import parse_stock_list
     from cdumm.semantic.parser import parse_pabgh_index, _parse_entry_header
 
     from cdumm.engine.storeinfo_native_parser import serialize_stock_list
     from cdumm.engine.storeinfo_writer import _record_identity
+
+    layout = _fixture_layout()
+    list_count_off = layout.count_payload_offset
 
     body = _BODY.read_bytes()
     header = _HDR.read_bytes()
@@ -95,7 +114,7 @@ def test_hernandpets_applies_end_to_end():
     ks, offs = parse_pabgh_index(new_header, "storeinfo")
     _, _, payload = _parse_entry_header(patched, offs[3101], ks)
     records, _s, _e = parse_stock_list(
-        patched, payload + LIST_COUNT_PAYLOAD_OFFSET)
+        patched, payload + list_count_off, layout)
     assert len(records) == 42
 
     # Split the mod's records into matched-vanilla vs new by identity
@@ -104,7 +123,7 @@ def test_hernandpets_applies_end_to_end():
     _, voffs = parse_pabgh_index(header, "storeinfo")
     _, _, vpayload = _parse_entry_header(body, voffs[3101], ks)
     vrecords, _vs, _ve = parse_stock_list(
-        body, vpayload + LIST_COUNT_PAYLOAD_OFFSET)
+        body, vpayload + list_count_off, layout)
     vbodies = {r.body for r in vrecords}
     new_js = [j for j in intent.new
               if _record_identity(j) not in vbodies]
@@ -152,9 +171,9 @@ def test_hernandpets_applies_end_to_end():
 def test_new_record_with_unmapped_field_refuses():
     from cdumm.engine.storeinfo_writer import (
         StoreinfoWriteRefused, build_storeinfo_changes, _record_identity)
-    from cdumm.engine.storeinfo_native_parser import (
-        LIST_COUNT_PAYLOAD_OFFSET, parse_stock_list)
+    from cdumm.engine.storeinfo_native_parser import parse_stock_list
     from cdumm.semantic.parser import parse_pabgh_index, _parse_entry_header
+    layout = _fixture_layout()
     body = _BODY.read_bytes()
     header = _HDR.read_bytes()
     intent = _mod_intent()
@@ -163,7 +182,8 @@ def test_new_record_with_unmapped_field_refuses():
     # unmapped interior value.
     ks, offs = parse_pabgh_index(header, "storeinfo")
     _, _, pl = _parse_entry_header(body, offs[3101], ks)
-    vrecs, _s, _e = parse_stock_list(body, pl + LIST_COUNT_PAYLOAD_OFFSET)
+    vrecs, _s, _e = parse_stock_list(
+        body, pl + layout.count_payload_offset, layout)
     vbodies = {r.body for r in vrecs}
     bad = json.loads(json.dumps(intent.new))
     new_i = next(i for i, j in enumerate(bad)


### PR DESCRIPTION
Closes the test-hygiene work you left open on #351. Small and self-contained.

## Restating what the bug was

Not a regression, and not a drifted constant. Those four tests call the fixed-offset entry point without passing a layout:

```python
count_off = payload + LIST_COUNT_PAYLOAD_OFFSET
records, start, end = parse_stock_list(body, count_off)
```

and that parameter defaults to `DEFAULT_LAYOUT`, which is deliberately the **newest** build. The fixture is the untracked CD 1.11 era extraction under `issue_repro/183`, so a 1.11 table was being parsed as CD 1.16. CD 1.11 puts the const byte at record offset 34 and CD 1.16 at 42 — exactly the byte in the error.

One detail worth adding, because it explains why my #352 lead was a no-op in a second independent way: **`count_payload_offset` is 44 on CD 1.11, 1.13 AND 1.16.** The offset constant was never the thing that differed between those layouts. It is the record *shape* that moved. So re-deriving the count offset could not have helped even in principle.

## What changed

**1. The fixed-offset tests name their layout.** `_FIXTURE_LAYOUT = CD 1.11`, passed explicitly to every `parse_stock_list` / `serialize_stock_list` call in both files. The default moving out from under a pinned test is the bug; pinning is the fix.

**2. The coverage that matters no longer depends on anyone's local snapshot.** New tests read the committed `vanilla113` / `vanilla116` fixtures and go through `locate_stock_list` — the path production uses, which takes no offset constant:

```
vanilla113  CD 1.13  located 263  records 5,443  empty 30  not_found 0
vanilla116  CD 1.16  located 397  records 6,376  empty 35  not_found 0
```

`located + provably-empty == entries`, zero not-found, every record round-tripping byte-exact. Those are the same 397 / 6,376 / 35 numbers we both measured against the live table, which is worth noting on its own: for this purpose the committed 1.16 fixture is equivalent to a live install, so this coverage did not need a game install to exist. It just never had it.

This is audit finding **C7** again, and `tests/fixture_loaders`'s own docstring describes it exactly — a proof gated on a machine-local path runs nowhere. Your point that green CI was correct rather than blind is right, and this is the other half of it: correct, but with nothing to fail.

## Two more tests

* **Older layouts must lose decisively** on each committed fixture (< half the entries located). A tie means `_score_layout` can no longer separate two layouts — which is exactly how the #352 no-op looked like an improvement, and I would rather that fail loudly than be broken by tuple ordering.
* **The bug class itself, with no fixture needed.** A CD 1.11 shaped list parsed under the newest layout must **raise**, not return plausible records. That is what makes omitting the layout argument a loud failure instead of a wrong answer, and it runs on a fresh clone.

## Verification

```
storeinfo files    26 passed, 5 skipped
full fast suite  2,838 passed, 42 skipped, 0 failures
```

The 5 skips are the `issue_repro` fixtures, absent on this machine — so I have **not** been able to run the two live-fixture tests I pinned the layout on. That is the one thing here I cannot prove, only reason about: the layout is pinned to what the docstrings and your diagnosis both say the snapshot is. You have the folder; if the pin is wrong those two will now fail deterministically instead of failing for the wrong reason, which is at least a better failure.

ruff: 9 findings before my last cleanup pass, 7 after, which is master's exact count for these two files. No new findings added.

Refs #351, #352
