### PR TITLE
Recover field read order from the Windows exe — fixes the cold-block bug I flagged on #350

### DIFF
--- a/docs/EXTRACT_FIELD_ORDER.md
+++ b/docs/EXTRACT_FIELD_ORDER.md
@@ -61,6 +61,33 @@ immediately after the field's read, in true sequence, outlined or not. With that
 | CharacterInfo | 7 | diverges @1 | diverges @1 |
 | StageInfo | 30 | diverges @6 | diverges @6 |
 
+### Named is not serialised — the trap
+
+An error string proves a field exists **on the type** and is read by the
+deserializer. It says nothing about whether that field occupies bytes **in the
+record body**. Two measured counterexamples:
+
+| field | named by exe | in the record body |
+|---|---|---|
+| `_stringKey` / `_key` | yes | **no** — the entry header consumes them; `_stringKey` *is* the entry name |
+| `SkillInfo._isNoAlert` | yes | **no** — see below |
+
+`_isNoAlert` is the sharper one because it looks so much like a fix.
+`_vendor/skillinfo_parser` reads **six** consecutive `u8` flags; the exe names
+**seven**, with `_isNoAlert` between `_isUseChildPatternDescriptionBuffData` and
+`_damageType`. A missing one-byte field is exactly the shape of the bug in
+[#355](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/355),
+where 29% of skill entries fail to parse. Adding it:
+
+```
+as shipped (6 flags)      1,424 / 2,013   (70.7%)
++ _isNoAlert (7 flags)      449 / 2,013   (22.3%)     -975 entries
+```
+
+Treat the output as an order over the fields that **are** serialised, not as a
+list of what to read. A field this tool names that a walker does not consume is
+a hypothesis; only decoding real records settles it.
+
 ### Two things it does not give you
 
 **It is not a complete order.** Only fields with an error string are named — 12 of

--- a/docs/EXTRACT_FIELD_ORDER.md
+++ b/docs/EXTRACT_FIELD_ORDER.md
@@ -1,4 +1,4 @@
-# Unlocking more tables: extract field order from the macOS binary
+# Unlocking more tables: extract field order from the game binary
 
 The shipped `pabgb_complete_schema.json` lists each table's fields in **memory
 order**, not on-disk **read order**, so ~82 of the game's 134 data tables can't
@@ -11,18 +11,94 @@ order, in its reflection **error strings**:
 file order, and runs the result through `cdumm.engine.schema_verify` — so the
 output is only trusted if it reproduces the 7 tables CDUMM already knows byte-exact.
 
-## Which binary — this matters
+## Which binary, and which tool
 
-| binary | error strings | usable for order? |
+| binary | tool | what you get |
 |---|---|---|
-| **macOS** `CrimsonDesert_Steam-*` | in **read order** | ✅ **yes — use this** |
-| Windows `CrimsonDesert.exe` | present, but string-table order ≠ read order | ❌ membership only |
+| **macOS** `CrimsonDesert_Steam-*` | `extract_field_order.py` | strings are already in **read order** — a complete order per class |
+| **Windows** `CrimsonDesert.exe` | `extract_field_order_win.py` | read order for the fields that **have** an error string |
 
 Proven on 2026-07-11: the Windows exe yields correct field *membership* for **505
-reflection classes**, but the extractor's own verification **fails all 7 known
-tables** on it — because the order is wrong. That failure is the tool working, not
-breaking. The macOS binary is specifically the one whose strings are ordered
-(unstripped build; this is the method NattKh used to decode `skill.pabgb`).
+reflection classes**, but `extract_field_order.py`'s verification **fails all 7
+known tables** on it — because the string-table order is not read order. That
+failure is the tool working, not breaking. The macOS binary is specifically the one
+whose strings are ordered (unstripped build; this is the method NattKh used to
+decode `skill.pabgb`).
+
+That is a limitation of the *string-table* method, not of the Windows exe.
+
+## The Windows route
+
+`extract_field_order_win.py` gets order from the same strings by looking at where
+the **code** references them rather than where the linker put them. Each field read
+is a guarded call whose failure branch loads that field's message:
+
+```
+    lea  rdx, [rsi + 0x70]                  ; destination in the struct
+    mov  r8d, 8                             ; stream bytes (primitives only)
+    call qword ptr [rax + 8]                ; the sized reader
+    test al, al
+    jne  ok
+    lea  rax, [rip + "CharacterInfo의 _gender를 ..."]     <-- one xref per field
+    jmp  fail
+ok: ...
+```
+
+**Do not sort by the `lea`'s own address.** A conditionally read field has its error
+block *outlined* — moved to the end of the function, with a forward branch left
+behind — so the address sort drops every such field to the end of the table, and the
+result still looks like a plausible order. On ItemInfo it relocates
+`_itemUseInfoList`, `_cooltime` and `_maxChargedUseableCount` from indices 9, 67 and
+70 to the end, and diverges from the verified order at index 9.
+
+Sort by the **hot-path branch that reaches the error block** instead. It sits
+immediately after the field's read, in true sequence, outlined or not. With that:
+
+| table | shared with verified order | address sort | hot-path sort |
+|---|---|---|---|
+| ItemInfo | 101 | diverges @9 | **exact match** |
+| RegionInfo | 19 | `_key` last | `_key` @0, one adjacent pair left |
+| CharacterInfo | 7 | diverges @1 | diverges @1 |
+| StageInfo | 30 | diverges @6 | diverges @6 |
+
+### Two things it does not give you
+
+**It is not a complete order.** Only fields with an error string are named — 12 of
+ItemInfo's 113 and 9 of CharacterInfo's 164 are never named — so something else still
+has to place the rest. Verification runs through
+`schema_verify.verify_order_source_relative`, which compares on shared names and
+reports the unplaced ones instead of pretending they do not exist. A source that
+matches but is incomplete **corroborates** an order; it does not become
+`_ordered_fields`.
+
+**It does not settle a disagreement by itself.** Where the hot-path order still
+disagrees with a verified order, the byte oracle usually cannot referee: `decode_score`
+counts bytes consumed, so any permutation that preserves the *total* width over a span
+decodes identically. Splicing the extracted CharacterInfo order into the verified one
+leaves both at 14/14 fields on 100% of records — the same score, so the fixture cannot
+choose. Settling those needs `value_agreement`, not a deeper disassembly.
+
+### Where it corroborates something independently
+
+`ORDER_VARIANTS['ItemInfo']` drops four fields for CD 1.16 and its comment splits them
+two ways by hand: `_inventoryInfo` and `_gimmickVisualPrefabDataList` are *absent from
+the binary*, while `_repairDataList` and `_prefabDataList` still exist and are dropped
+only because a field-name list cannot express the opaque run 1.16 wrapped them in. The
+extractor reproduces that split exactly — the first two are not named by the exe, the
+second two are. `tests/test_extract_field_order_win.py` pins it.
+
+### Running it
+
+```
+python -m pip install capstone pefile        # analysis-only, not app deps
+python tools/extract_field_order_win.py "<game>/bin64/CrimsonDesert.exe"
+```
+
+`capstone` and `pefile` are deliberately **not** runtime dependencies — nothing that
+ships imports them, and the tests skip without them. The exe is opened read-only and
+mmapped; it is never copied, patched or executed.
+
+## The macOS route (a complete order, if you can get the binary)
 
 ## Getting the macOS executable
 

--- a/docs/GAME_DATA_UNLOCK_ROADMAP.md
+++ b/docs/GAME_DATA_UNLOCK_ROADMAP.md
@@ -177,8 +177,32 @@ have (2026-07-11): the Korean error-string machinery is present (4362
 "read", 5309 "fail" strings) and 105/113 ItemInfo field names are present —
 but the names are **not** laid out in order (longest ordered, packed run =
 2 fields). They're pointer-referenced from descriptor structs, so on Windows
-you still need IDA on the reader functions. **The Mac binary is the
-artifact that makes this a regex instead of an RE project.**
+the string table alone is not enough.
+
+**Update (2026-08-10) — Windows works too, and it did not need IDA.**
+`tools/extract_field_order_win.py` orders fields by the *code* that
+references each string rather than by the string table, and reproduces
+ItemInfo's verified order exactly on all **101** fields it shares with the
+shipped schema. It is a scripted `capstone` sweep, not an interactive RE
+session. Two things had to be right:
+
+* each field's error string has exactly one rip-relative `lea` xref, and all
+  of a class's xrefs sit inside one densely packed deserializer
+  (CharacterInfo: 190 xrefs across 9.3 KB, no gap above 512 bytes);
+* ordering must key on the **hot-path branch reaching the error block**, not
+  the `lea`'s own address — conditionally read fields get their error block
+  outlined to the end of the function, and the address sort silently drops
+  them to the end of the table.
+
+So the earlier conclusion was too pessimistic about Windows, but right about
+one thing: this is not a regex. See `docs/EXTRACT_FIELD_ORDER.md`.
+
+**The Mac binary still buys something the Windows route cannot.** The
+Windows method only names fields that *have* an error string — 12 of
+ItemInfo's 113 and 9 of CharacterInfo's 164 are never named — so it
+corroborates an order and supplies order for unknown tables, but it cannot
+be a table's complete `_ordered_fields` by itself. If the macOS build is
+obtainable it remains the better artifact; it is no longer a prerequisite.
 
 Concrete next step for this path: obtain the macOS build of Crimson Desert
 (same game, Steam macOS depot), scan its per-class Korean error strings for
@@ -278,11 +302,26 @@ big win available, and the licence is clean (MIT, with attribution).
       + `tests/test_schema_verify.py`. Any order source now runs through
       `verify_order_source` before it is trusted. This was the answer to
       "who's to say the rest works."
-- [ ] **Path C′ (macOS binary) is now the recommended first attempt** — it
-      is a regex over unstripped Korean error strings, per NattKh's MPL-2.0
-      method doc, not a live hook or a disassembly. Get the macOS build,
-      extract per-class field order, run it through §4a. Far cheaper than
-      Path C if it pans out.
+- [x] **Path C′ on the WINDOWS exe — DONE, partially.**
+      `tools/extract_field_order_win.py` recovers read order from the exe we
+      already have, by xref position rather than string-table position, and
+      reproduces ItemInfo's verified order on all 101 shared fields. Covers
+      only fields that have an error string, so it corroborates an order
+      rather than replacing one. §4a gained
+      `verify_order_source_relative` to judge such a source honestly.
+- [ ] **Path C′ (macOS binary) — still worth getting, no longer a
+      prerequisite.** Its strings are in read order *and* it names the
+      fields the Windows route misses, so it is the artifact that turns a
+      corroborating source into a complete one. Get the macOS build, extract
+      per-class field order, run it through §4a.
+- [ ] **Settle the four disagreements the byte oracle cannot referee.**
+      Where the Windows order disagrees with a verified one (CharacterInfo,
+      StageInfo, RegionInfo, WantedInfo) `decode_score` scores both
+      identically — it counts bytes consumed, so any width-preserving
+      rearrangement is invisible to it. Splicing the extracted CharacterInfo
+      order into the verified one leaves both at 14/14 fields on 100% of
+      records. These need `value_agreement`, not more disassembly, and until
+      then they are open questions rather than conflicts.
 - [ ] **Path C (ASI reader-order hook)** stays the durable, version-proof
       fallback for whatever the Mac scan can't resolve. The reflection
       metadata is unencrypted in the exe (§4); the live hook observes

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -614,3 +614,99 @@ def verify_order_source(
             decode_ok=decode_ok,
         ))
     return report
