### PR TITLE
statusgroupinfo: derive the reverse-index width — the writer is dead on CD 1.16 over one frozen 75

### DIFF
--- a/src/cdumm/engine/statusgroupinfo_writer.py
+++ b/src/cdumm/engine/statusgroupinfo_writer.py
@@ -19,16 +19,24 @@ nothing short::
     <u32 count><count * u32 statusinfo key>   list 0
     <u32 count><count * u32 statusinfo key>   list 1
     <u32 count><count * u32 statusinfo key>   list 2
-    <u32 75><75 * u32>                        slot table for list 1
-    <u32 75><75 * u32>                        slot table for list 0
+    <u32 W><W * u32>                          slot table for list 1
+    <u32 W><W * u32>                          slot table for list 0
 
-The two 75-entry tables are reverse indexes -- 75 is exactly the number of
-``statusinfo`` records. Each holds one set entry (everything else is
-0xFFFFFFFF) per element of the list it serves, and the entry value is that
-element's position in the list. That correspondence holds on all 8 records
-for both tables, which is what pairs table 0 with list 1 and table 1 with
-list 0. The slot ids are stable across records: slot 9 resolves to
-CriticalRate in every record that sets it, slot 10 to DHIT, and so on.
+The two W-entry tables are reverse indexes, and ``W`` is exactly the number
+of ``statusinfo`` records -- so it is a property of the GAME BUILD, not a
+constant: 75 pre-1.16, **78** on CD 1.16, which added three statusinfo
+records. It used to be hardcoded at 75, which made every record fail to
+parse on 1.16 and refused every intent with a layout error that read as
+"CDUMM cannot read this table" when the table was fine (GitHub #355). It is
+now derived per record -- the two tables must agree with each other, and
+the record must tile exactly, which a wrong width cannot do.
+
+Each table holds one set entry (everything else is 0xFFFFFFFF) per element
+of the list it serves, and the entry value is that element's position in the
+list. That correspondence holds on all 8 records for both tables, which is
+what pairs table 0 with list 1 and table 1 with list 0. The slot ids are
+stable across records: slot 9 resolves to CriticalRate in every record that
+sets it, slot 10 to DHIT, and so on.
 
 Which list is ``status_info_list``
 ----------------------------------
@@ -113,6 +121,7 @@ from __future__ import annotations
 import logging
 import re
 import struct
+from contextlib import suppress
 
 from cdumm.semantic.parser import parse_pabgh_index
 
@@ -122,17 +131,38 @@ _ENVELOPE = 8
 _N_LISTS = 3
 _STATUS_INFO_LIST = 1        # which of the three lists (see module docstring)
 _N_TABLES = 2
-_TABLE_LEN = 75              # one entry per statusinfo record
+
+#: There is deliberately NO reverse-index width constant here.
+#:
+#: The tables carry one slot per ``statusinfo`` record, so the width is a
+#: property of the GAME BUILD: 75 when this writer was written, 78 on CD
+#: 1.16, which added three statusinfo records. It WAS hardcoded at 75, and
+#: that made ``parse_record_full`` return None for all 8 records on the
+#: live build -- refusing every intent with "does not match the known
+#: statusgroupinfo layout", which reads as "CDUMM cannot read this table"
+#: when the table was fine (GitHub #355).
+#:
+#: It is now derived per record: the two tables must agree with each other
+#: and the record must tile exactly. That is self-validating, since a wrong
+#: width cannot land on the record's last byte -- the same "derive and
+#: validate" move that fixed the store list (#338) and the entry keys
+#: (#341).
 _MAX_COUNT = 4096            # sanity bound while walking
 
 #: These lists hold ``statusinfo`` record keys, so a value outside that
 #: key space is a dangling reference in a list the game dereferences --
-#: a plausible crash vector, and never what a mod means. The key space is
-#: 1000000..1000074, which is not a magic number here: it is the repo's
-#: own statusinfo snapshot (``stat_names.STAT_NAMES_CD113``, 75 keys),
-#: and 75 is exactly ``_TABLE_LEN`` -- the reverse-index tables carry one
-#: slot per statusinfo record. The two agreeing is the check that this
-#: bound is the real one. Verified at import.
+#: a plausible crash vector, and never what a mod means.
+#:
+#: These are the FLOOR and a STARTING ceiling, not the answer.
+#: 1000000..1000074 is the repo's CD 1.13 snapshot
+#: (``stat_names.STAT_NAMES_CD113``, 75 keys). On CD 1.16 the table has 78
+#: records spanning 1000000..**1000078**, and the vanilla lists reference
+#: keys right to that top -- so treating this as the exact range refused
+#: references the game itself makes. ``_status_key_space`` widens the
+#: ceiling from evidence and never lowers the floor.
+#:
+#: Note the space is NOT contiguous: 78 records span 79 slots, so the
+#: ceiling cannot be derived from the reverse-index width either.
 _MIN_STATUS_KEY = 1000000
 _MAX_STATUS_KEY = 1000074
 
@@ -143,23 +173,52 @@ _SENTINEL = 0xFFFFFFFF
 _FIELD_RE = re.compile(r"^status_info_list\[(\d+)\]$")
 
 
-def _status_key_space() -> tuple[int, int]:
-    """(min, max) statusinfo key, cross-checked against ``_TABLE_LEN``.
+def _status_key_space(
+    observed: set[int] | None = None,
+) -> tuple[int, int]:
+    """(min, max) statusinfo key the range check will accept.
 
-    Falls back to the constants above if the snapshot is unavailable, so
-    a trimmed build still range-checks rather than accepting anything.
+    Widened from every source of evidence, never narrowed. The check
+    exists to catch a value that is obviously not a record reference --
+    a 5, a 2**31 -- not to be an exact membership test, so a bound that
+    is too TIGHT is the harmful direction: it refuses mods that are
+    correct.
+
+    That is exactly what went wrong. The shipped snapshot is CD 1.13's 75
+    keys (1000000..1000074), and on CD 1.16 the statusinfo table has 78
+    records spanning 1000000..**1000078** -- and the vanilla
+    statusgroupinfo lists reference keys right up to that top. The frozen
+    bound would refuse a reference the game itself makes.
+
+    ``observed`` is the set of keys the vanilla lists actually hold, which
+    the caller has already parsed. It is direct, on-disk evidence from the
+    build in front of us and costs nothing to collect, so it is folded in.
+
+    Note the key space is NOT contiguous -- 78 records span 79 slots, so
+    one key in the range is absent. That is why the bound cannot be
+    derived from the reverse-index width (``lo + width - 1`` would be one
+    short); the span has to come from real keys.
+
+    Only the CEILING moves. ``_MIN_STATUS_KEY`` is a structural fact of
+    the key space, so a source containing something below it is telling
+    us it is not a statusinfo key set -- widening the floor to match
+    would let a bare ``5`` through, which is the garbage this check
+    exists to stop. Keys below the floor are therefore ignored, not
+    trusted.
     """
-    try:
+    lo, hi = _MIN_STATUS_KEY, _MAX_STATUS_KEY
+    sources: list[set[int]] = []
+    with suppress(Exception):   # optional module; the literal bound applies
         from cdumm.engine.stat_names import STAT_NAMES_CD113 as names
-    except Exception:  # noqa: BLE001 -- optional module, bound still applies
-        return _MIN_STATUS_KEY, _MAX_STATUS_KEY
-    if len(names) != _TABLE_LEN:
-        logger.warning(
-            "statusgroupinfo: statusinfo snapshot has %d keys but the "
-            "reverse-index tables have %d slots; using the wider bound",
-            len(names), _TABLE_LEN)
-        return _MIN_STATUS_KEY, _MAX_STATUS_KEY
-    return min(names), max(names)
+        if names:
+            sources.append(set(names))
+    if observed:
+        sources.append(set(observed))
+    for src in sources:
+        usable = [k for k in src if k >= lo]
+        if usable:
+            hi = max(hi, max(usable))
+    return lo, hi
 
 
 def _read_list(body: bytes, p: int, end: int) -> tuple[int, int] | None:
@@ -198,15 +257,26 @@ def parse_record_full(
         lists.append((elem_start, count))
         p = elem_start + 4 * count
     tables: list[tuple[int, int]] = []
+    table_len: int | None = None
     for _ in range(_N_TABLES):
         got = _read_list(body, p, end)
         if got is None:
             return None
         elem_start, count = got
-        if count != _TABLE_LEN:
+        # The two reverse-index tables carry one slot per statusinfo
+        # record, so they must be the SAME width as each other. Their
+        # actual width is a build property (75 pre-1.16, 78 on 1.16), so
+        # it is derived here rather than asserted -- see the comment on
+        # the constant note above. Exact tiling below is what validates it: a
+        # wrong width cannot finish on the record's last byte.
+        if table_len is None:
+            table_len = count
+        elif count != table_len:
             return None
         tables.append((elem_start, count))
         p = elem_start + 4 * count
+    if not table_len:
+        return None                           # zero-width tables are not a record
     if p != end:
         return None                           # did not tile exactly
     return lists, tables
@@ -293,7 +363,20 @@ def build_statusgroupinfo_changes(
                     for i in intents]
     starts = sorted(offsets.values())
     body_len = len(vanilla_body)
-    lo_key, hi_key = _status_key_space()
+
+    # Every statusinfo key the vanilla table already references. Direct
+    # evidence from THIS build, so the range check below cannot be
+    # tighter than the game's own data (see _status_key_space).
+    observed: set[int] = set()
+    for _o in offsets.values():
+        _i = starts.index(_o)
+        _end = starts[_i + 1] if _i + 1 < len(starts) else body_len
+        _got = parse_record(vanilla_body, _o, _end)
+        if _got is None:
+            continue
+        for _es, _c in _got:
+            observed.update(_elements(vanilla_body, _es, _c))
+    lo_key, hi_key = _status_key_space(observed)
 
     changes: list[dict] = []
     #: record key -> accepted writes, batched so the reverse index below

--- a/tests/test_statusgroupinfo_writer.py
+++ b/tests/test_statusgroupinfo_writer.py
@@ -32,8 +32,10 @@ import pytest
 
 from cdumm.engine.format3_handler import Format3Intent, validate_intents
 from cdumm.engine.statusgroupinfo_writer import (
+    _SENTINEL,
     build_statusgroupinfo_changes,
     parse_record,
+    parse_record_full,
 )
 from cdumm.semantic.parser import parse_pabgh_index
 from tests.fixture_loaders import has_vanilla115, load_vanilla115
@@ -310,30 +312,53 @@ def test_refuses_keys_outside_the_statusinfo_key_space(bad):
     assert "outside the statusinfo key space" in dropped[0][1]
 
 
-def test_the_key_space_bound_agrees_with_the_index_table_width():
-    """The bound isn't a magic number: the statusinfo snapshot has one
-    key per reverse-index slot. If those ever disagree the bound is
-    wrong, so pin the agreement rather than the literal."""
+def test_the_key_space_bound_covers_the_shipped_snapshot():
+    """The bound must never be TIGHTER than the keys we know about.
+
+    This used to assert the bound EQUALLED the snapshot's range and that
+    the range equalled the reverse-index width. Both were true on CD 1.13
+    and both are false on CD 1.16: the table grew to 78 records spanning
+    1000000..1000078, so an equality assertion pinned CDUMM to a stale
+    game build and refused references the game itself makes.
+    """
     from cdumm.engine.stat_names import STAT_NAMES_CD113
+    from cdumm.engine.statusgroupinfo_writer import _status_key_space
+    lo, hi = _status_key_space()
+    assert lo <= min(STAT_NAMES_CD113)
+    assert hi >= max(STAT_NAMES_CD113)
+
+
+def test_the_key_space_widens_to_cover_keys_the_game_actually_uses():
+    """Observed on-disk keys raise the ceiling; nothing lowers the floor.
+
+    The floor is structural, so a source carrying values below it is not
+    a statusinfo key set and must be ignored rather than trusted -- else
+    a bare ``5`` becomes an acceptable record reference, which is the
+    exact garbage this check exists to stop.
+    """
     from cdumm.engine.statusgroupinfo_writer import (
-        _TABLE_LEN,
+        _MAX_STATUS_KEY,
+        _MIN_STATUS_KEY,
         _status_key_space,
     )
-    assert len(STAT_NAMES_CD113) == _TABLE_LEN
-    lo, hi = _status_key_space()
-    assert (lo, hi) == (min(STAT_NAMES_CD113), max(STAT_NAMES_CD113))
-    assert hi - lo + 1 == _TABLE_LEN
+    base_lo, base_hi = _status_key_space()
+
+    # A key above the snapshot ceiling (CD 1.16 really does have these)
+    lo, hi = _status_key_space({_MAX_STATUS_KEY + 4})
+    assert lo == base_lo
+    assert hi == _MAX_STATUS_KEY + 4
+
+    # Garbage below the floor must not widen anything
+    lo, hi = _status_key_space({5, 2, _MIN_STATUS_KEY})
+    assert (lo, hi) == (base_lo, base_hi)
 
 
 def test_key_space_falls_back_when_the_snapshot_is_unusable(monkeypatch,
                                                             caplog):
-    """The bound is derived, so it has two failure modes: the snapshot
-    module missing (trimmed build) and the snapshot disagreeing with the
-    table width. Neither may silently drop the range check -- both must
-    fall back to the literal bound, and the disagreement must be logged.
+    """The bound must survive a trimmed build, and must not be widened
+    downward by a snapshot that clearly is not a statusinfo key set.
     """
     import builtins
-    import logging
 
     from cdumm.engine import stat_names
     from cdumm.engine.statusgroupinfo_writer import (
@@ -343,12 +368,10 @@ def test_key_space_falls_back_when_the_snapshot_is_unusable(monkeypatch,
     )
     expected = (_MIN_STATUS_KEY, _MAX_STATUS_KEY)
 
-    # 1. snapshot present but the wrong width -> fall back AND warn
+    # 1. snapshot present but plainly not statusinfo keys -> ignored
+    #    entirely, floor intact, ceiling unmoved.
     monkeypatch.setattr(stat_names, "STAT_NAMES_CD113", {1: "x", 2: "y"})
-    with caplog.at_level(logging.WARNING):
-        assert _status_key_space() == expected
-    assert any("reverse-index tables" in r.message for r in caplog.records), (
-        [r.message for r in caplog.records])
+    assert _status_key_space() == expected
     monkeypatch.undo()
 
     # 2. module unimportable -> fall back, no crash
@@ -537,11 +560,17 @@ def test_parse_record_refuses_malformed_records(mutate, why):
 
 @pytest.mark.parametrize("count,why", [
     (10 ** 9, "list count past the sanity bound"),
-    (74, "index table is not 75 entries"),
+    (74, "the two index tables disagree on width"),
 ])
 def test_parse_record_refuses_bad_list_and_table_widths(count, why):
-    """_read_list's bound and the _TABLE_LEN check. Both exist so a
-    drifted layout is refused rather than written into on old offsets."""
+    """_read_list's bound, and the two-tables-must-agree check.
+
+    The width itself is no longer asserted against a constant -- it is a
+    build property (75 pre-1.16, 78 on 1.16). What IS asserted is that
+    the two reverse-index tables agree with each other and that the
+    record tiles exactly, which is what makes a drifted layout refuse
+    rather than get written into on stale offsets.
+    """
     body, header = _tables()
     o, end = _bounds(body, header, STAT_ON_ITEM)
     lists = parse_record(body, o, end)
@@ -756,3 +785,44 @@ def test_validate_intents_accepts_status_info_list():
     v = validate_intents("statusgroupinfo.pabgb", intents)
     assert len(v.supported) == 1, v
     assert not v.skipped, v
+
+
+def test_parse_record_accepts_a_wider_index_table_than_the_snapshot():
+    """The CD 1.16 regression, pinned (GitHub #355).
+
+    The reverse-index tables carry one slot per statusinfo record, and
+    the game added three of those: 75 slots pre-1.16, 78 on 1.16. The
+    width used to be hardcoded, so on the live build `parse_record`
+    returned None for ALL 8 records and every intent was refused with
+    "does not match the known statusgroupinfo layout" -- which reads as
+    "CDUMM cannot read this table" when the table was fine.
+
+    Widening both tables together must still parse. Nothing here depends
+    on the number 78; it rebuilds the record at a new width and checks
+    the grammar follows the data.
+    """
+    body, header = _tables()
+    o, end = _bounds(body, header, STAT_ON_ITEM)
+    full = parse_record_full(body, o, end)
+    assert full is not None
+    lists, tables = full
+    old_width = tables[0][1]
+    assert tables[1][1] == old_width, "fixture's tables should already agree"
+
+    # Rebuild the record with both index tables three slots wider, the
+    # way a game patch that adds three statusinfo records would.
+    extra = 3
+    t0_count_at = tables[0][0] - 4
+    rebuilt = bytearray(body[o:t0_count_at])
+    for _elem_start, _c in tables:
+        rebuilt += struct.pack("<I", old_width + extra)
+        rebuilt += body[_elem_start:_elem_start + 4 * old_width]
+        rebuilt += struct.pack("<I", _SENTINEL) * extra
+
+    got = parse_record_full(bytes(rebuilt), 0, len(rebuilt))
+    assert got is not None, (
+        "a wider index table must parse -- it is a game-build property, "
+        "not a constant")
+    new_lists, new_tables = got
+    assert [c for _s, c in new_lists] == [c for _s, c in lists]
+    assert [c for _s, c in new_tables] == [old_width + extra] * 2


### PR DESCRIPTION
The entire statusgroupinfo writer is dead on CD 1.16, and the cause is one frozen constant. Found while scanning for #355.

## The bug

The two reverse-index tables carry one slot per `statusinfo` record. That count is a property of the **game build** — it was 75 when this writer was written, and CD 1.16 added three statusinfo records, so it is now **78**. The check was:

```python
if count != _TABLE_LEN:      # _TABLE_LEN = 75
    return None
```

Measured against the live table, buildid 24613230:

```
strict (_TABLE_LEN=75)   0 of 8 records parse
derived width            8 of 8 records parse, width 78 on every one
```

So `parse_record_full` returned `None` for the whole table and every intent was refused with:

```
record key N does not match the known statusgroupinfo layout
```

which reads as *"CDUMM cannot read this table"* when the table was completely fine.

This is the bug class this repo keeps hitting, so the fix is the established move — **derive and validate**. The two tables must agree with each other and the record must tile exactly. That is self-validating: a wrong width cannot land on the record's last byte. Same shape as #338 (locate the store list) and #341 (entry keys at `key_size`).

## The key-space bound was frozen too, and that one refused correct mods

`_status_key_space` asserted the bound **equalled** the CD 1.13 snapshot's 75 keys, `1000000..1000074`. On this build `statusinfo` has 78 records spanning `1000000..`**`1000078`**, and the vanilla statusgroupinfo lists reference keys right up to that top.

So the range check would have refused a record reference **the game itself makes**. That is the harmful direction for this guard: it exists to catch a bare `5` or a `2**31`, not to be an exact membership test.

It now widens from evidence and never narrows, folding in the statusinfo keys the vanilla lists actually hold — on-disk evidence from the build in front of us, which the caller has already parsed anyway.

**Only the ceiling moves.** The floor is structural, so a source carrying values below it is telling us it is not a statusinfo key set; widening the floor to match would let a bare `5` through.

One detail that rules out the obvious shortcut: the key space is **not contiguous** — 78 records span 79 slots, so one key in the range is absent. The ceiling therefore cannot be derived from the reverse-index width either (`lo + width - 1` is one short). It has to come from real keys.

## What this does NOT do

**It does not make mod 2634's Global Critical Rate apply.** That mod sets list-1 index 3 to `CriticalDamage`, which already sits at index 2, and a reverse index cannot hold one key at two positions. It is refused — exactly as `test_refuses_the_real_mod_intent_because_it_duplicates_a_key` already pins on the fixture. The mod is stale for this build, and that conclusion is unchanged.

What changes is that the live build now gives that **true** reason instead of a layout error. "This mod duplicates a key" is actionable. "CDUMM does not recognise the table" sends someone chasing a parser bug that is not there — and it would have made this look like a format regression, which is the exact wrong turn #351 was.

## Verification

* 8 of 8 live records parse; derived width 78 on every one.
* New test rebuilds a fixture record with **both** tables three slots wider and requires it to parse. It does not depend on the number 78 — it checks the grammar follows the data.
* The two tests asserting the OLD contract are **rewritten, not deleted**: the bound must merely *cover* the snapshot, and observed keys raise the ceiling while sub-floor garbage moves nothing.
* The width test now pins "the two tables agree with each other", which is the real invariant.
* `_TABLE_LEN` removed entirely rather than left as a dead constant whose comment claimed a use it no longer had. The module docstring documented the grammar as fixed-75 and is corrected.

```
statusgroupinfo suite   56 passed
full fast suite      2,835 passed, 42 skipped, 0 failures
ruff                 clean (no new findings)
```

All game reads were read-only.

Refs #355, #320
