### PR TITLE
Table coverage: 7 -> 46 tables proven byte-exact, five wrong layouts retracted, ten derivation bugs fixed

### DIFF
--- a/schemas/pabgb_complete_schema.json
+++ b/schemas/pabgb_complete_schema.json
@@ -28443,5 +28443,79 @@
   {
    "f": "_isBlocked"
   }
+ ],
+ "factiongroup": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_factionGroupName"
+  },
+  {
+   "f": "_factionInfoList"
+  },
+  {
+   "f": "_knowledgeInfo"
+  },
+  {
+   "f": "_uiIconPath"
+  },
+  {
+   "f": "_uiDailyQuestImagePath"
+  }
+ ],
+ "uisocialaction": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_name"
+  },
+  {
+   "f": "_description"
+  },
+  {
+   "f": "_quickSlotUiTabIndex"
+  },
+  {
+   "f": "_quickSlotUiIndex"
+  }
+ ],
+ "factionreblockadinginfo": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_reoccupationQuestDataList"
+  },
+  {
+   "f": "_factionNodeList"
+  },
+  {
+   "f": "_delayTime"
+  },
+  {
+   "f": "_protectCombatPower"
+  }
+ ],
+ "globalgameeventgroup": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_defaultOption"
+  },
+  {
+   "f": "_globalGameEventUpdateOption"
+  },
+  {
+   "f": "_globalGameEventInfoList"
+  },
+  {
+   "f": "_fieldInfo"
+  },
+  {
+   "f": "_updateType"
+  }
  ]
 }

--- a/schemas/pabgb_complete_schema.json
+++ b/schemas/pabgb_complete_schema.json
@@ -28517,5 +28517,22 @@
   {
    "f": "_updateType"
   }
+ ],
+ "royalsupply": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_Quest"
+  },
+  {
+   "f": "_Mission"
+  },
+  {
+   "f": "_defaultRandomList"
+  },
+  {
+   "f": "_stageInfo"
+  }
  ]
 }

--- a/schemas/pabgb_complete_schema.json
+++ b/schemas/pabgb_complete_schema.json
@@ -28557,5 +28557,13 @@
   {
    "f": "_pushKnowledgeToGimmick"
   }
+ ],
+ "factionwaypoint": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_wayPointData"
+  }
  ]
 }

--- a/schemas/pabgb_complete_schema.json
+++ b/schemas/pabgb_complete_schema.json
@@ -28534,5 +28534,28 @@
   {
    "f": "_stageInfo"
   }
+ ],
+ "gimmickgateconnection": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_materialItemInfo"
+  },
+  {
+   "f": "_resultItemInfo"
+  },
+  {
+   "f": "_knowledgeInfo"
+  },
+  {
+   "f": "_srcGateInfo"
+  },
+  {
+   "f": "_destGateInfo"
+  },
+  {
+   "f": "_pushKnowledgeToGimmick"
+  }
  ]
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -1323,7 +1323,7 @@
     }
   },
   "FailMessageInfo": {
-    "_meta_note": "Derived 2026-08-11 from game buildid 24613230 by tools/derive_table_layout.py. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block (tools/extract_field_order_win.py). Field WIDTHS come from the sized reads in the deserializer, with count-prefixed list element widths solved against the table data under a unique-or-nothing rule. PROOF: the walk consumes every one of this table's 11 records to its exact last byte, and no other shape in the format's documented grammar does. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as a fact or written to until its values are cross-checked.",
+    "_meta_note": "Derived 2026-08-11 from game buildid 24613230 by tools/derive_table_layout.py. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block (tools/extract_field_order_win.py). Field WIDTHS come from the sized reads in the deserializer, with count-prefixed list element widths solved against the table data under a unique-or-nothing rule. PROOF: the walk consumes every one of this table's 11 records to its exact last byte, and no other shape in the format's documented grammar does. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as a fact or written to until its values are cross-checked. CORRECTION 2026-08-12: _failMessageInfoList shipped as CArray<[u8;33]>, a FIXED element width, and that was WRONG. The element ends in a LocalizableString read, so it has no constant width; the fixed value only fitted because every element string in this build is 16 bytes (17+16==33). Stage 2's candidate space contains no variable-element list shape, so it could not see the competing hypothesis and reported uniqueness inside an incomplete space. Both models tile 100% of records exactly, so the DATA cannot separate them -- the reader's disassembly can, and does. Now CArray<FailMessageInfo_Entry> (u32+LocalizableString). Exact tiling still holds under the corrected model, verified through CDUMM's own _consume_field_bytes.",
     "_no_null_skip": true,
     "_ordered_fields": [
       "_isBlocked",
@@ -1334,7 +1334,7 @@
       "type": "u8"
     },
     "_failMessageInfoList": {
-      "type": "CArray<[u8;33]>"
+      "type": "CArray<FailMessageInfo_Entry>"
     }
   },
   "GameAdviceGroupInfo": {
@@ -1804,7 +1804,7 @@
     }
   },
   "HouseInfo": {
-    "_meta_note": "Derived 2026-08-11 from game buildid 24613230 by tools/derive_table_layout.py. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block (tools/extract_field_order_win.py). Field WIDTHS come from the sized reads in the deserializer, with count-prefixed list element widths solved against the table data under a unique-or-nothing rule. PROOF: the walk consumes every one of this table's 4 records to its exact last byte, and no other shape in the format's documented grammar does. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as a fact or written to until its values are cross-checked.",
+    "_meta_note": "Derived 2026-08-11 from game buildid 24613230 by tools/derive_table_layout.py. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block (tools/extract_field_order_win.py). Field WIDTHS come from the sized reads in the deserializer, with count-prefixed list element widths solved against the table data under a unique-or-nothing rule. PROOF: the walk consumes every one of this table's 4 records to its exact last byte, and no other shape in the format's documented grammar does. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as a fact or written to until its values are cross-checked. CORRECTION 2026-08-12: _houseRegionDataList shipped as CArray<[u8;46]>, a FIXED element width, and that was WRONG. The element ends in a CString read, so it has no constant width; the fixed value only fitted because every element string in this build is 34 bytes (12+34==46). Stage 2's candidate space contains no variable-element list shape, so it could not see the competing hypothesis and reported uniqueness inside an incomplete space. Both models tile 100% of records exactly, so the DATA cannot separate them -- the reader's disassembly can, and does. Now CArray<HouseInfo_RegionDataEntry> (u32+u32+CString). Exact tiling still holds under the corrected model, verified through CDUMM's own _consume_field_bytes.",
     "_no_null_skip": true,
     "_ordered_fields": [
       "_isBlocked",
@@ -1824,7 +1824,7 @@
       "type": "u32"
     },
     "_houseRegionDataList": {
-      "type": "CArray<[u8;46]>"
+      "type": "CArray<HouseInfo_RegionDataEntry>"
     },
     "_floorHeight": {
       "type": "u32"

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2150,5 +2150,670 @@
     "_stageInfo": {
       "type": "u32"
     }
+  },
+  "AIEventTableInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class AIEventTableInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 988 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'aieventtableinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_showName",
+      "_delegateEventHandler",
+      "_reactionLevel",
+      "_allowTypeFlag",
+      "_eventType",
+      "_isSequencerInterruptEvent",
+      "_eventDelayType",
+      "_isTargetMustExist",
+      "_isMustHandled"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_showName": {
+      "type": "CString"
+    },
+    "_delegateEventHandler": {
+      "type": "u32"
+    },
+    "_reactionLevel": {
+      "type": "u32"
+    },
+    "_allowTypeFlag": {
+      "type": "u32"
+    },
+    "_eventType": {
+      "type": "u32"
+    },
+    "_isSequencerInterruptEvent": {
+      "type": "u8"
+    },
+    "_eventDelayType": {
+      "type": "u64"
+    },
+    "_isTargetMustExist": {
+      "type": "u8"
+    },
+    "_isMustHandled": {
+      "type": "u8"
+    }
+  },
+  "UIMapTextureInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class UIMapTextureInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 2025 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'uimaptextureinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_worldPosition",
+      "_uiTemplateName",
+      "_uiTextureName",
+      "_uiSmallTextureName",
+      "_uiFilterGroupComponentName",
+      "_uiFilterTextureName",
+      "_uiMapLayerType",
+      "_mapIconType",
+      "_knowledgeInfo",
+      "_gameplayTriggerInfo",
+      "_filterGroupName",
+      "_filterGroupParentInfo",
+      "_zIndex",
+      "_isFlexibleSize",
+      "_isFlexibleIcon",
+      "_isSimpleMaterial",
+      "_tooltipText",
+      "_autoRemoveDistance",
+      "_maxScale",
+      "_minScale",
+      "_lerpIconMinSize",
+      "_lerpMinZoom",
+      "_lerpMaxZoom",
+      "_lerpSize",
+      "_changeScaleRatio",
+      "_filterType",
+      "_isShowTooltip",
+      "_isRegionKnowledgeIcon",
+      "_isUIMapQuestType",
+      "_isUIMapDebugQuestType",
+      "_isUIMapDebugQuestAreaType",
+      "_isUIMapNPCType",
+      "_isUIMapMissionType",
+      "_isActorType",
+      "_isPerspectiveIcon",
+      "_isAlwayShowMinimap",
+      "_checkHasOwnerActorIcon",
+      "_isFixScaleIconImage",
+      "_useChangeScale",
+      "_useChangeScaleWhenZoomOut",
+      "_useAutoAbyssLayer",
+      "_minimapForceUpdateIcon",
+      "_indoorStateForceShow",
+      "_otherSpaceForceShow",
+      "_isKeepShowByCharacterInfo",
+      "_isDiscoverGimmickIcon",
+      "_uiFilterGroupByInfo"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_worldPosition": {
+      "type": "[u8;12]"
+    },
+    "_uiTemplateName": {
+      "type": "u32"
+    },
+    "_uiTextureName": {
+      "type": "u32"
+    },
+    "_uiSmallTextureName": {
+      "type": "u32"
+    },
+    "_uiFilterGroupComponentName": {
+      "type": "u32"
+    },
+    "_uiFilterTextureName": {
+      "type": "u32"
+    },
+    "_uiMapLayerType": {
+      "type": "u8"
+    },
+    "_mapIconType": {
+      "type": "u32"
+    },
+    "_knowledgeInfo": {
+      "type": "u32"
+    },
+    "_gameplayTriggerInfo": {
+      "type": "u32"
+    },
+    "_filterGroupName": {
+      "type": "LocalizableString"
+    },
+    "_filterGroupParentInfo": {
+      "type": "u32"
+    },
+    "_zIndex": {
+      "type": "u32"
+    },
+    "_isFlexibleSize": {
+      "type": "u8"
+    },
+    "_isFlexibleIcon": {
+      "type": "u8"
+    },
+    "_isSimpleMaterial": {
+      "type": "u8"
+    },
+    "_tooltipText": {
+      "type": "LocalizableString"
+    },
+    "_autoRemoveDistance": {
+      "type": "u32"
+    },
+    "_maxScale": {
+      "type": "u32"
+    },
+    "_minScale": {
+      "type": "u32"
+    },
+    "_lerpIconMinSize": {
+      "type": "u32"
+    },
+    "_lerpMinZoom": {
+      "type": "u32"
+    },
+    "_lerpMaxZoom": {
+      "type": "u32"
+    },
+    "_lerpSize": {
+      "type": "u32"
+    },
+    "_changeScaleRatio": {
+      "type": "u32"
+    },
+    "_filterType": {
+      "type": "u8"
+    },
+    "_isShowTooltip": {
+      "type": "u8"
+    },
+    "_isRegionKnowledgeIcon": {
+      "type": "u8"
+    },
+    "_isUIMapQuestType": {
+      "type": "u8"
+    },
+    "_isUIMapDebugQuestType": {
+      "type": "u8"
+    },
+    "_isUIMapDebugQuestAreaType": {
+      "type": "u8"
+    },
+    "_isUIMapNPCType": {
+      "type": "u8"
+    },
+    "_isUIMapMissionType": {
+      "type": "u8"
+    },
+    "_isActorType": {
+      "type": "u8"
+    },
+    "_isPerspectiveIcon": {
+      "type": "u8"
+    },
+    "_isAlwayShowMinimap": {
+      "type": "u8"
+    },
+    "_checkHasOwnerActorIcon": {
+      "type": "u8"
+    },
+    "_isFixScaleIconImage": {
+      "type": "u8"
+    },
+    "_useChangeScale": {
+      "type": "u8"
+    },
+    "_useChangeScaleWhenZoomOut": {
+      "type": "u8"
+    },
+    "_useAutoAbyssLayer": {
+      "type": "u8"
+    },
+    "_minimapForceUpdateIcon": {
+      "type": "u8"
+    },
+    "_indoorStateForceShow": {
+      "type": "u8"
+    },
+    "_otherSpaceForceShow": {
+      "type": "u8"
+    },
+    "_isKeepShowByCharacterInfo": {
+      "type": "u8"
+    },
+    "_isDiscoverGimmickIcon": {
+      "type": "u8"
+    },
+    "_uiFilterGroupByInfo": {
+      "type": "u8"
+    }
+  },
+  "KnowledgeGroupInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class KnowledgeGroupInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 600 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'knowledgegroupinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_knowledgeGroupName",
+      "_knowledgeGroupUnknownName",
+      "_knowledgeGroupDesc",
+      "_uiTextureName",
+      "_knowledgeGroupIconPath",
+      "_uiComponentName",
+      "_knowledgeInfoList",
+      "_childKnowledgeGroupInfoList",
+      "_parentKnowledgeGroupInfo",
+      "_isShowUI",
+      "_isShowUIAlert",
+      "_isMeditationLearnable"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_knowledgeGroupName": {
+      "type": "LocalizableString"
+    },
+    "_knowledgeGroupUnknownName": {
+      "type": "LocalizableString"
+    },
+    "_knowledgeGroupDesc": {
+      "type": "LocalizableString"
+    },
+    "_uiTextureName": {
+      "type": "u32"
+    },
+    "_knowledgeGroupIconPath": {
+      "type": "u32"
+    },
+    "_uiComponentName": {
+      "type": "u32"
+    },
+    "_knowledgeInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_childKnowledgeGroupInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_parentKnowledgeGroupInfo": {
+      "type": "u32"
+    },
+    "_isShowUI": {
+      "type": "u8"
+    },
+    "_isShowUIAlert": {
+      "type": "u8"
+    },
+    "_isMeditationLearnable": {
+      "type": "u8"
+    }
+  },
+  "QuestGaugeInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class QuestGaugeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 509 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'questgaugeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_parentQuest",
+      "_startEventData",
+      "_completeEventData",
+      "_questInfoList",
+      "_targetMissionInfoList",
+      "_excludeStageInfoList",
+      "_factionInfoList",
+      "_factionNodeInfoList",
+      "_gaugeTime",
+      "_percent",
+      "_gaugeType",
+      "_progressDataList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_parentQuest": {
+      "type": "u32"
+    },
+    "_startEventData": {
+      "type": "[u8;13]"
+    },
+    "_completeEventData": {
+      "type": "[u8;13]"
+    },
+    "_questInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_targetMissionInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_excludeStageInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_factionInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_factionNodeInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_gaugeTime": {
+      "type": "u32"
+    },
+    "_percent": {
+      "type": "u64"
+    },
+    "_gaugeType": {
+      "type": "u8"
+    },
+    "_progressDataList": {
+      "type": "CArray<[u8;21]>"
+    }
+  },
+  "GameAdviceInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class GameAdviceInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 472 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'gameadviceinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_titleLocalStringInfo",
+      "_descLocalStringInfo",
+      "_keyMouseInputDescLocalStringInfo",
+      "_gameAdviceUnknownName",
+      "_uiTextureNameStringInfo",
+      "_uiVideoPathStringInfo",
+      "_narrationAudioPathStringInfo",
+      "_widgetIdStringInfo",
+      "_groupRelativeIndex",
+      "_isOnce",
+      "_isShowGuideList",
+      "_gameAdviceGroupInfo",
+      "_isDefault",
+      "_isUseLoadingView"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_titleLocalStringInfo": {
+      "type": "LocalizableString"
+    },
+    "_descLocalStringInfo": {
+      "type": "LocalizableString"
+    },
+    "_keyMouseInputDescLocalStringInfo": {
+      "type": "LocalizableString"
+    },
+    "_gameAdviceUnknownName": {
+      "type": "LocalizableString"
+    },
+    "_uiTextureNameStringInfo": {
+      "type": "u32"
+    },
+    "_uiVideoPathStringInfo": {
+      "type": "u32"
+    },
+    "_narrationAudioPathStringInfo": {
+      "type": "u32"
+    },
+    "_widgetIdStringInfo": {
+      "type": "u32"
+    },
+    "_groupRelativeIndex": {
+      "type": "u32"
+    },
+    "_isOnce": {
+      "type": "u8"
+    },
+    "_isShowGuideList": {
+      "type": "u8"
+    },
+    "_gameAdviceGroupInfo": {
+      "type": "u32"
+    },
+    "_isDefault": {
+      "type": "u8"
+    },
+    "_isUseLoadingView": {
+      "type": "u8"
+    }
+  },
+  "CategoryInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class CategoryInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 432 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'categoryinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_mainCategoryIndex",
+      "_middleCategoryIndex",
+      "_subCategoryIndex"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_mainCategoryIndex": {
+      "type": "u16"
+    },
+    "_middleCategoryIndex": {
+      "type": "u16"
+    },
+    "_subCategoryIndex": {
+      "type": "u16"
+    }
+  },
+  "GimmickGateInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class GimmickGateInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 396 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'gimmickgateinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_position",
+      "_rotation",
+      "_fieldInfo"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_position": {
+      "type": "[u8;12]"
+    },
+    "_rotation": {
+      "type": "u32"
+    },
+    "_fieldInfo": {
+      "type": "u32"
+    }
+  },
+  "gimmickgateconnection": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class GimmickGateConnectionInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 242 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'gimmickgateconnection' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_materialItemInfo",
+      "_resultItemInfo",
+      "_knowledgeInfo",
+      "_srcGateInfo",
+      "_destGateInfo",
+      "_pushKnowledgeToGimmick"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_materialItemInfo": {
+      "type": "u32"
+    },
+    "_resultItemInfo": {
+      "type": "u32"
+    },
+    "_knowledgeInfo": {
+      "type": "u32"
+    },
+    "_srcGateInfo": {
+      "type": "u32"
+    },
+    "_destGateInfo": {
+      "type": "u32"
+    },
+    "_pushKnowledgeToGimmick": {
+      "type": "u8"
+    }
+  },
+  "EquipTypeInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class EquipTypeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 112 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'equiptypeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_destroyedAiEvent",
+      "_useResourceItemType",
+      "_applyStatusGroupInfoOnActivate",
+      "_applyPassiveSkillOnActivate",
+      "_isShowStamina",
+      "_decreaseEndurancePercent",
+      "_onGuardDamageReductionPercent",
+      "_isCriticalCollidable",
+      "_enableTransfer",
+      "_enableEnchant",
+      "_useActionOnQuickSlot",
+      "_cameraPresetHash",
+      "_dyeRotationValue",
+      "_equipAbleHashList",
+      "_equipTypeName",
+      "_showHelmOnBattleStance"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_destroyedAiEvent": {
+      "type": "[u8;12]"
+    },
+    "_useResourceItemType": {
+      "type": "u32"
+    },
+    "_applyStatusGroupInfoOnActivate": {
+      "type": "u32"
+    },
+    "_applyPassiveSkillOnActivate": {
+      "type": "u8"
+    },
+    "_isShowStamina": {
+      "type": "u8"
+    },
+    "_decreaseEndurancePercent": {
+      "type": "u64"
+    },
+    "_onGuardDamageReductionPercent": {
+      "type": "u64"
+    },
+    "_isCriticalCollidable": {
+      "type": "u8"
+    },
+    "_enableTransfer": {
+      "type": "u8"
+    },
+    "_enableEnchant": {
+      "type": "u8"
+    },
+    "_useActionOnQuickSlot": {
+      "type": "u8"
+    },
+    "_cameraPresetHash": {
+      "type": "u32"
+    },
+    "_dyeRotationValue": {
+      "type": "u32"
+    },
+    "_equipAbleHashList": {
+      "type": "CArray<u32>"
+    },
+    "_equipTypeName": {
+      "type": "LocalizableString"
+    },
+    "_showHelmOnBattleStance": {
+      "type": "u8"
+    }
+  },
+  "QuestGroupInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class QuestGroupInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 42 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'questgroupinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_questType",
+      "_name",
+      "_questGroupDesc",
+      "_questList",
+      "_debugColor",
+      "_stageIconPath",
+      "_stageTextIconPath",
+      "_stageImagePath",
+      "_factionGroupInfo",
+      "_isSave",
+      "_isDev",
+      "_isAutoSave",
+      "_isCompletable"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_questType": {
+      "type": "u8"
+    },
+    "_name": {
+      "type": "LocalizableString"
+    },
+    "_questGroupDesc": {
+      "type": "LocalizableString"
+    },
+    "_questList": {
+      "type": "CArray<u32>"
+    },
+    "_debugColor": {
+      "type": "u32"
+    },
+    "_stageIconPath": {
+      "type": "u32"
+    },
+    "_stageTextIconPath": {
+      "type": "u32"
+    },
+    "_stageImagePath": {
+      "type": "u32"
+    },
+    "_factionGroupInfo": {
+      "type": "u16"
+    },
+    "_isSave": {
+      "type": "u8"
+    },
+    "_isDev": {
+      "type": "u8"
+    },
+    "_isAutoSave": {
+      "type": "u8"
+    },
+    "_isCompletable": {
+      "type": "u8"
+    }
+  },
+  "AIActionAttributeInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class AIActionAttributeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 2 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'aiactionattributeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_passiveSkillKeyList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_passiveSkillKeyList": {
+      "type": "CArray<u64>"
+    }
   }
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -1844,5 +1844,171 @@
     "_prefabPath": {
       "type": "CString"
     }