+
+
+# ── superset candidates ──────────────────────────────────────────────────
+#
+# `verify_order_source` compares with `cand == truth`, which is the right
+# test for a candidate that claims to be a table's COMPLETE order. Some
+# sources are not that shape. A reflection-derived order names every field
+# the binary has a read-error string for, which can be more fields than the
+# shipped schema models (CharacterInfo: 190 named vs 164 in the schema) and
+# fewer than it in the other direction (9 CharacterInfo fields have no error
+# string at all). It also uses the binary's real names where the schema
+# still carries hand-written placeholders (`_characterName` vs `_stringKey2`).
+#
+# Exact equality rejects such a source for being differently-shaped rather
+# than for being wrong, which tells you nothing. The test that does carry
+# information is whether the two agree on the fields they BOTH name, in
+# order. That still catches the failure that matters -- a field in the wrong
+# slot -- while not penalising a source for knowing more or less.
+#
+# This is deliberately weaker than `verify_order_source` and does not
+# replace it. A superset source earns the right to CORROBORATE a verified
+# order, or to supply order for tables that have none; it does not earn
+# `_ordered_fields` on its own, because the fields it omits still have to
+# be placed by something.
+
+
+@dataclass
+class RelativeOrderResult:
+    table: str
+    shared: list[str]              # fields both orders name, verified order
+    candidate_sequence: list[str]  # the same fields, in candidate order
+    first_divergence: int | None   # index into `shared`, None if identical
+    candidate_only: list[str]      # named by candidate, absent from verified
+    verified_only: list[str]       # in verified order, candidate never names
+
+    @property
+    def matches(self) -> bool:
+        return self.first_divergence is None
+
+    @property
+    def complete(self) -> bool:
+        """True when the candidate names every verified field.
+
+        A candidate that matches but is not complete cannot become
+        ``_ordered_fields`` by itself: the fields in ``verified_only`` have
+        no position from this source.
+        """
+        return not self.verified_only
+
+    def summary(self) -> str:
+        tag = "MATCH" if self.matches else f"DIVERGES@{self.first_divergence}"
+        return (f"{self.table:<16} {tag}  shared={len(self.shared)}"
+                f" cand_only={len(self.candidate_only)}"
+                f" unplaced={len(self.verified_only)}")
+
+
+def relative_order_matches(table: str, candidate: list[str]
+                           ) -> RelativeOrderResult:
+    """Check ``candidate`` against ``table``'s verified order, on shared names.
+
+    Raises ``KeyError`` if ``table`` has no verified order to check against.
+    """
+    truth = verified_order(table)
+    if not truth:
+        raise KeyError(f"{table} has no verified _ordered_fields")
+    pos = {f: i for i, f in enumerate(candidate)}
+    tset = set(truth)
+    shared = [f for f in truth if f in pos]
+    seq = sorted(shared, key=lambda f: pos[f])
+    div = next((i for i, (a, b) in enumerate(zip(shared, seq)) if a != b),
+               None)
+    return RelativeOrderResult(
+        table=table,
+        shared=shared,
+        candidate_sequence=seq,
+        first_divergence=div,
+        candidate_only=[f for f in candidate if f not in tset],
+        verified_only=[f for f in truth if f not in pos],
+    )
+
+
+def verify_order_source_relative(candidate: dict[str, list[str]]
+                                 ) -> list[RelativeOrderResult]:
+    """``relative_order_matches`` over every table with a verified order.
+
+    Tables the candidate does not cover are omitted rather than failed --
+    coverage is reported by the caller, which can weigh it separately.
+    """
+    parser_mod._loaded_schemas = None
+    out = []
+    for table in tables_with_verified_order():
+        cand = candidate.get(table)
+        if not cand:
+            continue
+        out.append(relative_order_matches(table, cand))
+    return out

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -29,12 +29,20 @@ A candidate order source is a mapping::
    real records", not "someone said so"), and it flags gross corruption.
 
    It is corroboration, NOT the primary gate, and it has a known blind
