### PR TITLE
docs: correct the _isNoAlert counterexample — it IS serialised, and it was the fix for #355

### DIFF
--- a/docs/EXTRACT_FIELD_ORDER.md
+++ b/docs/EXTRACT_FIELD_ORDER.md
@@ -65,28 +65,49 @@ immediately after the field's read, in true sequence, outlined or not. With that
 
 An error string proves a field exists **on the type** and is read by the
 deserializer. It says nothing about whether that field occupies bytes **in the
-record body**. Two measured counterexamples:
+record body**. The measured counterexample:
 
 | field | named by exe | in the record body |
 |---|---|---|
 | `_stringKey` / `_key` | yes | **no** — the entry header consumes them; `_stringKey` *is* the entry name |
-| `SkillInfo._isNoAlert` | yes | **no** — see below |
 
-`_isNoAlert` is the sharper one because it looks so much like a fix.
-`_vendor/skillinfo_parser` reads **six** consecutive `u8` flags; the exe names
-**seven**, with `_isNoAlert` between `_isUseChildPatternDescriptionBuffData` and
-`_damageType`. A missing one-byte field is exactly the shape of the bug in
-[#355](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/355),
-where 29% of skill entries fail to parse. Adding it:
-
-```
-as shipped (6 flags)      1,424 / 2,013   (70.7%)
-+ _isNoAlert (7 flags)      449 / 2,013   (22.3%)     -975 entries
-```
+Splicing this tool's order into a verified one without pinning those two takes
+RegionInfo's walker from a median of 21 fields to 2, on the live table.
 
 Treat the output as an order over the fields that **are** serialised, not as a
-list of what to read. A field this tool names that a walker does not consume is
-a hypothesis; only decoding real records settles it.
+list of what to read.
+
+#### But do not over-apply this
+
+A named field a walker skips is **far more often a real missing field** than a
+memory-only one, and this very caveat was used to wave away a genuine bug.
+
+`SkillInfo._isNoAlert` (index 25) is named here and was not read by
+`_vendor/skillinfo_parser`, which took a run of seven consecutive `u8` flags for
+six. **It is serialised**, and inserting it is the fix for
+[#355](https://github.com/faisalkindi/CrimsonDesert-UltimateModsManager/issues/355)
+— 2013/2013 records on CD 1.16, up from 1424.
+
+An earlier revision of this page cited it as a counterexample, on the strength
+of a measurement showing 449/2013. **That measurement was wrong.** It patched
+the field *reader* without widening the matching flag-run skip in the boundary
+probe, so the brute-force search then landed on wrong offsets. The field was
+right; the test of it was incomplete.
+
+So the lesson is narrower than "distrust the tool":
+
+> Decide with an **aggregate decode over a whole table, on both an old and a new
+> build**. Per-record signals cannot referee. The boundary search makes a wrong
+> layout land exactly on the record end, and the record then round-trips
+> byte-exact too — because it writes back whatever it read.
+
+The aggregate is decisive where per-record evidence is blind:
+
+```
+layout      CD 1.13          CD 1.16
+6 flags     1999/1999        1424/2013
+7 flags     1576/1999        2013/2013
+```
 
 ### Two things it does not give you
 

--- a/tools/extract_field_order_win.py
+++ b/tools/extract_field_order_win.py
@@ -72,16 +72,32 @@ Two measured counterexamples:
     them -- `_stringKey` IS the entry name. Splicing this order into a
     verified one without pinning those two takes RegionInfo's walker from
     a median of 21 fields to 2.
-  * `SkillInfo._isNoAlert` is named, and sits in a run of seven
-    consecutive `u8` flags where `_vendor/skillinfo_parser` reads only
-    six. Adding it as the obvious missing byte takes skill parsing from
-    1,424/2,013 entries (70.7%) to 449/2,013 (22.3%). It is not in the
-    record body. (GitHub #355.)
-
 So treat the output as an ORDER over the fields that are serialised, not
 as a list of what to read. A field this tool names and a walker does not
 consume is a hypothesis, and the only thing that settles it is decoding
 real records.
+
+DO NOT OVER-APPLY THAT. A named field the walker skips is far more often a
+real missing field than a memory-only one, and this caveat has already
+been used to wave away a genuine bug:
+
+    `SkillInfo._isNoAlert` (index 25) is named here and was not read by
+    `_vendor/skillinfo_parser`, which took a run of seven consecutive u8
+    flags for six. It IS serialised, and inserting it is the fix for
+    GitHub #355 -- 2013/2013 records on CD 1.16, up from 1424.
+
+    An earlier revision of this file cited it as a counterexample on the
+    strength of a measurement showing 449/2013. That measurement was
+    wrong: it patched the field READER without widening the matching
+    flag-run skip in the boundary probe, so the brute-force search then
+    landed on the wrong offsets. The field was right; the test of it was
+    incomplete.
+
+The lesson is narrower than "distrust the tool". It is: decide with an
+AGGREGATE decode over a whole table, on both an old and a new build.
+Per-record signals cannot referee here -- the boundary search makes a
+wrong layout land exactly on the record end, and the record then
+round-trips byte-exact too, because it writes back whatever it read.
 
 Requires `capstone` and `pefile`, which are analysis-only and deliberately
 not runtime dependencies of the app::


### PR DESCRIPTION
**I got this wrong and it shipped in #354, so it is corrected in the open rather than quietly edited.**

#354 added a "named is not serialised" caveat to the Windows field-order extractor, and used `SkillInfo._isNoAlert` as its sharpest example — named by the binary, not read by `_vendor/skillinfo_parser`, and inserting it appeared to take skill parsing from 1424/2013 down to 449/2013.

**`_isNoAlert` is serialised, and inserting it is the fix for #355** — 2013 of 2013 records on CD 1.16, now merged as 21b0f5f.

## What I did wrong

I patched the field *reader* (`_read_post_buff`) without widening the matching flag-run skip in `_try_parse_post_buff`. The brute-force boundary search then landed on wrong offsets and collapsed the table. **The field was right; my test of it was incomplete**, and I reported the negative result as though it settled the question.

That is the worse half. A caveat saying "the tool names fields that aren't really there" is exactly the kind of claim that stops the next person looking — and a named field a walker skips is far more often a real missing field than a memory-only one.

## What survives

The caveat itself stands, on the example that is actually verified: `_stringKey` and `_key` are named by the exe and consumed by the **entry header**. Splicing this tool's order in without pinning those two takes RegionInfo's walker from a median of 21 fields to 2 on the live table. That measurement I did check.

## What the episode actually teaches

Narrower, and now what the docs say:

> Decide with an **aggregate decode over a whole table, on both an old and a new build**. Per-record signals cannot referee — the boundary search makes a wrong layout land exactly on the record end, and the record then round-trips byte-exact too, because it writes back whatever it read.

Your own numbers are the clean demonstration, so they are in the docs now:

```
layout      CD 1.13          CD 1.16
6 flags     1999/1999        1424/2013
7 flags     1576/1999        2013/2013
```

I had the round-trip result in front of me — 2013/2013 byte-exact on the live table — and read it as evidence the reads were sound. It is byte-exact *because* 1408 of those records carry their buff region as an opaque blob and write it back verbatim. That is the blindness your commit message names, and I walked into it.

Docs only, no behaviour change. `ruff` clean, extractor tests 7 passed.

Refs #354, #355