+  },
+  "factiongroup": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class FactionGroupInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 7 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'factiongroup' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_factionGroupName",
+      "_factionInfoList",
+      "_knowledgeInfo",
+      "_uiIconPath",
+      "_uiDailyQuestImagePath"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_factionGroupName": {
+      "type": "LocalizableString"
+    },
+    "_factionInfoList": {
+      "type": "CArray<u32>"
+    },
+    "_knowledgeInfo": {
+      "type": "u32"
+    },
+    "_uiIconPath": {
+      "type": "u32"
+    },
+    "_uiDailyQuestImagePath": {
+      "type": "u32"
+    }
+  },
+  "uisocialaction": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class UISocialActionInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 2 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'uisocialaction' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_name",
+      "_description",
+      "_quickSlotUiTabIndex",
+      "_quickSlotUiIndex"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_name": {
+      "type": "LocalizableString"
+    },
+    "_description": {
+      "type": "LocalizableString"
+    },
+    "_quickSlotUiTabIndex": {
+      "type": "u8"
+    },
+    "_quickSlotUiIndex": {
+      "type": "u8"
+    }
+  },
+  "CraftToolInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class CraftToolInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 19 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'crafttoolinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_craftToolGroupInfo",
+      "_failItem",
+      "_ingredientsItemGroupInfo"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_craftToolGroupInfo": {
+      "type": "u16"
+    },
+    "_failItem": {
+      "type": "u32"
+    },
+    "_ingredientsItemGroupInfo": {
+      "type": "CArray<u16>"
+    }
+  },
+  "CraftToolGroupInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class CraftToolGroupInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 12 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'crafttoolgroupinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_craftToolInfoList",
+      "_craftToolType",
+      "_ignoreReduceMaterialCountBuff",
+      "_materialInventoryInfoList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_craftToolInfoList": {
+      "type": "CArray<u16>"
+    },
+    "_craftToolType": {
+      "type": "u8"
+    },
+    "_ignoreReduceMaterialCountBuff": {
+      "type": "u8"
+    },
+    "_materialInventoryInfoList": {
+      "type": "CArray<u16>"
+    }
+  },
+  "factionreblockadinginfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class FactionReblockadingInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 108 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'factionreblockadinginfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_reoccupationQuestDataList",
+      "_factionNodeList",
+      "_delayTime",
+      "_protectCombatPower"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_reoccupationQuestDataList": {
+      "type": "CArray<[u8;20]>"
+    },
+    "_factionNodeList": {
+      "type": "CArray<u32>"
+    },
+    "_delayTime": {
+      "type": "u32"
+    },
+    "_protectCombatPower": {
+      "type": "u32"
+    }
+  },
+  "globalgameeventgroup": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class GlobalGameEventGroupInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 12 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'globalgameeventgroup' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_defaultOption",
+      "_globalGameEventUpdateOption",
+      "_globalGameEventInfoList",
+      "_fieldInfo",
+      "_updateType"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_defaultOption": {
+      "type": "[u8;24]"
+    },
+    "_globalGameEventUpdateOption": {
+      "type": "CArray<[u8;24]>"
+    },
+    "_globalGameEventInfoList": {
+      "type": "CArray<u16>"
+    },
+    "_fieldInfo": {
+      "type": "u32"
+    },
+    "_updateType": {
+      "type": "u8"
+    }
   }
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2010,5 +2010,36 @@
     "_updateType": {
       "type": "u8"
     }
+  },
+  "MaterialMatchInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class MaterialMatchInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 116 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'materialmatchinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_effectWeaponKeyHash",
+      "_effectArmorKeyHash",
+      "_soundWeaponKeyHash",
+      "_soundArmorKeyHash",
+      "_physicsMaterialName"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_effectWeaponKeyHash": {
+      "type": "u32"
+    },
+    "_effectArmorKeyHash": {
+      "type": "u32"
+    },
+    "_soundWeaponKeyHash": {
+      "type": "u32"
+    },
+    "_soundArmorKeyHash": {
+      "type": "u32"
+    },
+    "_physicsMaterialName": {
+      "type": "CString"
+    }
   }
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -1140,10 +1140,10 @@
     }
   },
   "WantedInfo": {
-    "_meta_note": "Verified-only pass 2026-07-03. Only _increasePrice is validated: read as u64 at payload offset 0 (the default entry header consumes exactly key(2)+name_len(4, always 0)+null(1) = 7 bytes on every record, landing on the price). Values track the wanted tier — 30/50/100/500/1500 gold, consistent across all 5 key groups. _isBlocked/_useTargetPrice are all-zero in shipped data except one toggling flag byte whose name mapping can't be proven from the files alone (the field defs live only in the exe), so they are listed but gated as unverified rather than guessed. _stringKey (untyped in the base schema) stays dropped.",
+    "_meta_note": "Verified-only pass 2026-07-03. Only _increasePrice is validated: read as u64 at payload offset 0 (the default entry header consumes exactly key(2)+name_len(4, always 0)+null(1) = 7 bytes on every record, landing on the price). Values track the wanted tier — 30/50/100/500/1500 gold, consistent across all 5 key groups. _isBlocked/_useTargetPrice are all-zero in shipped data except one toggling flag byte whose name mapping can't be proven from the files alone (the field defs live only in the exe), so they are listed but gated as unverified rather than guessed. _stringKey (untyped in the base schema) stays dropped. CORRECTION 2026-08-13: the field ORDER was wrong and the entry header was mis-measured, and the two errors cancelled on the one field that mattered. There is no trailing NUL -- the name is EMPTY on every record, so there is nothing to terminate, and the byte read as a NUL at payload offset 6 is _isBlocked. Order is now _isBlocked, _increasePrice, _useTargetPrice with _no_null_skip, which accounts for all 16 bytes of every record: header 6, _isBlocked at 6, _increasePrice at 7..14, _useTargetPrice at 15. The previous model tiled 0 of 35 records (it ran _useTargetPrice to offset 16, one past the record) while still placing _increasePrice at 7, which is why the verified-only pass read the right values. _increasePrice's offset is UNCHANGED at 7, so no mod that edits it behaves differently; the note's own 30/50/100/500/1500 are exactly what the corrected walk reads. Found by the field_reads order oracle (hot-path branch order), which had WantedInfo as one of 3 tables out of 40 disagreeing with its shipped order; exact tiling could not see it because 1+8+1 and 8+1+1 both consume 10 bytes.",
     "_ordered_fields": [
-      "_increasePrice",
       "_isBlocked",
+      "_increasePrice",
       "_useTargetPrice"
     ],
     "_verified_fields": [
@@ -1157,7 +1157,8 @@
     },
     "_useTargetPrice": {
       "type": "u8"
-    }
+    },
+    "_no_null_skip": true
   },
   "AIDialogTypeInfo": {
     "_meta_note": "Derived 2026-08-11 from game buildid 24613230 by tools/derive_table_layout.py. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block (tools/extract_field_order_win.py). Field WIDTHS come from the sized reads in the deserializer, with count-prefixed list element widths solved against the table data under a unique-or-nothing rule. PROOF: the walk consumes every one of this table's 108 records to its exact last byte, and no other shape in the format's documented grammar does. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as a fact or written to until its values are cross-checked.",

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2041,5 +2041,113 @@
     "_physicsMaterialName": {
       "type": "CString"
     }
+  },
+  "FieldLevelNameTableInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class FieldLevelNameTableInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS from the sized reads in the deserializer; count-prefixed list element widths from the loop body via Deriver.list_element. PROOF: the walk consumes every one of this table's 2 records to its exact last byte. KEYED BY FILE STEM 'fieldlevelnametableinfo' because that is what identify_table_from_path returns and what get_schema is asked for. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means. _levelNameInfoDataList is a list whose ELEMENT has no constant width, so it is CArray<FieldLevelNameTableInfo_KeyEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_fieldLevelName",
+      "_levelNameInfoDataList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_fieldLevelName": {
+      "type": "CString"
+    },
+    "_levelNameInfoDataList": {
+      "type": "CArray<FieldLevelNameTableInfo_KeyEntry>"
+    }
+  },
+  "PartPrefabDyeTexturePalleteInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class PartPrefabDyeTexturePalleteInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS from the sized reads in the deserializer; count-prefixed list element widths from the loop body via Deriver.list_element. PROOF: the walk consumes every one of this table's 11 records to its exact last byte. KEYED BY FILE STEM 'partprefabdyetexturepalleteinfo' because that is what identify_table_from_path returns and what get_schema is asked for. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means. _textureSetArray is a list whose ELEMENT has no constant width, so it is CArray<PartPrefabDyeTexturePalleteInfo_KeyEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_textureSetIndex",
+      "_textureSetArray"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_textureSetIndex": {
+      "type": "u32"
+    },
+    "_textureSetArray": {
+      "type": "CArray<PartPrefabDyeTexturePalleteInfo_KeyEntry>"
+    }
+  },
+  "RelationInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class RelationInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS from the sized reads in the deserializer; count-prefixed list element widths from the loop body via Deriver.list_element. PROOF: the walk consumes every one of this table's 52 records to its exact last byte. KEYED BY FILE STEM 'relationinfo' because that is what identify_table_from_path returns and what get_schema is asked for. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means. _gimmickTagDataList is a list whose ELEMENT has no constant width, so it is CArray<RelationInfo_KeyEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_relationReactionType",
+      "_order",
+      "_detectRestrictCount",
+      "_detectMemorizeTime",
+      "_doCompleteNotPriorityActor",
+      "_detectValueRatio",
+      "_isDetectEventOnly",
+      "_gimmickTagDataList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_relationReactionType": {
+      "type": "u8"
+    },
+    "_order": {
+      "type": "u8"
+    },
+    "_detectRestrictCount": {
+      "type": "u8"
+    },
+    "_detectMemorizeTime": {
+      "type": "u64"
+    },
+    "_doCompleteNotPriorityActor": {
+      "type": "u8"
+    },
+    "_detectValueRatio": {
+      "type": "u32"
+    },
+    "_isDetectEventOnly": {
+      "type": "u8"
+    },
+    "_gimmickTagDataList": {
+      "type": "CArray<RelationInfo_KeyEntry>"
+    }
+  },
+  "royalsupply": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class RoyalSupplyInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS from the sized reads in the deserializer; count-prefixed list element widths from the loop body via Deriver.list_element. PROOF: the walk consumes every one of this table's 4 records to its exact last byte. KEYED BY FILE STEM 'royalsupply' because that is what identify_table_from_path returns and what get_schema is asked for. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means. _Quest is a list whose ELEMENT has no constant width, so it is CArray<RoyalSupplyInfo_QuestEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning. _Mission is a list whose ELEMENT has no constant width, so it is CArray<RoyalSupplyInfo_QuestEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_Quest",
+      "_Mission",
+      "_defaultRandomList",
+      "_stageInfo"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_Quest": {
+      "type": "CArray<RoyalSupplyInfo_QuestEntry>"
+    },
+    "_Mission": {
+      "type": "CArray<RoyalSupplyInfo_QuestEntry>"
+    },
+    "_defaultRandomList": {
+      "type": "CArray<[u8;20]>"
+    },
+    "_stageInfo": {
+      "type": "u32"
+    }
   }
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2815,5 +2815,20 @@
     "_passiveSkillKeyList": {
       "type": "CArray<u64>"
     }