-   spot: two fields of the same width, swapped upstream of the point where
-   the walker stalls, decode identically — the byte count doesn't move.
-   Order-identity is what catches those. The decode score's sharpness also
-   scales with how far the walker reaches (it stalls early on some tables
-   until their nested types are modelled), so it is reported, weighed, but
-   never trusted alone.
+   spot. The narrow statement is that two fields of the same width, swapped
+   upstream of where the walker stalls, decode identically — the byte count
+   doesn't move. The blind spot is actually WIDER than that: the score is a
+   function of bytes consumed, so **any** rearrangement preserving the total
+   width over a span is invisible to it, not only swaps of equal-width
+   pairs. Measured: reordering six of CharacterInfo's fields (moving two u8s
+   from before a u16 + two u64s + a u8 to after them) leaves the score
+   unchanged at 14/14 fields on 100% of records. Order-identity is what
+   catches those, and where two orders disagree only in that way the decode
+   score cannot referee at all — that needs ``value_agreement``.
+
+   The decode score's sharpness also scales with how far the walker reaches
+   (it stalls early on some tables until their nested types are modelled),
+   so it is reported, weighed, but never trusted alone.
 
 Order-identity is the workhorse; the decode score keeps it honest. A
 source that fails EITHER on any known table is rejected. A source that