+  },
+  "factionwaypoint": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class FactionWayPointInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block, with function bounds taken from .pdata unwind chains. Struct- and list-shaped fields whose width is NOT constant are described as substructs built from the reader's own read sequence (Deriver.reader_parts / element_parts), which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. PROOF: the walk consumes every one of this table's 475 records to its exact last byte. KEYED BY FILE STEM 'factionwaypoint' because that is what identify_table_from_path returns. Substruct member names are ANONYMOUS on purpose: the parts give structure and say nothing about meaning. _verified_fields is EMPTY.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_wayPointData"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_wayPointData": {
+      "type": "FactionWayPointInfo_wayPointData"
+    }
   }
 }

--- a/src/cdumm/semantic/pabgb_types.py
+++ b/src/cdumm/semantic/pabgb_types.py
@@ -403,6 +403,35 @@ SUBSTRUCT_DEFS: dict[str, list[tuple[str, str]]] = {
         ("key", "u32"),
         ("message", "LocalizableString"),
     ],
+    # ── Derived variable-length list elements (2026-08-12) ──────────────
+    # Members come from each reader's own loop body via
+    # Deriver.element_parts. Names are anonymous: structure is
+    # derived, meaning is not, so nothing here may be gated to
+    # _verified_fields on the strength of a name.
+    "RoyalSupplyInfo_QuestEntry": [  # sub_1412A1370 element
+        ("u32", "u32"),
+        ("list", "CArray<[u8;20]>"),
+    ],
+    "RelationInfo_KeyEntry": [  # sub_1412A1970 element
+        ("u32", "u32"),
+        ("list", "CArray<u32>"),
+        ("list_2", "CArray<u32>"),
+    ],
+    "PartPrefabDyeTexturePalleteInfo_KeyEntry": [  # sub_1412A3630 element
+        ("name", "CString"),
+        ("name_2", "CString"),
+        ("name_3", "CString"),
+        ("name_4", "CString"),
+        ("u32", "u32"),
+    ],
+    "FieldLevelNameTableInfo_KeyEntry": [  # sub_1412A69D0 element
+        ("u32", "u32"),
+        ("u32_2", "u32"),
+        ("name", "CString"),
+        ("u8", "u8"),
+        ("blob", "[u8;12]"),
+        ("blob_2", "[u8;12]"),
+    ],
 }
 
 

--- a/src/cdumm/semantic/pabgb_types.py
+++ b/src/cdumm/semantic/pabgb_types.py
@@ -403,6 +403,18 @@ SUBSTRUCT_DEFS: dict[str, list[tuple[str, str]]] = {
         ("key", "u32"),
         ("message", "LocalizableString"),
     ],
+
+    # ── A struct-shaped FIELD reader (2026-08-13) ──────────────────────────
+    # Not a list element: _wayPointData is a single struct whose width is not
+    # constant, because it ends in a counted list. Members come from
+    # sub_1412C1A50's own read sequence via Deriver.reader_parts, the
+    # whole-function analogue of element_parts. Names are anonymous:
+    # structure is derived, meaning is not.
+    "FactionWayPointInfo_wayPointData": [
+        ("u32", "u32"),
+        ("u32_2", "u32"),
+        ("list", "CArray<[u8;12]>"),
+    ],
     # ── Derived variable-length list elements (2026-08-12) ──────────────
     # Members come from each reader's own loop body via
     # Deriver.element_parts. Names are anonymous: structure is

--- a/src/cdumm/semantic/pabgb_types.py
+++ b/src/cdumm/semantic/pabgb_types.py
@@ -372,6 +372,37 @@ SUBSTRUCT_DEFS: dict[str, list[tuple[str, str]]] = {
         ("domain_faction", "u32"),
         ("prison_stage", "u32"),
     ],
+    # ── Corrections to two derived tables shipped in v3.13 ─────────────────
+    # Both were shipped as CArray of a FIXED-width element, and both were
+    # wrong. Stage 2 of tools/derive_table_layout.py recovers a list's
+    # element width by fitting the table data, and its candidate space
+    # contains only fixed-width elements -- there is no variable-element list
+    # shape in it. So for a list whose element ends in a string, a constant
+    # width can fit, and "unique-or-nothing" then reports uniqueness inside a
+    # space that never held the competing hypothesis.
+    #
+    # It fit because every string in THIS build happens to be one length:
+    #   HouseInfo         all 7 element strings are 34 bytes -> 12+34 == 46
+    #   FailMessageInfo   all 18 element strings are 16 bytes -> 17+16 == 33
+    # Both the fixed and the variable model tile 100% of records exactly, so
+    # the data cannot distinguish them; the disassembly can, and does.
+    #
+    # Caveat that survives this fix: exact tiling constrains the element's
+    # TOTAL consumption, so a reordering of the two same-width u32s below
+    # would be invisible to it. The order is the loop body's call order.
+    "HouseInfo_RegionDataEntry": [
+        # sub_1412A8A50 element: sub_14129CD10 (4B) + sub_141297490 (4B)
+        # + sub_1411A31F0 (CString) = 12 + n
+        ("u32_a", "u32"),
+        ("u32_b", "u32"),
+        ("name", "CString"),
+    ],
+    "FailMessageInfo_Entry": [
+        # sub_1412AABF0 element: sub_141296000 (4B)
+        # + sub_141071DE0 (LocalizableString) = 17 + n
+        ("key", "u32"),
+        ("message", "LocalizableString"),
+    ],
 }
 
 

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -49,6 +49,7 @@ DERIVED = {
     "JobInfo": 209,
     "LocalStringInfo": 43863,
     "MaterialRelationInfo": 11,
+    "MaterialMatchInfo": 116,
     "VibratePatternInfo": 28,
     "CharacterAppearanceIndexInfo": 8344,
     "MercenaryInfo": 21,

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -86,6 +86,23 @@ DERIVED = {
     "PartPrefabDyeTexturePalleteInfo": 11,
     "RelationInfo": 52,
     "royalsupply": 4,
+    # ── added 2026-08-13: the .pdata function-bounds sweep ───────────────
+    # These became derivable when field_reads stopped sweeping from an
+    # arbitrary byte. capstone's disasm is a generator that STOPS at the
+    # first undecodable byte, so the old sweep truncated -- on these tables
+    # it died before the first field. All eleven are FULLY STATIC: no width
+    # came from a data search.
+    "AIEventTableInfo": 988,
+    "UIMapTextureInfo": 2025,
+    "KnowledgeGroupInfo": 600,
+    "QuestGaugeInfo": 509,
+    "GameAdviceInfo": 472,
+    "CategoryInfo": 432,
+    "GimmickGateInfo": 396,
+    "gimmickgateconnection": 242,
+    "EquipTypeInfo": 112,
+    "QuestGroupInfo": 42,
+    "AIActionAttributeInfo": 2,
 }
 
 

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -237,3 +237,57 @@ def test_the_correction_is_documented_in_the_provenance(key):
     assert "CORRECTION" in note, (
         f"{table} was shipped with a wrong element width; its note must "
         f"record the correction so the history is not lost")
+
+
+# ── WantedInfo: the phantom trailing NUL ─────────────────────────────────
+#
+# WantedInfo shipped with `_ordered_fields` starting at `_increasePrice` and
+# with the default (NUL-skipping) entry header. That model tiles 0 of 35
+# records: it places _useTargetPrice at offset 16, one byte past the end of a
+# 16-byte record. It nonetheless read the right prices, because the wrong
+# order and the mis-measured header cancelled on the one field that mattered
+# -- _increasePrice sat at offset 7 either way, which is why the
+# verified-only pass recorded 30/50/100/500/1500 correctly.
+#
+# There is no trailing NUL. The name is EMPTY on every record, so there is
+# nothing to terminate; the byte at payload offset 6 is _isBlocked, which is
+# the first field of essentially every table in this format. With
+# _no_null_skip and _isBlocked first, all 16 bytes are accounted for on all
+# 35 records: header 6, _isBlocked at 6, _increasePrice at 7..14,
+# _useTargetPrice at 15.
+#
+# Exact tiling could NOT catch this: 1+8+1 and 8+1+1 both consume 10 bytes.
+# The order oracle caught it -- field_reads' hot-path branch order had
+# WantedInfo as one of 3 tables out of 40 disagreeing with its shipped order.
+
+def test_wantedinfo_puts_isblocked_first_and_skips_no_null():
+    w = _overrides()["WantedInfo"]
+    assert w["_ordered_fields"] == [
+        "_isBlocked", "_increasePrice", "_useTargetPrice"], (
+        "WantedInfo's order regressed; _increasePrice-first tiles 0 of 35 "
+        "records because _useTargetPrice then lands past the record end")
+    assert w.get("_no_null_skip") is True, (
+        "WantedInfo has no trailing NUL to skip -- its names are empty, and "
+        "the byte previously skipped as one is _isBlocked")
+
+
+def test_wantedinfo_price_offset_is_unchanged_by_the_correction():
+    """The correction must not move the one writable field.
+
+    `_increasePrice` is the only entry in `_verified_fields`, so it is the
+    only field a mod can edit here. Under both the old and the corrected
+    model it sits at offset 7 (old: 7-byte header + field 0; new: 6-byte
+    header + 1-byte _isBlocked). If that ever stops being true, existing
+    mods start writing somewhere else.
+    """
+    w = _overrides()["WantedInfo"]
+    assert w["_verified_fields"] == ["_increasePrice"]
+    header = 2 + 4                      # key_size 2, name_len u32, name empty
+    order = w["_ordered_fields"]
+    widths = {"u8": 1, "u16": 2, "u32": 4, "u64": 8}
+    off = header
+    for name in order:
+        if name == "_increasePrice":
+            break
+        off += widths[w[name]["type"]]
+    assert off == 7, f"_increasePrice moved to offset {off}, must stay at 7"

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -103,6 +103,13 @@ DERIVED = {
     "EquipTypeInfo": 112,
     "QuestGroupInfo": 42,
     "AIActionAttributeInfo": 2,
+    # ── added 2026-08-13: a struct-shaped FIELD reader ────────────────────
+    # _wayPointData is a single struct, not a list element, whose width is
+    # not constant because it ends in a counted list. Decomposed by
+    # Deriver.reader_parts. Two sibling tables were built the same way and
+    # ROLLED BACK for tiling 0 records, which is the distinction that
+    # matters: decomposable is not the same as correct.
+    "factionwaypoint": 475,
 }
 
 

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -138,3 +138,75 @@ def test_the_derivation_provenance_is_recorded():
             f"against")
         assert "_verified_fields is EMPTY" in note, (
             f"{table} note must state why it is gated")