--- a/tests/test_extract_field_order_win.py
+++ b/tests/test_extract_field_order_win.py
@@ -1,0 +1,261 @@
+"""Windows-exe field-order extraction: the cold-block fix, pinned.
+
+The bug this guards against is subtle and silent. Field order is read off
+the reflection error strings, one `lea` per field, and those `lea`s appear
+in field order *only when they are laid out where they were emitted*. A
+conditionally read field gets its error block outlined to the end of the
+function, so ordering by the `lea`'s own address drops it to the end of
+the table — and the result still looks like a plausible field order.
+
+Measured on the real binary, naive ordering puts three ItemInfo fields
+(`_itemUseInfoList`, `_cooltime`, `_maxChargedUseableCount`) at the end
+instead of indices 9, 67 and 70. Ordering by the hot-path branch that
+*reaches* the error block fixes all three.
+
+The core test below needs no game binary: it assembles a three-field
+function whose error blocks are outlined in reverse order, which is the
+worst case for the naive rule, and pins that the hot-path rule recovers
+the true sequence. The exe-gated test at the bottom checks the same
+property against the real ItemInfo deserializer and skips without a game
+install.
+"""
+from __future__ import annotations
+
+import os
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+capstone = pytest.importorskip(
+    "capstone", reason="analysis-only dependency: pip install capstone pefile")
+
+from extract_field_order_win import sweep_bytes
+
+_BASE = 0x1000
+_STRINGS = (0x2000, 0x2010, 0x2020)
+
+
+def _field_block(width: int) -> bytes:
+    """One guarded field read whose failure path is a forward jump.
+
+        mov  r8d, <width>          41 B8 imm32
+        call qword ptr [rax + 8]   FF 50 08
+        test al, al                84 C0
+        jne  ok                    75 05      (over the 5-byte jmp)
+        jmp  <cold block>          E9 rel32   (patched by the caller)
+      ok:
+    """
+    return (b"\x41\xb8" + struct.pack("<I", width)
+            + b"\xff\x50\x08"
+            + b"\x84\xc0"
+            + b"\x75\x05"
+            + b"\xe9\x00\x00\x00\x00")
+
+
+_BLOCK_LEN = len(_field_block(0))
+assert _BLOCK_LEN == 18
+_JMP_AT = 13                      # offset of the E9 within a field block
+
+
+def _build_outlined_function(n: int = 3, reverse_cold: bool = True):
+    """Assemble a function with ``n`` fields and outlined error blocks.
+
+    Returns ``(blob, base_va, lea_addrs)`` where ``lea_addrs[i]`` is the
+    address of field ``i``'s error-``lea``.
+
+    With ``reverse_cold`` the cold blocks are emitted in reverse field
+    order — so sorting by ``lea`` address yields exactly the reverse of
+    the truth. That is the strongest available statement of the bug: not
+    "slightly off", but maximally wrong.
+    """
+    hot = bytearray()
+    for i in range(n):
+        hot += _field_block(4 + i)
+    hot += b"\xc3"                                    # ret on the ok path
+
+    cold_base = _BASE + len(hot)
+    order = list(reversed(range(n))) if reverse_cold else list(range(n))
+
+    # lea rdx, [rip + disp32]  (7 bytes) + ret (1)
+    cold = bytearray()
+    lea_addrs: dict[int, int] = {}
+    for slot, fld in enumerate(order):
+        at = cold_base + slot * 8
+        lea_addrs[fld] = at
+        disp = _STRINGS[fld % len(_STRINGS)] - (at + 7)
+        cold += b"\x48\x8d\x15" + struct.pack("<i", disp) + b"\xc3"
+
+    # Patch each field's jmp to its own cold block.
+    for i in range(n):
+        at = _BASE + i * _BLOCK_LEN + _JMP_AT
+        rel = lea_addrs[i] - (at + 5)
+        struct.pack_into("<i", hot, i * _BLOCK_LEN + _JMP_AT + 1, rel)
+
+    return bytes(hot + cold), _BASE, [lea_addrs[i] for i in range(n)]
+
+
+def test_naive_lea_order_is_wrong_when_error_blocks_are_outlined():
+    """The bug, stated as a fact about the input rather than the fix.
+
+    If this ever stops failing to reproduce the reversal, the synthetic
+    function has stopped modelling the compiler output it stands in for
+    and the fix test below is no longer proving anything.
+    """
+    blob, base, leas = _build_outlined_function(3)
+    func = sweep_bytes(blob, base)
+
+    naive = sorted(range(3), key=lambda i: leas[i])
+    assert naive == [2, 1, 0], (
+        "cold blocks were emitted in reverse, so lea-address order must be "
+        f"the reverse of the true order; got {naive}")
+    # And the sweep really did see three outlined blocks.
+    assert all(leas[i] in func.inbound for i in range(3)), (
+        "each error block must be a branch target, or hot_key has nothing "
+        "to work with")
+
+
+def test_hot_path_order_recovers_the_true_field_order():
+    blob, base, leas = _build_outlined_function(3)
+    func = sweep_bytes(blob, base)
+
+    got = sorted(range(3), key=lambda i: func.hot_key(leas[i]))
+    assert got == [0, 1, 2]
+
+    # The key is the branch that reaches the block, and those branches are
+    # in the hot path — strictly increasing, and all below the cold region.
+    keys = [func.hot_key(leas[i])[0] for i in range(3)]
+    assert keys == sorted(keys)
+    assert max(keys) < min(leas)
+
+
+def test_hot_path_order_is_stable_when_nothing_is_outlined():
+    """The fix must not disturb the case the naive rule already got right."""
+    blob, base, leas = _build_outlined_function(3, reverse_cold=False)
+    func = sweep_bytes(blob, base)
+    assert sorted(range(3), key=lambda i: leas[i]) == [0, 1, 2]
+    assert sorted(range(3), key=lambda i: func.hot_key(leas[i])) == [0, 1, 2]
+
+
+def test_hot_key_falls_back_to_the_lea_for_a_fall_through_block():
+    """A block nothing branches into keeps its own address as the key.
+
+    Ordering by an absent branch would otherwise collapse those fields
+    onto one key and lose their sequence.
+    """
+    blob, base, _leas = _build_outlined_function(1)
+    func = sweep_bytes(blob, base)
+    # An address inside the entry block: no inbound branch exists.
+    inside = base + 6
+    assert func.block_start_of(inside) == base
+    assert base not in func.inbound
+    assert func.hot_key(inside) == (inside, inside)
+
+
+def test_hot_key_is_a_total_order_within_one_cold_block():
+    """Two fields sharing a cold block must still be separable.
+
+    They would tie on the branch address, so the lea address is the
+    tiebreak. Without it `sorted` would keep them in input order, which is
+    the string-table order the whole method exists to avoid.
+    """
+    blob, base, _ = _build_outlined_function(2)
+    func = sweep_bytes(blob, base)
+    blk = min(func.inbound)
+    a, b = blk, blk + 1
+    assert func.block_start_of(a) == func.block_start_of(b) == blk
+    assert func.hot_key(a) < func.hot_key(b)
+
+
+# ── against the real binary (skips without a game install) ────────────────
+
+def _game_exe() -> Path | None:
+    env = os.environ.get("CDUMM_GAME_EXE")
+    if env and Path(env).is_file():
+        return Path(env)
+    for root in ("C:", "D:", "E:", "F:"):
+        for lib in ("SteamLibrary", "Steam"):
+            p = Path(f"{root}/{lib}/steamapps/common/Crimson Desert/"
+                     "bin64/CrimsonDesert.exe")
+            if p.is_file():
+                return p
+    return None
+
+
+@pytest.mark.slow
+def test_real_exe_hot_path_beats_naive_on_iteminfo():
+    """ItemInfo is the real oracle: 101 fields shared with the verified order.
+
+    Naive ordering must FAIL it and hot-path ordering must PASS it. Pinning
+    both directions is what stops a future refactor from quietly reverting
+    to the address sort and still looking green.
+    """
+    pytest.importorskip("pefile", reason="analysis-only dependency")
+    exe = _game_exe()
+    if exe is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_EXE)")
+
+    from extract_field_order_win import extract_orders
+
+    from cdumm.engine.schema_verify import relative_order_matches
+
+    hot, stats = extract_orders(exe)
+    naive, _ = extract_orders(exe, naive=True)
+    assert stats["classes"] > 100, "extraction found implausibly few classes"
+
+    r_hot = relative_order_matches("ItemInfo", hot["ItemInfo"])
+    r_naive = relative_order_matches("ItemInfo", naive["ItemInfo"])
+
+    assert len(r_hot.shared) >= 90, (
+        f"only {len(r_hot.shared)} ItemInfo fields shared with the verified "
+        f"order — the oracle has weakened, re-check before trusting this")
+    assert r_hot.matches, (
+        f"hot-path order diverges at shared index {r_hot.first_divergence}: "
+        f"verified {r_hot.shared[r_hot.first_divergence:][:3]} vs extracted "
+        f"{r_hot.candidate_sequence[r_hot.first_divergence:][:3]}")
+    assert not r_naive.matches, (
+        "naive lea-address order now MATCHES on ItemInfo. Either the "
+        "compiler stopped outlining error blocks, or the fix has been "
+        "reverted and this test is no longer discriminating.")
+
+
+@pytest.mark.slow
+def test_real_exe_corroborates_the_cd116_field_removals():
+    """The binary agrees with ORDER_VARIANTS, four ways.
+
+    ``ORDER_VARIANTS['ItemInfo']`` drops four fields for CD 1.16, and its
+    comment distinguishes two reasons: `_inventoryInfo` and
+    `_gimmickVisualPrefabDataList` are *absent from the binary*, while
+    `_repairDataList` and `_prefabDataList` still exist and are dropped
+    only because a field-name list cannot express the opaque run 1.16
+    wrapped them in.
+
+    That hand-made distinction is independently checkable: the two absent
+    ones must not be named by the exe, and the two surviving ones must be.
+    """
+    pytest.importorskip("pefile", reason="analysis-only dependency")
+    exe = _game_exe()
+    if exe is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_EXE)")
+
+    from extract_field_order_win import extract_orders
+
+    from cdumm.engine.schema_verify import ORDER_VARIANTS
+
+    orders, _ = extract_orders(exe)
+    named = set(orders["ItemInfo"])
+    removed = set(ORDER_VARIANTS["ItemInfo"][0][1])
+
+    assert {"_inventoryInfo", "_gimmickVisualPrefabDataList"} <= removed
+    for absent in ("_inventoryInfo", "_gimmickVisualPrefabDataList"):
+        assert absent not in named, (
+            f"{absent} is named by this build's binary, so the cd116 "
+            f"variant's reason for dropping it no longer holds")
+    for present in ("_repairDataList", "_prefabDataList"):
+        assert present in named, (
+            f"{present} is NOT named by this build's binary — the cd116 "
+            f"variant says it still exists and is dropped for another "
+            f"reason, which is no longer true")

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import random
 
+import pytest
 
 from tests.fixture_loaders import load_vanilla113
 
 from cdumm.engine.schema_verify import (
-    DecodeScore, decode_score, tables_with_verified_order, verified_order,
-    verify_order_source)
+    DecodeScore, decode_score, relative_order_matches,
+    tables_with_verified_order, verified_order, verify_order_source,
+    verify_order_source_relative)
 
 ITEM = "ItemInfo"
 
@@ -167,3 +169,88 @@ def test_decode_score_at_least_ordering():
     b = DecodeScore(100, 4.0, 0.0, "x")
     assert a.at_least(b)
     assert not b.at_least(a)
+
+
+# ── superset candidates: relative_order_matches ──────────────────────────
+#
+# A reflection-derived order names the fields the binary has an error string
+# for. That set overlaps the shipped schema without equalling it in either
+# direction, so `cand == truth` rejects it for being differently shaped
+# rather than for being wrong. These pin the weaker check that does carry
+# information — and pin that it is genuinely weaker, so it cannot be
+# mistaken for the real gate.
+
+
+def test_relative_order_passes_the_ground_truth():
+    r = relative_order_matches(ITEM, verified_order(ITEM))
+    assert r.matches
+    assert r.complete
+    assert r.shared == verified_order(ITEM)
+    assert r.candidate_only == [] and r.verified_only == []
+
+
+def test_relative_order_still_rejects_a_scrambled_order():
+    r = relative_order_matches(ITEM, list(reversed(verified_order(ITEM))))
+    assert not r.matches
+    assert r.first_divergence == 0
+
+
+def test_relative_order_catches_one_field_moved_to_the_end():
+    """The cold-block failure mode, in the abstract.
+
+    One field relocated to the end is the whole bug the Windows extractor
+    had, so the check must fail on exactly that and not shrug it off as a
+    shape difference.
+    """
+    truth = verified_order(ITEM)
+    moved = truth[:5] + truth[6:] + [truth[5]]
+    r = relative_order_matches(ITEM, moved)
+    assert not r.matches
+    assert r.first_divergence == 5
+    assert r.complete, "no field was dropped, only moved"
+
+
+def test_relative_order_tolerates_extra_names_but_reports_them():
+    truth = verified_order(ITEM)
+    cand = ["_someFieldTheSchemaLacks"] + truth + ["_andAnother"]
+    r = relative_order_matches(ITEM, cand)
+    assert r.matches
+    assert r.candidate_only == ["_someFieldTheSchemaLacks", "_andAnother"]
+    assert r.complete
+
+
+def test_a_matching_but_incomplete_candidate_is_not_complete():
+    """Matching on shared names does not earn `_ordered_fields`.
+
+    A source that omits fields cannot place them, so `complete` is what
+    separates "corroborates the order" from "can be the order".
+    """
+    truth = verified_order(ITEM)
+    r = relative_order_matches(ITEM, truth[:-3])
+    assert r.matches
+    assert not r.complete
+    assert r.verified_only == truth[-3:]
+
+
+def test_relative_order_is_weaker_than_identity_and_says_so():
+    """A candidate the strict gate rejects can pass the relative one.
+
+    That is the point, and it is also the risk: this asserts the gap
+    exists so nobody swaps one for the other by accident.
+    """
+    truth = verified_order(ITEM)
+    cand = truth[:20]                             # a correct prefix only
+    assert verify_order_source({ITEM: cand}).trustworthy is False
+    assert relative_order_matches(ITEM, cand).matches is True
+
+
+def test_relative_order_raises_for_a_table_with_no_verified_order():
+    with pytest.raises(KeyError):
+        relative_order_matches("NoSuchTableInfo", ["_a", "_b"])
+
+
+def test_verify_relative_skips_uncovered_tables_rather_than_failing_them():
+    results = verify_order_source_relative({ITEM: verified_order(ITEM)})
+    assert [r.table for r in results] == [ITEM]
+    assert all(r.matches for r in results)
+    assert verify_order_source_relative({}) == []

--- a/tools/extract_field_order.py
+++ b/tools/extract_field_order.py
@@ -18,6 +18,15 @@ IMPORTANT — which binary:
     still run, but the order it produces from a Windows binary will fail
     verification — that's expected, not a bug.
 
+    That is a limitation of THIS script's method, not of the Windows exe.
+    Order is recoverable from the exe, just not from the string table:
+    `tools/extract_field_order_win.py` orders fields by where the *code*
+    references each string, and reproduces ItemInfo's verified order
+    exactly on all 101 fields it shares with the shipped schema. Reach for
+    that when you only have the Windows build. It needs `capstone` and
+    `pefile`, and it covers only the fields that have an error string, so
+    it corroborates an order rather than replacing one.
+
 Whatever binary you give it, the output is run through
 `cdumm.engine.schema_verify.verify_order_source`: the extracted order for
 every table CDUMM already has a verified `_ordered_fields` for must match