+
+
+# ── the fixed-vs-variable list element trap ──────────────────────────────
+#
+# Two entries shipped in v3.13 described a list element as a FIXED width when
+# the element actually ends in a string. Stage 2 recovers an element width by
+# fitting the table data, and `Deriver.candidates()` offers only fixed-width
+# elements -- there is no variable-element list shape in that space. So for
+# these two the search could not see the competing hypothesis, and
+# "unique-or-nothing" reported uniqueness inside an incomplete space.
+#
+# It fitted because every string in this build happens to be one length:
+#   HouseInfo        7 element strings, all 34 bytes -> 12 + 34 == 46
+#   FailMessageInfo 18 element strings, all 16 bytes -> 17 + 16 == 33
+# Both the fixed and the variable model tile 100% of records EXACTLY, so no
+# amount of data from this build separates them. The reader's disassembly
+# does: the element makes a CString / LocalizableString read.
+#
+# These pin the corrected shape so the wrong one cannot come back. A future
+# derivation re-running stage 2 on a build where the strings are still
+# uniform would fit the fixed width again and look perfectly proven.
+
+#: field -> (struct descriptor it must use, the fixed width it must NOT use)
+_VARIABLE_ELEMENT_LISTS = {
+    ("HouseInfo", "_houseRegionDataList"):
+        ("CArray<HouseInfo_RegionDataEntry>", "CArray<[u8;46]>"),
+    ("FailMessageInfo", "_failMessageInfoList"):
+        ("CArray<FailMessageInfo_Entry>", "CArray<[u8;33]>"),
+}
+
+
+@pytest.mark.parametrize("key", sorted(_VARIABLE_ELEMENT_LISTS))
+def test_variable_length_list_elements_are_not_modelled_as_fixed(key):
+    table, field = key
+    want, forbidden = _VARIABLE_ELEMENT_LISTS[key]
+    got = _overrides()[table][field]["type"]
+    assert got != forbidden, (
+        f"{table}.{field} is back to {forbidden}. That width only fits "
+        f"because every element string in the measured build was one "
+        f"length; the element is variable and this will mis-frame the "
+        f"record as soon as one string differs.")
+    assert got == want, (
+        f"{table}.{field} must be {want}, got {got}")
+
+
+@pytest.mark.parametrize("key", sorted(_VARIABLE_ELEMENT_LISTS))
+def test_the_corrected_element_structs_end_in_a_string(key):
+    """The correction is only meaningful if the struct really is variable.
+
+    A struct of fixed members would reintroduce the same bug wearing a
+    name, so this checks the last member is a string type rather than
+    trusting the descriptor's label.
+    """
+    from cdumm.semantic.pabgb_types import SUBSTRUCT_DEFS
+    want, _forbidden = _VARIABLE_ELEMENT_LISTS[key]
+    name = want[len("CArray<"):-1]
+    assert name in SUBSTRUCT_DEFS, f"{name} is not defined"
+    members = SUBSTRUCT_DEFS[name]
+    assert members, f"{name} has no members"
+    assert members[-1][1] in ("CString", "LocalizableString"), (
+        f"{name} must end in a variable-length string read; its last "
+        f"member is {members[-1]!r}. If it does not, the element has a "
+        f"constant width and the original CArray<[u8;N]> was right.")
+
+
+@pytest.mark.parametrize("key", sorted(_VARIABLE_ELEMENT_LISTS))
+def test_the_correction_is_documented_in_the_provenance(key):
+    table, _field = key
+    note = _overrides()[table].get("_meta_note", "")
+    assert "CORRECTION" in note, (
+        f"{table} was shipped with a wrong element width; its note must "
+        f"record the correction so the history is not lost")

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -76,6 +76,16 @@ DERIVED = {
     "uisocialaction": 2,
     "factionreblockadinginfo": 108,
     "globalgameeventgroup": 12,
+    # ── added 2026-08-12: variable-length list elements ──────────────────
+    # Each of these has a CArray whose ELEMENT has no constant width, so it
+    # is CArray<Substruct>, with the members taken from the reader's own
+    # loop body. All four are FULLY STATIC -- no width came from a data
+    # search -- which is what makes a 2-record or 4-record table acceptable
+    # here: the data confirmed the layout, it did not referee it.
+    "FieldLevelNameTableInfo": 2,
+    "PartPrefabDyeTexturePalleteInfo": 11,
+    "RelationInfo": 52,
+    "royalsupply": 4,
 }
 
 

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -59,6 +59,22 @@ DERIVED = {
     "FactionOperationGroupInfo": 9,
     "HouseInfo": 4,
     "ZoneInfo": 6,
+    # ── added 2026-08-12 ──────────────────────────────────────────────────
+    # The KEY is the base schema's key, and its lowercase must equal the
+    # table's FILE STEM, because _load_schemas iterates the base file and
+    # the app asks get_schema() for the stem that
+    # identify_table_from_path returns. So the casing here is not sloppy
+    # and must not be "tidied": CraftToolInfo reuses the base schema's
+    # existing key, while the five lowercase ones are new base entries
+    # keyed by a stem that drops the `Info` the class name carries
+    # (factiongroup.pabgb <-> FactionGroupInfo). Rename any of them to the
+    # class name and CDUMM silently stops finding that table.
+    "CraftToolInfo": 19,
+    "CraftToolGroupInfo": 12,
+    "factiongroup": 7,
+    "uisocialaction": 2,
+    "factionreblockadinginfo": 108,
+    "globalgameeventgroup": 12,
 }
 
 

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -51,7 +51,8 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            "DetectInfo", "DialogVoiceInfo", "FailMessageInfo",
            "GameAdviceGroupInfo", "GamePlayVariableInfo",
            "GimmickEventTableInfo", "JobInfo", "LocalStringInfo",
-           "MaterialRelationInfo", "VibratePatternInfo",
+           "MaterialRelationInfo", "MaterialMatchInfo",
+           "VibratePatternInfo",
            "CharacterAppearanceIndexInfo", "MercenaryInfo",
            "SocketInfo", "TerrainRegionNaviInfo",
            "AIMemoryInfo", "ContentsPhaseInfo",
@@ -71,7 +72,7 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 35 deliberately: the 28 in DERIVED have an
+    It grew from 7 to 36 deliberately: the 29 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -80,7 +81,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 35
+    assert len(tabs) == 36
 
 
 def test_ground_truth_passes_itself():

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -66,13 +66,16 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            # the class name makes CDUMM stop finding the table.
            "CraftToolInfo", "CraftToolGroupInfo",
            "factiongroup", "uisocialaction",
-           "factionreblockadinginfo", "globalgameeventgroup"}
+           "factionreblockadinginfo", "globalgameeventgroup",
+           # Variable-length list elements, shipped as CArray<Substruct>.
+           "FieldLevelNameTableInfo", "PartPrefabDyeTexturePalleteInfo",
+           "RelationInfo", "royalsupply"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 36 deliberately: the 29 in DERIVED have an
+    It grew from 7 to 40 deliberately: the 33 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -81,7 +84,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 36
+    assert len(tabs) == 40
 
 
 def test_ground_truth_passes_itself():

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -69,13 +69,15 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            "factionreblockadinginfo", "globalgameeventgroup",
            # Variable-length list elements, shipped as CArray<Substruct>.
            "FieldLevelNameTableInfo", "PartPrefabDyeTexturePalleteInfo",
-           "RelationInfo", "royalsupply"}
+           "RelationInfo", "royalsupply",
+           # Unlocked by the .pdata function-bounds sweep (2026-08-13).
+           "AIEventTableInfo", "UIMapTextureInfo", "KnowledgeGroupInfo", "QuestGaugeInfo", "GameAdviceInfo", "CategoryInfo", "GimmickGateInfo", "gimmickgateconnection", "EquipTypeInfo", "QuestGroupInfo", "AIActionAttributeInfo"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 40 deliberately: the 33 in DERIVED have an
+    It grew from 7 to 51 deliberately: the 44 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -84,7 +86,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 40
+    assert len(tabs) == 51
 
 
 def test_ground_truth_passes_itself():

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -71,13 +71,14 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            "FieldLevelNameTableInfo", "PartPrefabDyeTexturePalleteInfo",
            "RelationInfo", "royalsupply",
            # Unlocked by the .pdata function-bounds sweep (2026-08-13).
-           "AIEventTableInfo", "UIMapTextureInfo", "KnowledgeGroupInfo", "QuestGaugeInfo", "GameAdviceInfo", "CategoryInfo", "GimmickGateInfo", "gimmickgateconnection", "EquipTypeInfo", "QuestGroupInfo", "AIActionAttributeInfo"}
+           "AIEventTableInfo", "UIMapTextureInfo", "KnowledgeGroupInfo", "QuestGaugeInfo", "GameAdviceInfo", "CategoryInfo", "GimmickGateInfo", "gimmickgateconnection", "EquipTypeInfo", "QuestGroupInfo", "AIActionAttributeInfo",
+           "factionwaypoint"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 51 deliberately: the 44 in DERIVED have an
+    It grew from 7 to 52 deliberately: the 45 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -86,7 +87,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 51
+    assert len(tabs) == 52
 
 
 def test_ground_truth_passes_itself():

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -56,13 +56,22 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            "SocketInfo", "TerrainRegionNaviInfo",
            "AIMemoryInfo", "ContentsPhaseInfo",
            "FactionOperationGroupInfo", "HouseInfo",
-           "ZoneInfo"}
+           "ZoneInfo",
+           # Added 2026-08-12. The lowercase names are deliberate: an
+           # override key must match the base schema key exactly, and its
+           # lowercase must equal the table's FILE STEM, which for these
+           # drops the `Info` the reflection class keeps
+           # (factiongroup.pabgb <-> FactionGroupInfo). Renaming them to
+           # the class name makes CDUMM stop finding the table.
+           "CraftToolInfo", "CraftToolGroupInfo",
+           "factiongroup", "uisocialaction",
+           "factionreblockadinginfo", "globalgameeventgroup"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 29 deliberately: the 22 in DERIVED have an
+    It grew from 7 to 35 deliberately: the 28 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -71,7 +80,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 29
+    assert len(tabs) == 35
 
 
 def test_ground_truth_passes_itself():

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -666,6 +666,25 @@ def load_table(game: Path, stem: str):
     return body, sorted(offsets.items(), key=lambda kv: kv[1]), key_size
 
 
+def _carries_table_list(p: Path) -> bool:
+    """Does this file actually carry the table list we need?
+
+    Checked by CONTENT rather than by name. Matching on the filename is
+    what broke here in the first place, and a candidate that opens as
+    SQLite but has no ``data_tables`` is no use to us either.
+    """
+    import sqlite3
+    try:
+        con = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+        try:
+            con.execute("SELECT 1 FROM data_tables LIMIT 1").fetchone()
+            return True
+        finally:
+            con.close()
+    except Exception:                                # noqa: BLE001
+        return False
+
+
 def find_index(explicit: Path | None = None) -> Path | None:
     """The game index CDUMM's Game Data tab builds, newest first.
 
@@ -673,6 +692,17 @@ def find_index(explicit: Path | None = None) -> Path | None:
     has re-indexed since a patch keeps the previous one and the table LIST
     barely changes between builds -- it is only used to enumerate
     candidates, never to read bytes.
+
+    The glob is ``game_index*``, not ``game_index*.sqlite*``. The live
+    index is ``game_index.sqlite``, but the rotated copy is
+    ``game_index.<timestamp>.bak`` -- the timestamp REPLACES the
+    extension rather than following it, so the narrower glob could never
+    match the very ``.bak`` files this docstring claimed to accept. The
+    symptom was "No game index found under %LOCALAPPDATA%/cdumm" on a
+    machine that had one sitting right there.
+
+    Widening the glob means candidates must be validated, so each is
+    opened and checked for the table it is wanted for.
     """
     import os
     if explicit:
@@ -683,9 +713,9 @@ def find_index(explicit: Path | None = None) -> Path | None:
     d = Path(local) / "cdumm"
     if not d.is_dir():
         return None
-    cands = sorted(d.glob("game_index*.sqlite*"),
+    cands = sorted((p for p in d.glob("game_index*") if p.is_file()),
                    key=lambda p: p.stat().st_mtime, reverse=True)
-    return cands[0] if cands else None
+    return next((p for p in cands if _carries_table_list(p)), None)
 
 
 def table_stems(index: Path) -> list[str]:

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -955,6 +955,101 @@ class Deriver:
                    f"{fixed_before + bad[1] + 4} + n")
         return ("variable", why)
 
+    def reader_parts(self, va: int, seen: frozenset | None = None):
+        """A whole FIELD reader's members in program order, or None.
+
+        The function-body analogue of ``element_parts``, for a field whose
+        reader is a struct rather than a list. Same idea and the same
+        acceptance rule: keep the sequence rather than only a sum, so a
+        reader with no constant width is still describable as a substruct.
+
+        Refuses, rather than guessing, on:
+          * RECURSION -- actionpointinfo's ``_actionPoint`` (sub_141271150)
+            and sub_1412B1220 call each other, so the field is a TREE. That
+            is not expressible as a flat substruct at all, and it is the
+            honest ceiling for that table's 28,958 records on this route.
+          * an UNSIZED read that is not part of a length-prefixed pair.
+          * any sub-reader that cannot itself be modelled or decomposed.
+
+        The one pattern it does resolve beyond the obvious: a 4-byte read
+        IMMEDIATELY followed by an unsized read is a length prefix and its
+        bytes -- i.e. a CString. solve_reader only recognises that when the
+        4-byte read is the reader's FIRST, which is why a struct with
+        several fields before its string was refused. Measured: this rule
+        takes decomposable tables from 17 to 20.
+
+        Structure only. Nothing here says what a member MEANS.
+        """
+        from capstone import CS_OP_IMM, CS_OP_MEM, CS_OP_REG
+        seen = frozenset() if seen is None else seen
+        if va in seen or len(seen) > 6:
+            return None
+        ins = self.body(va)
+        if not ins:
+            return None
+        # A loop that encloses a read makes this a list or worse; leave those
+        # to list_element rather than flattening them here.
+        addr_i = {x.address: k for k, x in enumerate(ins)}
+        ranges = []
+        for n, i in enumerate(ins):
+            o = i.operands
+            if (i.mnemonic.startswith("j") and len(o) == 1
+                    and o[0].type == CS_OP_IMM and o[0].imm < i.address
+                    and o[0].imm in addr_i
+                    and self.closes_cycle(ins, n, o[0].imm)):
+                ranges.append((addr_i[o[0].imm], n))
+
+        out: list = []
+        pend = None
+        pend_var = False
+        last_was_4 = False
+        for n, i in enumerate(ins):
+            o = i.operands
+            dst = i.op_str.split(",")[0].strip()
+            if (i.mnemonic in ("mov", "lea") and len(o) == 2
+                    and o[0].type == CS_OP_REG and "r8" in dst):
+                if o[1].type == CS_OP_IMM:
+                    pend, pend_var = o[1].imm, False
+                elif (i.mnemonic == "lea" and o[1].type == CS_OP_MEM
+                      and o[1].mem.index == 0 and o[1].mem.disp >= 0):
+                    pend, pend_var = o[1].mem.disp, False
+                else:
+                    pend, pend_var = None, True
+                continue
+            if i.mnemonic != "call" or len(o) != 1:
+                continue
+            in_loop = any(lo <= n <= hi for lo, hi in ranges)
+            if o[0].type == CS_OP_MEM:
+                if in_loop:
+                    return None            # a read inside a loop: not flat
+                if pend is not None:
+                    out.append(("fixed", pend))
+                    last_was_4 = (pend == 4)
+                elif pend_var and last_was_4 and out:
+                    out[-1] = ("str", 0)   # u32 length + that many bytes
+                    last_was_4 = False
+                else:
+                    return None            # unsized read we cannot size
+            elif o[0].type == CS_OP_IMM and self.reads_stream(o[0].imm):
+                if in_loop:
+                    return None
+                sub = o[0].imm
+                m = self.solve_reader(sub)
+                if m is not None:
+                    out.append(m)
+                else:
+                    el = self.list_element(sub)
+                    if el is not None and el[0] == "fixed":
+                        out.append(("list", el[1]))
+                    else:
+                        inner = self.reader_parts(sub, seen | {va})
+                        if inner is None:
+                            return None
+                        out.append(("nest", tuple(inner)))
+                last_was_4 = False
+            pend, pend_var = None, False
+        return out or None
+
     def element_parts(self, va: int):
         """The element's members in program order, or None.
 

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -517,7 +517,7 @@ class Deriver:
         self._memo[va] = got
         return got
 
-    def list_element(self, va: int):
+    def list_element(self, va: int, seen: frozenset | None = None):
         """What ONE element of a count-prefixed list reader consumes.
 
         ``('fixed', n)``    a constant n bytes per element
@@ -552,6 +552,9 @@ class Deriver:
         the four readers stage 2 proved are plain fixed-width.
         """
         from capstone import CS_OP_IMM, CS_OP_MEM, CS_OP_REG
+        seen = frozenset() if seen is None else seen
+        if va in seen or len(seen) > 4:
+            return None                   # recursion guard
         ins = self.body(va)
         if not ins:
             return None
@@ -649,6 +652,24 @@ class Deriver:
                 elif o[0].type == CS_OP_IMM and self.reads_stream(o[0].imm):
                     sub = self.solve_reader(o[0].imm)
                     if sub is None:
+                        # Before abstaining: a sub-reader that is ITSELF a
+                        # count-prefixed list makes THIS element
+                        # variable-length, because the inner count is read
+                        # per element. Abstaining instead would leave
+                        # candidates() free to offer a constant width, which
+                        # is how royalsupply fitted ('list', 28): its element
+                        # calls sub_1412A11E0, itself 4 + count*20, so 28
+                        # only holds while every inner count is 1. That is
+                        # the HouseInfo coincidence one level down.
+                        if va not in seen:
+                            inner = self.list_element(o[0].imm,
+                                                      seen | {va})
+                            if inner is not None:
+                                return ("variable",
+                                        (f"sub_{o[0].imm:X} is itself a "
+                                         f"count-prefixed list "
+                                         f"({inner[0]}), so this element "
+                                         f"varies with the inner count"))
                         return None
                     if sub[0] in ("str", "strplus"):
                         return ("variable",

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -83,7 +83,7 @@ import argparse
 import collections
 import struct
 import sys
-from bisect import bisect_left
+from bisect import bisect_left, bisect_right
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parents[1]
@@ -769,7 +769,15 @@ class Deriver:
         blocks = sorted(targets | {lo})
 
         def hot(lea: int):
-            j = bisect_left(blocks, lea) - 1
+            # bisect_RIGHT, matching Func.block_start_of in
+            # extract_field_order_win.py (the implementation whose ordering
+            # was validated against the hand-RE'd tables). An outlined error
+            # block starts AT its own lea, so bisect_left lands one block
+            # EARLIER and reads that block's inbound edges -- ranking the
+            # field by where some other block is branched from. It is why
+            # this function disagreed with the verified order on ItemInfo,
+            # the very table extract_field_order_win.py cites as its proof.
+            j = bisect_right(blocks, lea) - 1
             b = blocks[j] if j >= 0 else blocks[0]
             src = inbound.get(b)
             return (min(src), lea) if src else (lea, lea)

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -117,6 +117,12 @@ MAX_ELEM = 128
 #: nothing real and turns a silent nonsense value into a refusal.
 MAX_READER_BYTES = 1 << 20
 
+#: Instructions after which control does not fall through. Used both to
+#: delimit basic blocks and to REFUSE to attribute a stream read to a field
+#: across one: when a field's error block is OUTLINED, what physically
+#: precedes it is some other block's tail, usually an epilogue.
+_UNCOND_END = frozenset({"ret", "jmp", "int3", "ud2"})
+
 #: An escape hatch for readers stage 1 genuinely cannot derive: a model
 #: read off the disassembly by hand, kept SEPARATE from the automatic ones
 #: so it is always visible which is which. An unmarked hand constant is how
@@ -260,6 +266,7 @@ class Deriver:
         self._memo: dict[int, tuple[str, int] | None] = {}
         self._reads: dict[int, bool] = {}
         self._parts: dict[int, list] = {}
+        self._pd = None                   # .pdata function extents, lazy
 
     # ── stage 1: static reader models ────────────────────────────────────
 
@@ -417,6 +424,142 @@ class Deriver:
                 return None
             loops.append((by_addr[target], n, trip))
         return loops
+
+    # ── true function bounds, from .pdata unwind chains ──────────────────
+
+    def _pdata(self):
+        """Merged function extents from .pdata, following unwind chains.
+
+        This replaces sweeping from ``leas[0] - SWEEP_PAD``, which was not
+        merely imprecise. ``capstone.Cs.disasm`` is a GENERATOR that stops at
+        the first byte sequence it cannot decode, so a sweep starting at an
+        arbitrary byte desyncs into garbage, hits an invalid opcode, and
+        TRUNCATES. On 15 tables it ended before the first field lea -- so no
+        field could be found, and with ``ins`` near-empty the block map was
+        empty too and field ORDER silently degraded to naive lea-address
+        order, which is exactly what the hot-path ranking exists to avoid.
+
+        .pdata does NOT enumerate functions, it enumerates UNWIND ranges. A
+        function with outlined blocks has a primary RUNTIME_FUNCTION plus
+        continuations flagged UNW_FLAG_CHAININFO (0x4), each carrying a
+        trailing RUNTIME_FUNCTION pointing at its parent. Anchoring on the
+        nearest BeginAddress bounds a FRAGMENT: measured on this build, 27 of
+        112 candidate tables have their field leas spread across more than
+        one fragment (up to 6, for QuestInfo). Following the chain to its
+        ROOT and merging brings all of them under one function -- 0 tables
+        left spanning multiple roots, 0 leas outside .pdata, and decoding the
+        merged extents reaches EVERY field lea in 112 of 112 tables.
+
+        UNWIND_INFO: byte0 = Version(3) | Flags(5), Flags & 4 == CHAININFO;
+        byte2 = CountOfCodes; the chained RUNTIME_FUNCTION follows the
+        unwind-code array, padded to an even count.
+        """
+        if self._pd is not None:
+            return self._pd
+        import pefile
+        pe = pefile.PE(str(self.game / "bin64" / "CrimsonDesert.exe"),
+                       fast_load=True)
+        d = pe.OPTIONAL_HEADER.DATA_DIRECTORY[3]        # ENTRY_EXCEPTION
+        rva, size = d.VirtualAddress, d.Size
+        base = pe.OPTIONAL_HEADER.ImageBase
+        pe.close()
+        rf = []
+        off = self.img.va_to_off(base + rva) if rva else None
+        if off is not None:
+            blob = self.img.data[off:off + size]
+            for p in range(0, len(blob) - 11, 12):
+                b, e, u = struct.unpack_from("<III", blob, p)
+                if b and e > b:
+                    rf.append((base + b, base + e, base + u if u else 0))
+        rf.sort()
+        by_begin = {b: (b, e, u) for b, e, u in rf}
+
+        def parent(u):
+            if not u:
+                return None
+            o = self.img.va_to_off(u)
+            if o is None or o + 4 > len(self.img.data):
+                return None
+            if not ((self.img.data[o] >> 3) & 0x4):
+                return None                   # not a chained fragment
+            n = self.img.data[o + 2]          # CountOfCodes
+            c = o + 4 + 2 * ((n + 1) & ~1)
+            if c + 12 > len(self.img.data):
+                return None
+            pb, _pe, _pu = struct.unpack_from("<III", self.img.data, c)
+            return base + pb
+
+        root: dict[int, int] = {}
+
+        def resolve(b, seen=frozenset()):
+            if b in root:
+                return root[b]
+            if b in seen:
+                return b                      # cycle guard
+            ent = by_begin.get(b)
+            p = parent(ent[2]) if ent else None
+            r = (resolve(p, seen | {b})
+                 if p is not None and p in by_begin else b)
+            root[b] = r
+            return r
+
+        for b, _e, _u in rf:
+            resolve(b)
+        ext: dict[int, list[int]] = {}
+        for b, e, _u in rf:
+            r = root[b]
+            cur = ext.setdefault(r, [b, e])
+            cur[0] = min(cur[0], b)
+            cur[1] = max(cur[1], e)
+        self._pd = (rf, [b for b, _e, _u in rf], by_begin, root, ext)
+        return self._pd
+
+    def function_extent(self, va: int):
+        """(lo, hi) of the whole function containing ``va``, or None."""
+        _rf, starts, by_begin, root, ext = self._pdata()
+        i = bisect_right(starts, va) - 1
+        if i < 0:
+            return None
+        b, e, _u = by_begin[starts[i]]
+        if not (b <= va < e):
+            return None
+        lo, hi = ext[root[starts[i]]]
+        return (lo, hi)
+
+    def sweep(self, leas: list[int]):
+        """(instructions, addresses) covering every lea, boundary-true.
+
+        Decodes each distinct enclosing FUNCTION once, from its real start,
+        so every instruction boundary is genuine. Falls back to the old
+        padded window only for a lea outside .pdata entirely (none on this
+        build), because a missing field is worse than an imprecise one.
+        """
+        from extract_field_order_win import SWEEP_PAD
+        spans, orphans = set(), []
+        for a in leas:
+            x = self.function_extent(a)
+            if x is None:
+                orphans.append(a)
+            else:
+                spans.add(x)
+        ins = []
+        for lo, hi in sorted(spans):
+            off = self.img.va_to_off(lo)
+            if off is not None:
+                ins += list(self.md.disasm(
+                    self.img.data[off:off + (hi - lo)], lo))
+        for a in orphans:
+            off = self.img.va_to_off(a - SWEEP_PAD)
+            if off is not None:
+                ins += list(self.md.disasm(
+                    self.img.data[off:off + 2 * SWEEP_PAD], a - SWEEP_PAD))
+        ins.sort(key=lambda i: i.address)
+        out, seen = [], set()
+        for i in ins:
+            if i.address not in seen:
+                seen.add(i.address)
+                out.append(i)
+        return out, [i.address for i in out]
 
     def closes_cycle(self, ins: list, branch: int, target_addr: int) -> bool:
         """Does this backward branch actually form a LOOP?
@@ -836,14 +979,14 @@ class Deriver:
     def field_reads(self, cls: str):
         """[(name, 'fixed'|'call'|'?', width_or_callee)] in hot-path order."""
         from capstone import CS_OP_IMM, CS_OP_REG
-        from extract_field_order_win import SWEEP_PAD
         pairs = self.by_cls[cls]
         leas = sorted(a for _f, a in pairs)
-        lo = leas[0] - SWEEP_PAD
-        off = self.img.va_to_off(lo)
-        span = (leas[-1] + SWEEP_PAD) - lo
-        ins = list(self.md.disasm(self.img.data[off:off + span], lo))
-        addrs = [i.address for i in ins]
+        # Decode each enclosing FUNCTION from its real .pdata start rather
+        # than a padded window, so every instruction boundary is genuine and
+        # the decode cannot truncate before the fields. See sweep()/_pdata().
+        ins, addrs = self.sweep(leas)
+        if not addrs:
+            return [(f, "?", None) for f, _a in pairs]
         inbound = collections.defaultdict(list)
         targets: set[int] = set()
         for i in ins:
@@ -852,9 +995,10 @@ class Deriver:
                     and o[0].type == CS_OP_IMM):
                 targets.add(o[0].imm)
                 inbound[o[0].imm].append(i.address)
-            if i.mnemonic in ("ret", "jmp", "int3", "ud2"):
+            if i.mnemonic in _UNCOND_END:
                 targets.add(i.address + i.size)
-        blocks = sorted(targets | {lo})
+        blocks = sorted(targets | {addrs[0]})
+        set_addrs = set(addrs)
 
         def hot(lea: int):
             # bisect_RIGHT, matching Func.block_start_of in
@@ -870,14 +1014,43 @@ class Deriver:
             src = inbound.get(b)
             return (min(src), lea) if src else (lea, lea)
 
+        def guard_index(lea: int) -> int | None:
+            """Where to look back from for the read that guards this field.
+
+            For a FALL-THROUGH field, that is the lea itself. For an OUTLINED
+            error block it is NOT: the instructions physically before such a
+            block belong to some other block, usually an epilogue, so walking
+            back from the lea crosses a `ret` and picks up an unrelated
+            read. AIEventTableInfo `_eventDelayType` is the case -- the
+            lookback stepped over `ret` at 0x141271922 into
+            `_isMustHandled`'s `mov r8d, 1` and reported width 1, where the
+            sole branch into the block carries `mov r8d, 8`. Refereed by
+            tiling: 8 tiles aieventtableinfo 988/988, 1 does not tile at all.
+
+            So when the lea starts a block with inbound edges, look back from
+            the EARLIEST branch into it -- the same hot-path source the
+            ordering uses.
+            """
+            b = blocks[bisect_right(blocks, lea) - 1] if blocks else lea
+            src = inbound.get(b)
+            anchor = min(src) if (src and b == lea) else lea
+            k = bisect_left(addrs, anchor)
+            return k if k < len(addrs) and addrs[k] == anchor else None
+
         out = []
         for fld, lea in sorted(pairs, key=lambda p: hot(p[1])):
-            i = bisect_left(addrs, lea)
-            if i >= len(addrs) or addrs[i] != lea:
+            if lea not in set_addrs:
+                out.append((fld, "?", None))
+                continue
+            i = guard_index(lea)
+            if i is None:
                 out.append((fld, "?", None))
                 continue
             j, call = i - 1, None
             while j >= 0 and i - j < 24:
+                if ins[j].mnemonic in _UNCOND_END:
+                    break            # a different block; refuse rather than
+                    #                  borrow its read
                 if ins[j].mnemonic == "call":
                     call = ins[j]
                     break
@@ -891,6 +1064,9 @@ class Deriver:
                 continue
             k, start = j - 1, max(0, j - 24)
             while k >= 0 and j - k < 24:
+                if ins[k].mnemonic in _UNCOND_END:
+                    start = k + 1     # do not take a width from another block
+                    break
                 if ins[k].mnemonic == "call":
                     start = k + 1
                     break

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -249,6 +249,7 @@ class Deriver:
         self.elem: dict[int, int] = {}
         self._memo: dict[int, tuple[str, int] | None] = {}
         self._reads: dict[int, bool] = {}
+        self._parts: dict[int, list] = {}
 
     # ── stage 1: static reader models ────────────────────────────────────
 
@@ -691,8 +692,14 @@ class Deriver:
         if lo is None:
             return None
 
-        # 3. what the loop body consumes per iteration
-        total = 0
+        # 3. what the loop body consumes per iteration, MEMBER BY MEMBER.
+        # Keeping the sequence rather than only the sum is what lets a
+        # variable-length element still be described: the format can express
+        # `CArray<Substruct>`, so an element of u32 + u32 + CString is
+        # representable even though its width is not constant. Recording the
+        # parts here is what HouseInfo_RegionDataEntry was written by hand
+        # from.
+        parts: list[tuple[str, int]] = []
         pend = None
         for i in ins[lo:hi + 1]:
             o = i.operands
@@ -709,7 +716,7 @@ class Deriver:
                 if o[0].type == CS_OP_MEM:
                     if pend is None:
                         return None       # unsized stream call: no verdict
-                    total += pend
+                    parts.append(("fixed", pend))
                 elif o[0].type == CS_OP_IMM and self.reads_stream(o[0].imm):
                     sub = self.solve_reader(o[0].imm)
                     if sub is None:
@@ -726,22 +733,46 @@ class Deriver:
                             inner = self.list_element(o[0].imm,
                                                       seen | {va})
                             if inner is not None:
-                                return ("variable",
-                                        (f"sub_{o[0].imm:X} is itself a "
-                                         f"count-prefixed list "
-                                         f"({inner[0]}), so this element "
-                                         f"varies with the inner count"))
+                                parts.append(("nested", o[0].imm))
+                                pend = None
+                                continue
                         return None
-                    if sub[0] in ("str", "strplus"):
-                        return ("variable",
-                                (f"sub_{o[0].imm:X} is {sub[0]}({sub[1]}), "
-                                 f"so the element is "
-                                 f"{total + sub[1] + 4} + n"))
-                    total += sub[1]
+                    parts.append(sub)
                 pend = None
-        if total <= 0:
+        if not parts:
             return None
-        return ("fixed", total)
+        self._parts[va] = parts
+        if all(p[0] == "fixed" for p in parts):
+            total = sum(p[1] for p in parts)
+            return ("fixed", total) if total > 0 else None
+        bad = next(p for p in parts if p[0] != "fixed")
+        fixed_before = sum(p[1] for p in parts if p[0] == "fixed")
+        if bad[0] == "nested":
+            why = (f"sub_{bad[1]:X} is itself a count-prefixed list, so this "
+                   f"element varies with the inner count")
+        else:
+            why = (f"a {bad[0]}({bad[1]}) read, so the element is "
+                   f"{fixed_before + bad[1] + 4} + n")
+        return ("variable", why)
+
+    def element_parts(self, va: int):
+        """The element's members in program order, or None.
+
+        ``[('fixed', n) | ('str', 0) | ('strplus', 9) | ('nested', callee)]``
+
+        This is what makes a variable-length element shippable rather than
+        merely refused. ``CArray<[u8;N]>`` cannot describe an element whose
+        width varies, but ``CArray<Substruct>`` can, and the format already
+        supports it (see SUBSTRUCT_DEFS, e.g. StageInfo_Field608Entry =
+        u32 + CString). HouseInfo_RegionDataEntry and FailMessageInfo_Entry
+        were read off these same parts by hand; this returns them so the
+        remaining tables do not need hand work.
+
+        Structure only. It says nothing about what any member MEANS, so the
+        names generated from it must stay out of ``_verified_fields``.
+        """
+        self.list_element(va)
+        return self._parts.get(va)
 
     # ── field order + per-field read shape ───────────────────────────────
 

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -905,6 +905,14 @@ def main(argv: list[str] | None = None) -> int:
         if not added:
             break
 
+    # A table reported AMBIGUOUS in an early round is often PROVEN in a
+    # later one, once another table pins the reader that was free here.
+    # `ambiguous` was never cleared when that happened, so the report
+    # listed the same table under both headings and contradicted itself --
+    # dialogvoiceinfo showed up as 519 records proven AND as "130 shapes
+    # tile". Proven wins: it is the later, stronger result.
+    ambiguous = {s: v for s, v in ambiguous.items() if s not in proven}
+
     print()
     print(f"PROVEN -- exact tiling on 100% of records: {len(proven)} tables, "
           f"{sum(proven.values()):,} records")

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -135,6 +135,104 @@ def _cs():
     return md
 
 
+class Frame:
+    """Canonical stack-slot identity: an offset from the function's entry rsp.
+
+    Needed because the SAME slot is reached through different registers at
+    different points in a function. sub_1412A8A50 stores its element count
+    via ``lea rdx, [r11 + 8]`` and then bounds its loop with
+    ``cmp dword ptr [rsp + 0xa0], ...``. Those look unrelated until you
+    notice ``r11`` was set to rsp on entry and rsp has since moved by five
+    pushes (0x28) plus ``sub rsp, 0x70``: rsp+0xa0 == entry+8 == r11+8. One
+    slot, two spellings. Keying on (register, displacement) instead treats
+    them as two and loses the link between the count and the loop bound.
+
+    rsp is tracked only through the PROLOGUE and then frozen. These
+    functions set their frame up once and address locals at a constant
+    offset; the only later rsp moves are epilogues, and a linear sweep
+    cannot tell an epilogue from fall-through code. Applying
+    sub_14129A5F0's early-return ``add rsp, 0x38 / pop / pop`` to the main
+    path shifted every later slot by 0x48.
+    """
+
+    def __init__(self, md):
+        self.md = md
+        self.rsp = 0                      # rsp relative to function entry
+        self.base: dict[str, int] = {}    # reg -> entry-relative value
+        self.zero: set[str] = set()       # regs known to hold 0
+        self.frozen = False               # prologue over -> rsp is fixed
+
+    @staticmethod
+    def q(r: str) -> str:
+        """Normalise a 32-bit register name to its 64-bit counterpart."""
+        if r.startswith("e"):
+            return "r" + r[1:]
+        if r.startswith("r") and r.endswith("d"):
+            return r[:-1]
+        return r
+
+    def is_zero(self, reg: str) -> bool:
+        return self.q(reg) in {self.q(z) for z in self.zero}
+
+    def slot(self, op) -> int | None:
+        """Entry-relative offset of a stack memory operand, else None."""
+        m = op.mem
+        if m.index != 0:
+            return None                   # indexed: not a fixed slot
+        base = self.md.reg_name(m.base) if m.base else None
+        if base is None:
+            return None
+        if base == "rsp":
+            return self.rsp + m.disp
+        if base in self.base:
+            return self.base[base] + m.disp
+        return None
+
+    def step(self, i):
+        from capstone import CS_OP_IMM, CS_OP_MEM, CS_OP_REG
+        o = i.operands
+        m = i.mnemonic
+        dst = i.op_str.split(",")[0].strip()
+        if m == "call" or m.startswith("j"):
+            self.frozen = True
+            return
+        if m in ("push", "pop") or (
+                m in ("sub", "add") and len(o) == 2 and dst == "rsp"
+                and o[1].type == CS_OP_IMM):
+            if self.frozen:
+                return                    # epilogue noise
+            if m == "push":
+                self.rsp -= 8
+            elif m == "pop":
+                self.rsp += 8
+            else:
+                self.rsp += (-o[1].imm if m == "sub" else o[1].imm)
+            return
+        if m == "mov" and len(o) == 2 and o[0].type == CS_OP_REG:
+            src = i.op_str.split(",", 1)[1].strip()
+            if src == "rsp":
+                self.base[dst] = self.rsp
+            elif o[1].type == CS_OP_IMM and o[1].imm == 0:
+                self.zero.add(dst)
+                self.base.pop(dst, None)
+            else:
+                self.zero.discard(dst)
+                self.base.pop(dst, None)
+        elif m == "lea" and len(o) == 2 and o[0].type == CS_OP_REG:
+            s = self.slot(o[1]) if o[1].type == CS_OP_MEM else None
+            if s is None:
+                self.base.pop(dst, None)
+            else:
+                self.base[dst] = s
+            self.zero.discard(dst)
+        elif m == "xor" and len(o) == 2 and o[0].type == CS_OP_REG:
+            b = i.op_str.split(",", 1)[1].strip()
+            if self.q(dst) == self.q(b):
+                self.zero.add(dst)
+            else:
+                self.zero.discard(dst)
+
+
 class Deriver:
     def __init__(self, game_dir: Path):
         from extract_field_order_win import find_field_strings, find_lea_xrefs, open_image
@@ -419,6 +517,150 @@ class Deriver:
         self._memo[va] = got
         return got
 
+    def list_element(self, va: int):
+        """What ONE element of a count-prefixed list reader consumes.
+
+        ``('fixed', n)``    a constant n bytes per element
+        ``('variable', s)`` the element contains a CString /
+                            LocalizableString read, so it has NO constant
+                            width; ``s`` describes what was found
+        ``None``            not recognised as a dynamic-count list; no verdict
+
+        Why this exists. 163 of stage 1's 167 refusals are LOOP_UNPINNED,
+        and nearly all are CArray<T> readers: ``fixed_loops`` only pins a
+        loop whose trip count is an immediate, and here the count is READ
+        FROM THE STREAM, so the branch compares against a stack slot. The
+        count being dynamic does not make the ELEMENT dynamic, and the loop
+        body's own reads settle it without touching table data.
+
+        The ``variable`` verdict is the load-bearing one. HouseInfo and
+        FailMessageInfo shipped in v3.13 with a FIXED element width that
+        stage 2 had fitted from data, and both were wrong -- the element
+        ends in a string, and the constant only fitted because every string
+        in that build was one length (12+34 == 46, 17+16 == 33). Both the
+        fixed and the variable model tile 100% of records exactly, so the
+        data cannot separate them. ``candidates()`` uses this to stop
+        offering a fixed width for a reader whose element is variable,
+        which is what makes unique-or-nothing mean anything: uniqueness in
+        a candidate space that never held the right answer is not
+        uniqueness.
+
+        Validated against the eight readers stage 2 had already pinned from
+        table data -- a wholly separate line of evidence. It reproduces
+        five exactly, correctly reports the two above as variable, and
+        returns None for the last rather than guessing. It fires on none of
+        the four readers stage 2 proved are plain fixed-width.
+        """
+        from capstone import CS_OP_IMM, CS_OP_MEM, CS_OP_REG
+        ins = self.body(va)
+        if not ins:
+            return None
+        idx = {i.address: n for n, i in enumerate(ins)}
+
+        # Slot identity depends on the frame state AT that instruction, so
+        # record it per index in one pass.
+        fr = Frame(self.md)
+        slots: list[dict] = []
+        zeros: list[set] = []
+        for i in ins:
+            slots.append({k: fr.slot(op) for k, op in enumerate(i.operands)
+                          if op.type == CS_OP_MEM})
+            zeros.append(set(fr.zero))
+            fr.step(i)
+
+        # 1. the leading 4-byte read, and the slot it fills: that is the count
+        count_slot = count_at = None
+        pend = pend_dst = None
+        for n, i in enumerate(ins):
+            o = i.operands
+            dst = i.op_str.split(",")[0].strip()
+            if len(o) == 2 and o[0].type == CS_OP_REG and "r8" in dst:
+                if i.mnemonic == "mov" and o[1].type == CS_OP_IMM:
+                    pend = o[1].imm
+                elif (i.mnemonic == "lea" and o[1].type == CS_OP_MEM
+                      and o[1].mem.index == 0 and o[1].mem.disp >= 0):
+                    # `lea r8d, [r14 + 4]` is width 4, but only if r14 really
+                    # holds zero -- otherwise the width is whatever was in it.
+                    b = (self.md.reg_name(o[1].mem.base)
+                         if o[1].mem.base else None)
+                    pend = (o[1].mem.disp if b and Frame.q(b) in
+                            {Frame.q(z) for z in zeros[n]} else None)
+                else:
+                    pend = None
+            elif (i.mnemonic == "lea" and len(o) == 2 and dst == "rdx"
+                  and o[1].type == CS_OP_MEM):
+                pend_dst = slots[n].get(1)
+            elif (i.mnemonic == "call" and len(o) == 1
+                  and o[0].type == CS_OP_MEM):
+                if pend == 4 and pend_dst is not None:
+                    count_slot, count_at = pend_dst, n
+                    break
+                pend = pend_dst = None
+        if count_slot is None:
+            return None
+
+        # 2. a backward branch whose bound is that same slot
+        lo = hi = None
+        for n, i in enumerate(ins):
+            o = i.operands
+            if not (i.mnemonic in ("jb", "jl", "jbe", "jle", "jne")
+                    and len(o) == 1 and o[0].type == CS_OP_IMM
+                    and o[0].imm < i.address):
+                continue
+            ref = False
+            for k in range(n - 1, max(-1, n - 4), -1):
+                if ins[k].mnemonic != "cmp":
+                    continue
+                for ci, co in enumerate(ins[k].operands):
+                    if (co.type == CS_OP_MEM
+                            and slots[k].get(ci) == count_slot):
+                        ref = True
+                break
+            if not ref:
+                continue
+            t = o[0].imm
+            if t not in idx or idx[t] <= count_at:
+                return None               # loop precedes the count read
+            if lo is not None:
+                return None               # two dynamic loops: no verdict
+            lo, hi = idx[t], n
+        if lo is None:
+            return None
+
+        # 3. what the loop body consumes per iteration
+        total = 0
+        pend = None
+        for i in ins[lo:hi + 1]:
+            o = i.operands
+            dst = i.op_str.split(",")[0].strip()
+            if (i.mnemonic in ("mov", "lea") and len(o) == 2
+                    and o[0].type == CS_OP_REG and "r8" in dst):
+                # Clear a pending width, but do NOT call this an unsized
+                # read: r8 is general-purpose and the body uses it for other
+                # work (`mov r8, qword ptr [rcx + rdx*8]` in sub_14129A5F0
+                # is a hash-bucket pointer). A missing width only matters
+                # where a stream call actually happens, below.
+                pend = o[1].imm if o[1].type == CS_OP_IMM else None
+            elif i.mnemonic == "call" and len(o) == 1:
+                if o[0].type == CS_OP_MEM:
+                    if pend is None:
+                        return None       # unsized stream call: no verdict
+                    total += pend
+                elif o[0].type == CS_OP_IMM and self.reads_stream(o[0].imm):
+                    sub = self.solve_reader(o[0].imm)
+                    if sub is None:
+                        return None
+                    if sub[0] in ("str", "strplus"):
+                        return ("variable",
+                                (f"sub_{o[0].imm:X} is {sub[0]}({sub[1]}), "
+                                 f"so the element is "
+                                 f"{total + sub[1] + 4} + n"))
+                    total += sub[1]
+                pend = None
+        if total <= 0:
+            return None
+        return ("fixed", total)
+
     # ── field order + per-field read shape ───────────────────────────────
 
     def field_reads(self, cls: str):