--- a/tools/extract_field_order_win.py
+++ b/tools/extract_field_order_win.py
@@ -1,0 +1,372 @@
+"""Recover per-table field READ ORDER from the WINDOWS CrimsonDesert.exe.
+
+`extract_field_order.py` reads the reflection error strings in string-table
+order. That is read order on the unstripped macOS binary and it is NOT read
+order on the Windows exe, which is why that script warns and gives up on a
+`MZ` file. This module gets the order from the Windows exe instead, by
+looking at where the code REFERENCES those strings rather than where the
+linker happened to put them.
+
+Read-only throughout: the exe is opened for reading and mmapped. Never
+copied, patched or executed.
+
+The method
+----------
+Each field read is emitted as a guarded call, and the failure branch names
+the field::
+
+        lea  rdx, [rsi + 0x70]                  ; destination in the struct
+        mov  r8d, 8                             ; stream bytes (primitives)
+        call qword ptr [rax + 8]                ; the sized reader
+        test al, al
+        jne  ok
+        lea  rax, [rip + "CharacterInfo의 _gender를 ..."]   <-- the xref
+        jmp  fail
+    ok: ...
+
+So every field has exactly one `lea` that loads its message, and those
+`lea`s appear in field order -- as long as they are laid out where they
+were emitted.
+
+Why sorting by the lea address is wrong
+---------------------------------------
+They are not always laid out there. A conditionally read field gets its
+error block OUTLINED: the compiler moves the cold path to the end of the
+function and leaves a forward branch behind. Sorting by the lea's own
+address therefore drops every such field to the end of the order.
+
+That failure is measurable. On ItemInfo -- the largest table with a verified
+order, 101 fields shared with the shipped schema -- naive lea-address
+ordering puts `_itemUseInfoList`, `_cooltime` and `_maxChargedUseableCount`
+at the end of the table instead of at indices 9, 67 and 70, and disagrees
+with the verified order at index 9.
+
+The fix
+-------
+Order by the HOT-PATH branch that reaches the error block, not by where the
+block landed. The branch sits immediately after the field's read, in true
+sequence, whether or not the block was outlined. Fields whose error block is
+fallen into rather than branched to keep their own address, which is already
+in sequence.
+
+With that change ItemInfo's 101 shared fields match the verified order
+exactly, and RegionInfo's `_key` moves from last to index 0.
+
+What this does and does not establish
+-------------------------------------
+It establishes order for the fields that HAVE an error string. That is not
+every field: 9 of CharacterInfo's 164 schema fields and 12 of ItemInfo's 113
+are never named this way, so the output is not a drop-in `_ordered_fields`
+-- something still has to place the omitted ones. Verification therefore
+runs through `verify_order_source_relative`, which compares on shared names
+and reports the unplaced ones rather than pretending they do not exist.
+
+Requires `capstone` and `pefile`, which are analysis-only and deliberately
+not runtime dependencies of the app::
+
+    python -m pip install capstone pefile
+    python tools/extract_field_order_win.py "<game>/bin64/CrimsonDesert.exe"
+"""
+from __future__ import annotations
+
+import mmap
+import re
+import struct
+import sys
+from bisect import bisect_right
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from cdumm.engine.schema_verify import (
+    tables_with_verified_order,
+    verify_order_source_relative,
+)
+
+# <Class>의 ... _<field>를   —  의 = ec 9d 98, 를 = eb a5 bc
+_PAIR = re.compile(
+    rb"([A-Za-z][A-Za-z0-9]{1,60})\xec\x9d\x98"
+    rb".{0,48}?"
+    rb"(_[A-Za-z][A-Za-z0-9]{0,60})\xeb\xa5\xbc",
+    re.DOTALL)
+
+#: rip-relative lea: REX.W(48/4C) + 8D + modrm(mod=00, rm=101) + disp32.
+#: That encoding has no shorter alias, so the only false positives are the
+#: bytes appearing inside another instruction's operand -- filtered out
+#: later by requiring the hit to decode as a `lea` in the function sweep.
+_LEA = re.compile(
+    rb"[\x48\x4c]\x8d[\x05\x0d\x15\x1d\x25\x2d\x35\x3d]....",
+    re.DOTALL)
+
+#: How far either side of a class's xref cluster to disassemble. The
+#: deserializer is one densely packed function (CharacterInfo's 190 xrefs
+#: span 9.3 KB with no gap above 512 bytes), so a small pad reaches the
+#: whole thing including outlined blocks past the last xref.
+SWEEP_PAD = 0x400
+
+_UNCOND_END = frozenset({"ret", "jmp", "int3", "ud2"})
+
+
+@dataclass(frozen=True)
+class Section:
+    name: str
+    va: int
+    vsize: int
+    raw: int
+    rsize: int
+
+
+@dataclass
+class Image:
+    """A mapped PE, addressed by virtual address."""
+
+    data: mmap.mmap
+    base: int
+    sections: tuple[Section, ...]
+
+    def va_to_off(self, va: int) -> int | None:
+        for s in self.sections:
+            if s.va <= va < s.va + max(s.vsize, s.rsize):
+                d = va - s.va
+                if d < s.rsize:
+                    return s.raw + d
+        return None
+
+    def off_to_va(self, off: int) -> int | None:
+        for s in self.sections:
+            if s.raw <= off < s.raw + s.rsize:
+                return s.va + (off - s.raw)
+        return None
+
+    def raw_sections(self) -> tuple[Section, ...]:
+        # Walk every section with raw bytes. Section names change between
+        # builds -- one shipped no `.xpdata` -- so nothing is hardcoded.
+        return tuple(s for s in self.sections if s.rsize > 0)
+
+
+def open_image(path: Path) -> Image:
+    import pefile
+    fh = open(path, "rb")                       # noqa: SIM115 (lives with mm)
+    mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+    pe = pefile.PE(str(path), fast_load=True)
+    base = pe.OPTIONAL_HEADER.ImageBase
+    secs = tuple(
+        Section(name=s.Name.rstrip(b"\x00").decode("ascii", "replace"),
+                va=base + s.VirtualAddress,
+                vsize=s.Misc_VirtualSize,
+                raw=s.PointerToRawData,
+                rsize=s.SizeOfRawData)
+        for s in pe.sections)
+    pe.close()
+    return Image(data=mm, base=base, sections=secs)
+
+
+@dataclass(frozen=True)
+class FieldString:
+    cls: str
+    fld: str
+    va: int
+
+
+def find_field_strings(img: Image) -> list[FieldString]:
+    out = []
+    for m in _PAIR.finditer(img.data):
+        va = img.off_to_va(m.start())
+        if va is None:
+            continue
+        out.append(FieldString(cls=m.group(1).decode("ascii", "replace"),
+                               fld=m.group(2).decode("ascii", "replace"),
+                               va=va))
+    return out
+
+
+def find_lea_xrefs(img: Image, targets: set[int]) -> dict[int, list[int]]:
+    """{string_va: [address of each rip-relative lea that loads it]}."""
+    hits: dict[int, list[int]] = {}
+    for sec in img.raw_sections():
+        blob = img.data[sec.raw:sec.raw + sec.rsize]
+        for m in _LEA.finditer(blob):
+            p = m.start()
+            va = sec.va + p
+            tgt = va + 7 + struct.unpack_from("<i", blob, p + 3)[0]
+            if tgt in targets:
+                hits.setdefault(tgt, []).append(va)
+    return hits
+
+
+# ── function sweep ───────────────────────────────────────────────────────
+
+@dataclass
+class Func:
+    """A linear sweep of one function, indexed for branch queries."""
+
+    start: int
+    end: int
+    addrs: list[int] = field(default_factory=list)
+    block_starts: list[int] = field(default_factory=list)
+    #: basic-block start -> addresses that branch to it
+    inbound: dict[int, list[int]] = field(default_factory=dict)
+
+    def block_start_of(self, va: int) -> int:
+        i = bisect_right(self.block_starts, va) - 1
+        return self.block_starts[i] if i >= 0 else self.start
+
+    def hot_key(self, lea_va: int) -> tuple[int, int]:
+        """Ordering key for the field whose error-lea is at ``lea_va``.
+
+        The earliest branch into the lea's basic block, so an outlined
+        block orders by where it is branched FROM. Falls back to the lea's
+        own address when nothing branches in -- the fall-through case,
+        already in sequence. The lea address is the tiebreak so the result
+        is a total order.
+        """
+        srcs = self.inbound.get(self.block_start_of(lea_va))
+        return (min(srcs), lea_va) if srcs else (lea_va, lea_va)
+
+
+def sweep_function(img: Image, lo: int, hi: int) -> Func:
+    """Linear-sweep ``[lo, hi)`` and index its branches.
+
+    A linear sweep rather than a recursive traversal: this is one
+    compiler-emitted deserializer, so it is contiguous code with no data
+    islands, and every instruction is wanted in address order.
+    """
+    off = img.va_to_off(lo)
+    if off is None:
+        raise ValueError(f"VA {lo:#x} is not in a mapped section")
+    return sweep_bytes(img.data[off:off + (hi - lo)], lo)
+
+
+def sweep_bytes(blob: bytes, lo: int) -> Func:
+    """``sweep_function`` on a raw blob — the unit-testable half."""
+    from capstone import CS_ARCH_X86, CS_MODE_64, CS_OP_IMM, Cs
+    md = Cs(CS_ARCH_X86, CS_MODE_64)
+    md.detail = True
+
+    hi = lo + len(blob)
+    f = Func(start=lo, end=hi)
+    targets: set[int] = set()
+    for ins in md.disasm(blob, lo):
+        f.addrs.append(ins.address)
+        m = ins.mnemonic
+        if m.startswith("j"):
+            ops = ins.operands
+            if len(ops) == 1 and ops[0].type == CS_OP_IMM:
+                t = ops[0].imm
+                if lo <= t < hi:
+                    targets.add(t)
+                    f.inbound.setdefault(t, []).append(ins.address)
+        if m in _UNCOND_END:
+            nxt = ins.address + ins.size
+            if lo <= nxt < hi:
+                targets.add(nxt)
+    f.block_starts = sorted(targets | {lo})
+    return f
+
+
+# ── the extraction ───────────────────────────────────────────────────────
+
+def extract_orders(path: Path, naive: bool = False
+                   ) -> tuple[dict[str, list[str]], dict[str, int]]:
+    """{ClassName: [field, ...]} in read order, plus a few stats.
+
+    ``naive=True`` reproduces the broken lea-address ordering, which is
+    what the tests compare against so the fix cannot silently regress.
+    """
+    img = open_image(path)
+    strings = find_field_strings(img)
+    xrefs = find_lea_xrefs(img, {s.va for s in strings})
+
+    by_cls: dict[str, list[tuple[str, int]]] = {}
+    for s in strings:
+        for lea in xrefs.get(s.va, []):
+            by_cls.setdefault(s.cls, []).append((s.fld, lea))
+
+    orders: dict[str, list[str]] = {}
+    for cls, pairs in by_cls.items():
+        leas = sorted(a for _f, a in pairs)
+        if naive:
+            def key(pair):
+                return (pair[1], pair[1])
+        else:
+            func = sweep_function(
+                img, leas[0] - SWEEP_PAD, leas[-1] + SWEEP_PAD)
+
+            def key(pair, _f=func):
+                return _f.hot_key(pair[1])
+
+        seen: set[str] = set()
+        out: list[str] = []
+        for fld, _a in sorted(pairs, key=key):
+            if fld not in seen:                   # first occurrence wins
+                seen.add(fld)
+                out.append(fld)
+        orders[cls] = out
+
+    stats = {"strings": len(strings),
+             "classes": len(by_cls),
+             "xrefs": sum(len(v) for v in xrefs.values()),
+             "unreferenced": len(strings) - len(xrefs)}
+    return orders, stats
+
+
+def main(argv: list[str]) -> int:
+    # The field names are ASCII but the error strings around them are
+    # Korean, so a cp1252 console would raise mid-report. Best effort:
+    # a console that cannot be reconfigured still prints the ASCII.
+    with suppress(AttributeError, OSError, ValueError):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if len(argv) != 2:
+        print("usage: python tools/extract_field_order_win.py <exe-path>")
+        return 2
+    path = Path(argv[1])
+    with path.open("rb") as fh:
+        data_head = fh.read(2)
+    if data_head != b"MZ":
+        print("!! Not a Windows PE. For the macOS binary the strings are "
+              "already in read order — use tools/extract_field_order.py.")
+        return 2
+
+    print(f"binary: {path}  ({path.stat().st_size:,} bytes)")
+    orders, stats = extract_orders(path)
+    print(f"field strings {stats['strings']:,} across "
+          f"{stats['classes']:,} classes; {stats['xrefs']:,} lea xrefs, "
+          f"{stats['unreferenced']:,} strings never referenced")
+
+    results = verify_order_source_relative(orders)
+    known = tables_with_verified_order()
+    print(f"\nverified tables: {len(known)}  covered: {len(results)}")
+    ok = 0
+    for r in results:
+        print("  " + r.summary())
+        ok += r.matches
+    print(f"\nagree on shared names: {ok}/{len(results)}")
+
+    for r in results:
+        if r.matches:
+            continue
+        i = r.first_divergence
+        print(f"\n{r.table} diverges at shared index {i}:")
+        print(f"  verified  {r.shared[i:i + 4]}")
+        print(f"  extracted {r.candidate_sequence[i:i + 4]}")
+
+    unplaced = {r.table: r.verified_only for r in results if r.verified_only}
+    if unplaced:
+        print("\nFields the binary never names — this order cannot place "
+              "them, so it is NOT a drop-in _ordered_fields:")
+        for t, fs in sorted(unplaced.items()):
+            print(f"  {t}: {len(fs)}  {fs[:6]}{' ...' if len(fs) > 6 else ''}")
+
+    if ok != len(results):
+        print("\nNOT fully verified — see the divergences above.")
+        return 1
+    print("\nEvery covered table agrees on the fields it shares. Treat the "
+          "other classes as corroboration, and gate each new table to "
+          "_verified_fields after a value spot-check.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/extract_field_order_win.py
+++ b/tools/extract_field_order_win.py
@@ -61,6 +61,28 @@ are never named this way, so the output is not a drop-in `_ordered_fields`
 runs through `verify_order_source_relative`, which compares on shared names
 and reports the unplaced ones rather than pretending they do not exist.
 
+NAMED IS NOT SERIALISED. This is the trap, and it is worth stating on its
+own because the inference is so tempting: an error string proves the field
+exists ON THE TYPE and is read by the deserializer. It says NOTHING about
+whether that field occupies bytes in the record body.
+
+Two measured counterexamples:
+
+  * `_stringKey` / `_key` are named here, but the ENTRY HEADER consumes
+    them -- `_stringKey` IS the entry name. Splicing this order into a
+    verified one without pinning those two takes RegionInfo's walker from
+    a median of 21 fields to 2.
+  * `SkillInfo._isNoAlert` is named, and sits in a run of seven
+    consecutive `u8` flags where `_vendor/skillinfo_parser` reads only
+    six. Adding it as the obvious missing byte takes skill parsing from
+    1,424/2,013 entries (70.7%) to 449/2,013 (22.3%). It is not in the
+    record body. (GitHub #355.)
+
+So treat the output as an ORDER over the fields that are serialised, not
+as a list of what to read. A field this tool names and a walker does not
+consume is a hypothesis, and the only thing that settles it is decoding
+real records.
+
 Requires `capstone` and `pefile`, which are analysis-only and deliberately
 not runtime dependencies of the app::
 


### PR DESCRIPTION
On #350 I flagged a limitation on my own binary evidence and asked for it not to be over-trusted:

> I have verified field *membership* and *width* this way, but I have **not** established a reliable read *order* from it. [...] conditionally-read fields have their error strings emitted in cold blocks at the end of the function, so sorting by address puts them in the wrong place. So [...] disregard anything that would depend on my ordering until that is fixed.

This is that fix. It also pins the broken behaviour, so it cannot come back quietly.

## The bug, and why it needed an oracle to see

Order comes from the reflection error strings, one rip-relative `lea` per field. Sorting those by address is only right while they sit where they were emitted — and a **conditionally read** field gets its error block **outlined** to the end of the function, leaving a forward branch behind. The address sort drops every such field to the end of the table.

The output still looks like a plausible field order. That is the whole problem: nothing about it announces itself.

On ItemInfo — the largest table with a verified order, 101 fields shared with the shipped schema — the address sort relocates:

```
_itemUseInfoList          index   9  ->  end of table
_cooltime                 index  67  ->  end of table
_maxChargedUseableCount    index  70  ->  end of table
```

and first diverges from the verified order at index 9.

## The fix

Order by the **hot-path branch that reaches the error block**, not by where the block was laid out. That branch sits immediately after the field's read, in true sequence, outlined or not. Fall-through blocks keep their own address; the `lea` address is the tiebreak so the result is a total order.

```
table          shared   address sort      hot-path sort
ItemInfo          101   diverges @9       EXACT MATCH
RegionInfo         19   _key last         _key @0, 1 adjacent pair left
VehicleInfo         2   match             match
FieldInfo           1   match             match
CharacterInfo       7   diverges @1       diverges @1
StageInfo          30   diverges @6       diverges @6
WantedInfo          3   diverges @0       diverges @0
```

101 of 101 on the strongest oracle available, from the Windows exe alone. This is why my earlier "the order agrees with CDUMM's verified tail" on #347 was too weak a check to have caught it: it was one table's 4-field tail, and the tail is the part outlining does not disturb.

## Corroboration I did not go looking for

`ORDER_VARIANTS['ItemInfo']` drops four fields for CD 1.16, and its comment splits them two ways **by hand**: `_inventoryInfo` and `_gimmickVisualPrefabDataList` are "absent from the 1.16 binary", while `_repairDataList` and `_prefabDataList` "still EXIST (fields 110 and 111 of 115)" and are dropped only because a field-name list cannot express the opaque run 1.16 wrapped them in.

The extractor reproduces that split exactly — the first two are not named by the exe, the second two are. A four-way hand distinction recovered from the binary without being told. Pinned in tests, so if a future build changes it, the variant's stated *reason* stops being true loudly rather than silently.

## What this does NOT establish

**It is not a drop-in `_ordered_fields`.** Only fields that *have* an error string are named — 12 of ItemInfo's 113 and 9 of CharacterInfo's 164 are never named — so something still has to place the rest. `complete` on the result is what separates "corroborates an order" from "can be the order", and it is asserted separately from `matches` for that reason.

**Where it still disagrees, it does not win by default.** I checked whether the byte oracle can referee, and mostly it cannot. `decode_score` counts bytes consumed, so **any permutation preserving the total width over a span decodes identically** — which is a sharper statement of the blind spot `schema_verify`'s docstring already admits to ("same-width fields swapped"). It is not only same-width pairs; it is any width-preserving rearrangement.

Concretely, splicing the extracted CharacterInfo order into the verified one — holding every unnamed field at its verified index, moving only the 7 shared ones — leaves **both at 14/14 fields on 100% of records**. Identical score. The fixture cannot choose between them.

So I am explicitly **not** claiming the exe is right on CharacterInfo, StageInfo or WantedInfo. What I am claiming is narrower and I think more useful: those disagreements sit precisely where the empirical order was never pinned in the first place, so they are open questions rather than conflicts. Settling them needs `value_agreement`, not more disassembly.

## Also in here

* **`schema_verify.relative_order_matches` / `verify_order_source_relative`.** `verify_order_source` compares `cand == truth`, which is correct for a candidate claiming to be a complete order and useless for this one — it names more fields than the schema (CharacterInfo 190 vs 164), fewer in the other direction, and uses the binary's real names where the schema carries placeholders (`_characterName` vs `_stringKey2`). Exact equality rejects it for being differently *shaped* rather than wrong, which tells you nothing. The relative check compares on shared names and reports the unplaced ones. It is deliberately weaker, there is a test asserting it *is* weaker, and it does not replace the strict gate.
* **A docs correction.** `extract_field_order.py` and `docs/EXTRACT_FIELD_ORDER.md` both said the Windows exe gives "membership only" and cannot give order. That is true of *that script's* method and not of the exe. Corrected, with a pointer to the new tool and a plain statement of what it can and cannot do.

## Verification

* **5 unit tests need no game binary.** They assemble a 3-field function whose error blocks are outlined **in reverse** — the worst case, where the address sort yields exactly the reversed order — and pin that the hot-path rule recovers the truth, leaves the already-correct case alone, and handles the fall-through and shared-cold-block cases.
* **2 exe-gated tests** (marked `slow`, skip without an install) pin ItemInfo matching **and naive not matching**, so a silent revert to the address sort cannot pass green.
* **8 tests** for the relative check, including that it still catches a single field moved to the end — the exact bug — and that it is weaker than the strict gate.
* Full fast suite **2,851 passed, 42 skipped, 0 failures**. Both new files ruff-clean; modified files carry master's exact findings (9 before, 9 after) so nothing new was added.

`capstone` and `pefile` are analysis-only and deliberately **not** app dependencies — nothing shipped imports them, and the tests skip without them.

All exe work is read-only: opened for reading and mmapped, never copied, patched or executed. Re-derived on **buildid 24613230** (exe 2026-08-07), two builds newer than the 24568997 my #347 / #350 numbers were taken on.

Refs #347, #350