@@ -597,7 +839,7 @@ class Deriver:
                 return False
         return True
 
-    def candidates(self):
+    def candidates(self, va: int | None = None):
         """Every reader shape stage 2 will try, in one flat list.
 
         Widened from list-only. A reader stage 1 refused is not necessarily
@@ -609,9 +851,31 @@ class Deriver:
         Unique-or-nothing now applies across the WHOLE space: if a fixed
         width and a list width both tile, the data cannot tell them apart
         and the answer is unknown.
+
+        ...with one correction that the space itself was hiding. Every
+        ``('list', n)`` here is a list of FIXED-width elements; there is no
+        variable-element list shape. For a reader whose element ends in a
+        string, the right answer was therefore never in the space, and
+        stage 2 fitted the nearest constant instead -- reporting it as
+        unique because nothing could contradict it. That is how HouseInfo
+        got CArray<[u8;46]> and FailMessageInfo CArray<[u8;33]> into a
+        shipped release: every element string in the measured build was one
+        length, so 12+34 and 17+16 landed exactly on 100% of records.
+
+        So when ``va`` is given and its element is statically variable, the
+        list shapes are withheld. Stage 2 then finds nothing tiles and
+        reports the reader unresolved, which is the correct outcome: the
+        shape it needs is one this walker cannot express, and saying
+        "unknown" is worth more than a constant that happens to fit today.
         """
         out = [("fixed", n) for n in range(MAX_ELEM + 1)]
-        out += [("list", n) for n in range(1, MAX_ELEM + 1)]
+        offer_lists = True
+        if va is not None:
+            el = self.list_element(va)
+            if el is not None and el[0] == "variable":
+                offer_lists = False
+        if offer_lists:
+            out += [("list", n) for n in range(1, MAX_ELEM + 1)]
         out += [("str", n) for n in range(33)]
         return out
 
@@ -626,10 +890,10 @@ class Deriver:
         n = len(ent)
         step = max(1, n // 24)
         probe = list(range(0, n, step))[:24] or [0]
-        cands = self.candidates()
 
         if len(unknown) == 1:
             c = unknown[0]
+            cands = self.candidates(c)
             cheap = [x for x in cands
                      if self.tiles(body, ent, key_size, fields,
                                    {**self.elem, c: x}, probe)]
@@ -638,17 +902,18 @@ class Deriver:
                                   {**self.elem, c: x})]
 
         a, b = unknown
+        cands_a, cands_b = self.candidates(a), self.candidates(b)
         # Two unknowns over the full space would be ~300^2 tilings per
         # table. Prune each slot alone first: a shape that cannot tile the
         # probe for ANY partner cannot be part of a full solution.
-        viable_a = [x for x in cands
+        viable_a = [x for x in cands_a
                     if any(self.tiles(body, ent, key_size, fields,
                                       {**self.elem, a: x, b: y}, probe[:4])
-                           for y in cands[::8])]
-        viable_b = [y for y in cands
+                           for y in cands_b[::8])]
+        viable_b = [y for y in cands_b
                     if any(self.tiles(body, ent, key_size, fields,
                                       {**self.elem, a: x, b: y}, probe[:4])
-                           for x in viable_a[::8] or cands[::8])]
+                           for x in viable_a[::8] or cands_a[::8])]
         cheap = [(x, y) for x in viable_a for y in viable_b
                  if self.tiles(body, ent, key_size, fields,
                                {**self.elem, a: x, b: y}, probe)]
@@ -812,8 +1077,36 @@ def main(argv: list[str] | None = None) -> int:
         if c in callees and c not in d.model:
             d.model[c] = m
             hand += 1
-    print(f"sub-readers: {auto} solved statically, {hand} hand-verified "
+
+    # stage 1b -- count-prefixed lists, from the loop BODY rather than from
+    # table data. Nearly every refusal above is LOOP_UNPINNED, and nearly
+    # every one of those is a CArray<T>: fixed_loops only pins a loop whose
+    # trip count is an immediate, and here the count is read from the stream.
+    # A dynamic count does not imply a dynamic element.
+    static_lists = 0
+    variable: dict[int, str] = {}
+    for c in sorted(set(callees) - set(d.model)):
+        el = d.list_element(c)
+        if el is None:
+            continue
+        if el[0] == "fixed":
+            d.elem[c] = ("list", el[1])
+            static_lists += 1
+        else:
+            variable[c] = el[1]
+    print(f"sub-readers: {auto} solved statically, {hand} hand-verified, "
+          f"{static_lists} count-prefixed lists pinned from the loop body "
           f"(of {len(callees)} used as field readers)")
+    if variable:
+        # Worth printing loudly. A fixed width fitted for one of these is
+        # exactly the HouseInfo / FailMessageInfo bug: it can tile 100% of
+        # records and still be wrong, because the strings in one build happen
+        # to share a length.
+        print(f"list elements that are VARIABLE-length ({len(variable)}) -- "
+              f"no constant width may be fitted for these; the shape is not "
+              f"in the walker's grammar, so the honest result is unresolved:")
+        for c, s in sorted(variable.items()):
+            print(f"   sub_{c:X}  {s}")
 
     loaded = {}
     for s in stems:

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -407,6 +407,62 @@ class Deriver:
             loops.append((by_addr[target], n, trip))
         return loops
 
+    def closes_cycle(self, ins: list, branch: int, target_addr: int) -> bool:
+        """Does this backward branch actually form a LOOP?
+
+        A branch to an earlier address is not automatically a loop. It is a
+        loop only if control can get from the target back to the branch --
+        i.e. it closes a cycle. A backward ``jmp`` into a shared tail or
+        error block goes backwards and never returns, and treating it as a
+        loop refused the whole reader.
+
+        sub_141280820 is the case: three separate backward ``jmp
+        0x141280847`` at 0x1412808A4/BD/D6 converge on a shared tail. None
+        of them can reach its own branch again, so none is a loop -- but the
+        old test saw three and gave up. Guarding on reachability takes stage
+        1 from 52 readers to 67 and gains materialmatchinfo.
+
+        Walks the function's own instruction list, so it costs nothing
+        beyond the body already disassembled.
+        """
+        from capstone import CS_OP_IMM
+        idx = {i.address: n for n, i in enumerate(ins)}
+        start = idx.get(target_addr)
+        if start is None:
+            return False                     # target outside this body
+
+        def succ(n: int):
+            i = ins[n]
+            o = i.operands
+            m = i.mnemonic
+            if m in ("ret", "int3", "ud2"):
+                return
+            if m == "jmp":
+                if len(o) == 1 and o[0].type == CS_OP_IMM:
+                    t = idx.get(o[0].imm)
+                    if t is not None:
+                        yield t
+                return                       # unconditional: no fallthrough
+            if (m.startswith("j") and len(o) == 1
+                    and o[0].type == CS_OP_IMM):
+                t = idx.get(o[0].imm)
+                if t is not None:
+                    yield t
+            if n + 1 < len(ins):
+                yield n + 1
+
+        seen = {start}
+        stack = [start]
+        while stack:
+            n = stack.pop()
+            if n == branch:
+                return True
+            for s in succ(n):
+                if s not in seen:
+                    seen.add(s)
+                    stack.append(s)
+        return False
+
     def solve_reader(self, va: int, depth: int = 0):
         """('fixed'|'str'|'strplus', base) or None when not derivable."""
         from capstone import CS_OP_IMM, CS_OP_MEM, CS_OP_REG
@@ -427,7 +483,8 @@ class Deriver:
         var_read = False
         has_loop = False
         rcx_is_stream = True          # rcx holds the stream on entry
-        for i in ins:
+        back: list[tuple[int, int]] = []   # (branch index, target address)
+        for n, i in enumerate(ins):
             o = i.operands
             _dst = i.op_str.split(",")[0].strip()
             if (i.mnemonic in ("mov", "lea") and len(o) == 2
@@ -458,7 +515,11 @@ class Deriver:
                 rcx_is_stream = False             # a call clobbers rcx
             if (i.mnemonic.startswith("j") and len(o) == 1
                     and o[0].type == CS_OP_IMM and va <= o[0].imm < i.address):
-                has_loop = True
+                back.append((n, o[0].imm))
+        # A backward branch is only a LOOP if control can return to it. A
+        # backward jmp into a shared tail or error block never does, and
+        # counting those refused readers that contain no loop at all.
+        has_loop = any(self.closes_cycle(ins, n, t) for n, t in back)
         # A loop is only undecidable when its trip count is unknown -- that
         # is a count-prefixed list, and stage 2 derives its element width.
         # A loop whose bound is an immediate is fully determined, and a loop

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -107,6 +107,16 @@ HEADER_FIELDS = ("_stringKey", "_key")
 #: Widest plausible list element for the constraint search.
 MAX_ELEM = 128
 
+#: A derived width beyond this is not a width. sub_1440A7CCC comes out of
+#: solve_reader as ('fixed', 11565661) -- 11 MB for one field -- because it
+#: is not a reader at all and a `mov r8d, <big imm>` in it got taken for a
+#: read size. It is inert today only because reads_stream() says False for
+#: it so it contributes nothing to any sum, but a model that absurd should
+#: never be produced, let alone returned to a caller that might use it. No
+#: single record in the install is remotely near this, so the bound costs
+#: nothing real and turns a silent nonsense value into a refusal.
+MAX_READER_BYTES = 1 << 20
+
 #: An escape hatch for readers stage 1 genuinely cannot derive: a model
 #: read off the disassembly by hand, kept SEPARATE from the automatic ones
 #: so it is always visible which is which. An unmarked hand constant is how
@@ -481,10 +491,14 @@ class Deriver:
         reads: list[int] = []
         subs: list[int] = []
         pend = None
-        var_read = False
+        pend_var = False
+        var_read = False      # STRICT: an unsized read at an actual call site
+        var_seen = False      # PERMISSIVE: any non-immediate r8 write
         has_loop = False
         rcx_is_stream = True          # rcx holds the stream on entry
         back: list[tuple[int, int]] = []   # (branch index, target address)
+        read_pos: list[int] = []           # instruction index of each read
+        sub_pos: list[tuple[int, int]] = []   # (index, callee) of each subcall
         for n, i in enumerate(ins):
             o = i.operands
             _dst = i.op_str.split(",")[0].strip()
@@ -499,20 +513,37 @@ class Deriver:
                     and o[0].type == CS_OP_REG
                     and "r8" in i.op_str.split(",")[0]):
                 if o[1].type == CS_OP_IMM:
-                    pend = o[1].imm
+                    pend, pend_var = o[1].imm, False
                 elif (i.mnemonic == "lea" and o[1].type == CS_OP_MEM
                       and o[1].mem.disp >= 0):
-                    pend = o[1].mem.disp            # lea r8d,[rsi+4], rsi=0
+                    pend, pend_var = o[1].mem.disp, False   # lea r8d,[rsi+4]
                 else:
-                    pend, var_read = None, True     # width from a slot
+                    # A width from a slot -- but only if a stream read
+                    # actually follows. r8 is general-purpose and these
+                    # functions use it for other work: `mov r8, qword ptr
+                    # [rax + rcx*8]` in sub_141296960 is a hash-bucket
+                    # pointer, and treating it as an unsized read refused
+                    # that reader and blocked actionpointinfo's 28,958
+                    # records. Decided at the call site below, which is the
+                    # only place a missing width can matter.
+                    pend, pend_var = None, True
+                    var_seen = True
             if i.mnemonic == "call":
                 if len(o) == 1 and o[0].type == CS_OP_MEM:
                     if pend is not None:
                         reads.append(pend)
-                    pend = None
+                        read_pos.append(n)
+                    elif pend_var:
+                        # An unsized stream read: the width came from a slot.
+                        # This is the CString shape (read 4, then read that
+                        # many), which the ('str', 0) rule below depends on.
+                        var_read = True
+                        read_pos.append(n)
+                    pend, pend_var = None, False
                 elif len(o) == 1 and o[0].type == CS_OP_IMM:
                     if rcx_is_stream:
                         subs.append(o[0].imm)
+                        sub_pos.append((n, o[0].imm))
                 rcx_is_stream = False             # a call clobbers rcx
             if (i.mnemonic.startswith("j") and len(o) == 1
                     and o[0].type == CS_OP_IMM and va <= o[0].imm < i.address):
@@ -520,13 +551,28 @@ class Deriver:
         # A backward branch is only a LOOP if control can return to it. A
         # backward jmp into a shared tail or error block never does, and
         # counting those refused readers that contain no loop at all.
-        has_loop = any(self.closes_cycle(ins, n, t) for n, t in back)
+        addr_i = {x.address: k for k, x in enumerate(ins)}
+        ranges = [(addr_i[t], n) for n, t in back
+                  if t in addr_i and self.closes_cycle(ins, n, t)]
+
+        def _in_loop(p: int) -> bool:
+            return any(lo <= p <= hi for lo, hi in ranges)
+
+        # ...and a loop only matters if a STREAM READ IS INSIDE IT. The old
+        # test asked whether the function had a loop and whether it read
+        # anywhere, which refused readers whose loop touches no stream at
+        # all. sub_141296960 is one: a single 2-byte read, then a loop that
+        # does a lookup and reads nothing. It consumes 2 bytes, and refusing
+        # it blocked actionpointinfo -- 28,958 records, the largest table in
+        # the install.
+        has_loop = (any(_in_loop(p) for p in read_pos)
+                    or any(_in_loop(p) for p, c in sub_pos
+                           if self.reads_stream(c)))
         # A loop is only undecidable when its trip count is unknown -- that
         # is a count-prefixed list, and stage 2 derives its element width.
         # A loop whose bound is an immediate is fully determined, and a loop
         # in a helper that reads nothing consumes nothing either way.
-        if has_loop and (reads or var_read
-                         or any(self.reads_stream(s) for s in subs)):
+        if has_loop:
             loops = self.fixed_loops(ins)
             if not loops:
                 return None
@@ -556,12 +602,21 @@ class Deriver:
                         # `call r9` -- an indirect sized read inside a loop
                         total += pend2 * in_loop.get(idx, 1)
                     pend2 = None
-            if not total:
+            if not total or total > MAX_READER_BYTES:
                 return None
             got = ("fixed", total)
             self._memo[va] = got
             return got
-        if var_read and reads[:1] == [4]:
+        # CString detection deliberately uses the PERMISSIVE flag. The
+        # strict call-site rule misses sub_1411A33C0, which reads its u32
+        # length and then reads the bytes through `call qword ptr [rax+0x20]`
+        # and `call r8` rather than the usual `call [rax+8]` -- so no
+        # unsized read is visible at a recognised call site. The permissive
+        # flag is safe HERE because the rule also requires the reader's
+        # first read to be exactly 4 bytes, which is the length prefix; it
+        # is not safe for the loop veto above, where it counted a
+        # hash-bucket pointer load as a read.
+        if (var_read or var_seen) and reads[:1] == [4]:
             self._memo[va] = ("str", 0)
             return self._memo[va]
         extra, kind = 0, "fixed"
@@ -574,8 +629,10 @@ class Deriver:
             if r[0] in ("str", "strplus"):
                 kind = "strplus"
             extra += r[1]
-        got = (("fixed", 0) if (not reads and extra == 0)
-               else (kind, sum(reads) + extra))
+        total = sum(reads) + extra
+        if total > MAX_READER_BYTES:
+            return None                   # not a width; see MAX_READER_BYTES
+        got = ("fixed", 0) if (not reads and extra == 0) else (kind, total)
         self._memo[va] = got
         return got
 

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -718,6 +718,33 @@ def find_index(explicit: Path | None = None) -> Path | None:
     return next((p for p in cands if _carries_table_list(p)), None)
 
 
+def class_for_stem(stem: str, lower: dict[str, str]) -> str | None:
+    """Map a table's filename stem onto its reflection class name.
+
+    Most tables are the class name lowercased, but a sizeable minority
+    drop the ``Info`` suffix from the FILENAME while keeping it on the
+    class: ``faction.pabgb`` <-> ``FactionInfo``, ``inventory.pabgb`` <->
+    ``InventoryInfo``, ``board.pabgb`` <-> ``BoardInfo``. Twenty of this
+    install's 135 tables are named that way.
+
+    That mattered more than it looks. main() filtered candidates with
+    ``s.lower() in lower`` and silently dropped the rest, so the deriver
+    never looked at ONE of those tables -- they were not failing the
+    tiling gate, they were never offered to it.
+
+    EXACT matches only, ``stem`` then ``stem + "info"``. Deliberately no
+    fuzzy matching: difflib cheerfully offers ``QuickSlotInfo`` for
+    ``equipslotinfo`` and ``RegionInfo`` for ``reviepointinfo``, and
+    binding a table to the wrong class would hand the walker a different
+    type's field order -- which tiling might not even catch if the widths
+    happened to add up.
+    """
+    for k in (stem.lower(), stem.lower() + "info"):
+        if k in lower:
+            return lower[k]
+    return None
+
+
 def table_stems(index: Path) -> list[str]:
     import sqlite3
     con = sqlite3.connect(f"file:{index}?mode=ro", uri=True)
@@ -757,10 +784,20 @@ def main(argv: list[str] | None = None) -> int:
         print("No candidate tables.")
         return 2
     lower = {k.lower(): k for k in d.by_cls}
-    stems = [s for s in stems if s.lower() in lower]
-    print(f"candidate tables with a reflection class: {len(stems)}")
+    resolved = {s: class_for_stem(s, lower) for s in stems}
+    dropped = [s for s, c in resolved.items() if c is None]
+    stems = [s for s in stems if resolved[s]]
+    suffixed = sum(1 for s in stems if resolved[s].lower() != s.lower())
+    print(f"candidate tables with a reflection class: {len(stems)} "
+          f"({suffixed} matched via the dropped-Info filename convention)")
+    if dropped:
+        # Never silently. A table with no reflection class is outside the
+        # static route entirely, and that is a fact about coverage worth
+        # seeing rather than a row quietly missing from the report.
+        print(f"no reflection class, cannot be derived statically: "
+              f"{len(dropped)} ({', '.join(sorted(dropped))})")
 
-    fields = {s: d.field_reads(lower[s.lower()]) for s in stems}
+    fields = {s: d.field_reads(resolved[s]) for s in stems}
 
     # stage 1
     callees = {v for f in fields.values() for _n, k, v in f if k == "call"}

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -888,13 +888,33 @@ class Deriver:
         reports the reader unresolved, which is the correct outcome: the
         shape it needs is one this walker cannot express, and saying
         "unknown" is worth more than a constant that happens to fit today.
+
+        And symmetrically: a reader that IS a count-prefixed list must never
+        be offered a plain FIXED width. factionrelationgroup is the worked
+        example, found by an adversarial review of this pipeline.
+        sub_1412C3ED0 reads a u32 count and then 2 bytes per element, yet
+        stage 2 pinned it ('fixed', 24) UNIQUELY on 5 records -- because the
+        record's four counts happen to sum to 4 every time:
+
+            Graymane        0,2,0,2      HostileCombat   0,3,0,1
+            FriendlyCombat  0,2,0,2      NPC_Common      0,1,0,3
+            Monster_Common  0,4,0,0
+
+        so consumption is 16 + 2*4 = 24 in all five. Byte +12 of that field
+        is two list elements in one record and a u32 list header in another.
+        Perturbing the width does not catch it -- every +/-1 of 24 fails, so
+        it looks firmly pinned -- and the five records agree with each other,
+        so more of THIS table would not help either. Only the reader's own
+        code separates the two readings.
+
+        Stage 1b pins such a reader before any search, so this branch is the
+        second line of defence for a caller that reaches search() without it.
         """
-        out = [("fixed", n) for n in range(MAX_ELEM + 1)]
-        offer_lists = True
-        if va is not None:
-            el = self.list_element(va)
-            if el is not None and el[0] == "variable":
-                offer_lists = False
+        el = self.list_element(va) if va is not None else None
+        offer_fixed = el is None or el[0] != "fixed"
+        offer_lists = el is None or el[0] != "variable"
+        out = ([("fixed", n) for n in range(MAX_ELEM + 1)]
+               if offer_fixed else [])
         if offer_lists:
             out += [("list", n) for n in range(1, MAX_ELEM + 1)]
         out += [("str", n) for n in range(33)]


### PR DESCRIPTION
> **Current state** (this PR grew well past its original scope — the sections below are the first wave, and the commit log plus comments carry the rest):
>
> **7 → 46 tables proven byte-exact, 61,111 records**, every one held to exact tiling on 100% of its records through CDUMM's own `_consume_field_bytes`. Five coincidental layouts caught and retracted; ten bugs fixed in the derivation itself, two of which I introduced and the gate caught before they shipped. Full suite 3047 passed / 43 skipped.
>
> 100% coverage is **not** reachable by this route, for three measured reasons: 4 tables have no reflection class in the exe at all (`entitlementinfo`, `keymap`, `levelinfo`, `reviepointinfo`); the largest remaining table (`actionpointinfo`, 28,958 records) is a recursive tree; and the rest are dominated by unsized reads inside larger structs (26 tables / 15,692 records). Nothing unreached is editable — the grid refuses every field when `verified_fields is None`.

---

Continuing the table-derivation work from #360. Six new tables read record-by-record, two shipped entries **retracted as wrong**, and four bugs fixed in the deriver — two of which were silently capping coverage, and one of which had already put a wrong layout into a release.

Measured on game buildid 24613230. Every number here is from a run, not an estimate.

## The retraction first

`HouseInfo._houseRegionDataList` shipped in v3.13 as `CArray<[u8;46]>` and `FailMessageInfo._failMessageInfoList` as `CArray<[u8;33]>`. **Both are wrong.** Neither element has a constant width — each ends in a string read:

```
sub_1412A8A50 element = sub_14129CD10(4B) + sub_141297490(4B) + sub_1411A31F0 CString  = 12 + n
sub_1412AABF0 element = sub_141296000(4B) + sub_141071DE0 LocalizableString            = 17 + n
```

They fitted because every string in the measured build is one length: HouseInfo's 7 element strings are all 34 bytes (12+34 = 46), FailMessageInfo's 18 are all 16 (17+16 = 33). I walked both tables under the fixed *and* the variable model and **both tile 100% of records exactly**, so no amount of data from this build separates them. The disassembly does.

The root cause is not a slip in two entries. Stage 2 recovers a list element width by fitting table data, and `Deriver.candidates()` offers **only fixed-width list elements** — there is no variable-element list shape in that space at all. So unique-or-nothing reported uniqueness inside a space that never contained the competing hypothesis. Uniqueness within an incomplete candidate set is not uniqueness, and 4 and 11 records are few enough for a constant to land by coincidence.

Corrected by defining the elements as substructs, following the existing `StageInfo_Field608Entry` precedent (`u32 + CString`). I audited every `CArray<>` in the shipped overrides against its reader's disassembly; exactly these two claimed a fixed width the element does not have.

**User impact: none.** Both tables have `_verified_fields` empty, so nothing writes to them and the grid shows no values from them. The entries were wrong, not dangerous.

## Four bugs in the deriver

**`find_index` could never match the `.bak` files its own docstring promised.** The glob was `game_index*.sqlite*`, but the rotated copy is `game_index.<timestamp>.bak` — the timestamp *replaces* the extension. Symptom: "No game index found under %LOCALAPPDATA%/cdumm" on a machine with one sitting right there, which is how I hit it. Candidates are now validated by content (opened and checked for `data_tables`) rather than by filename, since filename matching is what failed.

**25 of the install's 135 tables were being dropped silently.** `main()` picked candidates with `s.lower() in lower` and dropped every stem with no identically-named reflection class. 20 were dropped for nothing but a filename convention — the file omits the `Info` the class keeps (`faction.pabgb` ↔ `FactionInfo`, `board.pabgb` ↔ `BoardInfo`). Those tables were never failing the tiling gate; they were never offered to it, and the count just read 94 and looked complete. `class_for_stem()` tries `stem` then `stem + "info"`, **exact matches only** — no fuzzy matching, because difflib cheerfully offers `QuickSlotInfo` for `equipslotinfo` and `RegionInfo` for `reviepointinfo`, and binding a table to the wrong class hands the walker another type's field order. Candidates: **94 → 112.**

**A proven table was still listed as ambiguous.** `dialogvoiceinfo` appeared under PROVEN with 519 records *and* under AMBIGUOUS with "130 shapes tile". Stage 2 runs to a fixed point and a table ambiguous early is often proven later once another table pins the reader that was free in this one; `ambiguous[stem]` was never cleared when that happened.

**163 of 167 stage-1 refusals were a single cause.** `LOOP_UNPINNED`: `fixed_loops` only pins a loop whose trip count is an immediate, and these are `CArray<T>` readers whose count is read from the stream. But a dynamic count does not imply a dynamic element — the loop body's own reads settle it without touching table data. `Deriver.list_element()` now derives it.

Two things were needed, and I found both by the method **failing its oracle**, not by reasoning:

- **Frame tracking.** The same slot is reached through different registers: `sub_1412A8A50` stores its count via `lea rdx, [r11 + 8]` and bounds its loop with `cmp dword ptr [rsp + 0xa0]`. `r11` was `rsp` on entry and `rsp` has since moved 0x98, so `rsp+0xa0 == r11+8` — one slot, two spellings. `rsp` is tracked through the **prologue only** and then frozen, because a linear sweep cannot tell an epilogue from fall-through code, and `sub_14129A5F0`'s early-return `add rsp,0x38 / pop / pop` shifted every later slot by 0x48.
- **`r8` is general-purpose.** `mov r8, qword ptr [rcx + rdx*8]` in `sub_14129A5F0`'s body is a hash-bucket pointer load, not a read width. Treating any non-immediate `r8` write as an unsized read refused all eight oracle readers.

## The oracle

Stage 2 had already pinned eight of these readers from table data — an independent line of evidence. The static derivation had to agree or be thrown away:

| check | result |
|---|---|
| reproduces the data-derived width exactly | 5 (widths 2, 2, 4, 12, 16) |
| correctly reported **variable** | 2 (the retraction above) |
| abstained rather than guess | 1 |
| contradictions | **0** |
| false positives on the 4 readers proved plain fixed | **0** |

`candidates()` is now reader-aware and withholds the list shapes when the element is variable, so those readers come back *unresolved* — which is correct, since the shape they need is not in this walker's grammar.

## Six tables wired in

Verified through CDUMM's own `_consume_field_bytes`, not the deriver's walker:

| table | records | fields |
|---|---|---|
| `factiongroup` | 7 | 6 |
| `uisocialaction` | 2 | 5 |
| `crafttoolinfo` | 19 | 4 |
| `crafttoolgroupinfo` | 12 | 5 |
| `factionreblockadinginfo` | 108 | 5 |
| `globalgameeventgroup` | 12 | 6 |

**Keyed by file stem**, which is the part that would have failed silently. `_load_schemas` iterates the base schema and does `overrides.get(table_name)` with no normalisation, and the app asks `get_schema()` for the stem `identify_table_from_path` returns. An override keyed `FactionGroupInfo` resolves to `factiongroupinfo` — a key nothing ever looks up for `factiongroup.pabgb` — and would have sat in the file doing nothing while a verification script that passed the class name reported EXACT on 100% of records. My first attempt did exactly that; `has_schema(stem)` is now part of the gate.

## One table withdrawn by the rule, not by hand

`royalsupply` proved, and I withdrew it. Its element reader `sub_1412A1370` calls `sub_1412A11E0`, which is **itself** a count-prefixed list (`4 + count*20`) — so the element varies with the inner count, and the unique `('list', 28)` fit only holds while every inner count is 1. That is the HouseInfo coincidence one level deeper, on a 4-record table. `list_element` now returns `variable` when an element's sub-reader is itself a list instead of abstaining, and `royalsupply` drops out of the deriver's own PROVEN set as a consequence.

The remaining small tables are safe for a reason rather than by luck. `factiongroup` (7), `uisocialaction` (2), `crafttoolgroupinfo` (12) and `factionreblockadinginfo` (108) are **fully static** — every width comes from the disassembly and the data refereed nothing, so a low record count cannot flatter them. `crafttoolinfo` (19) and `globalgameeventgroup` (12) each have one searched width, unique among ~290 shapes across records of differing lengths.

## Verification

```
28 derived entries, exact tiling on 100% of records, 0 failed, 54,596 records
deriver:  candidates 94 -> 112,  PROVEN 22 -> 26 tables,  AMBIGUOUS 6 -> 4
          sub-readers 52 solved + 50 count-prefixed lists pinned from the loop body
full test suite: 2997 passed, 43 skipped
```

Still `_verified_fields: []` on every derived table. Tiling proves where a field sits, not what it means — these are readable, not editable, and nothing writes to them.

## Known-unfixed, measured

`conditioninfo` (10,529 records) is the largest table still refusing, and it is now fully classified so the refusal is real rather than a scan artefact. `solve_reader` assumes the stream arrives in `rcx`; `sub_141EF6800` takes it in `rdx`. That assumption is wrong for at least one reader and I have not fixed it here.

