### PR TITLE
Table coverage wave 3: +2 tables, a field order the hot path got wrong, and a duplicate substruct key

### DIFF
--- a/schemas/pabgb_complete_schema.json
+++ b/schemas/pabgb_complete_schema.json
@@ -28565,5 +28565,40 @@
   {
    "f": "_wayPointData"
   }
+ ],
+ "uitalktreeinfo": [
+  {
+   "f": "_isBlocked"
+  },
+  {
+   "f": "_rootTalkTreeInfo"
+  },
+  {
+   "f": "_parentTalkTreeInfo"
+  },
+  {
+   "f": "_childTalkTreeInfoList"
+  },
+  {
+   "f": "_conditionInfo"
+  },
+  {
+   "f": "_targetConditionInfo"
+  },
+  {
+   "f": "_buttonText"
+  },
+  {
+   "f": "_npcActivityInfo"
+  },
+  {
+   "f": "_interactionInfo"
+  },
+  {
+   "f": "_effectInfo"
+  },
+  {
+   "f": "_resultDataList"
+  }
  ]
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2830,5 +2830,43 @@
     "_wayPointData": {
       "type": "FactionWayPointInfo_wayPointData"
     }
+  },
+  "LevelActionPointInfo": {
+    "_meta_note": "Derived 2026-08-12 from game buildid 24613230 by tools/derive_table_layout.py, reflection class LevelActionPointInfo. Field ORDER from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS from the sized reads in the deserializer; count-prefixed list element widths from the loop body via Deriver.list_element. PROOF: the walk consumes every one of this table's 60 records to its exact last byte. KEYED BY FILE STEM 'levelactionpointinfo' because that is what identify_table_from_path returns and what get_schema is asked for. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means. _levelActionPointGroupList is a list whose ELEMENT has no constant width, so it is CArray<LevelActionPointInfo_LevelActionPointGroupEntry> rather than CArray<[u8;N]>. The element's members come from the loop body's own read sequence via Deriver.element_parts, which independently reproduces the two substructs written by hand for HouseInfo and FailMessageInfo. Member names are anonymous on purpose: the parts give structure and say nothing about meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_accessType",
+      "_levelActionPointGroupList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_accessType": {
+      "type": "u8"
+    },
+    "_levelActionPointGroupList": {
+      "type": "CArray<LevelActionPointInfo_LevelActionPointGroupEntry>"
+    }
+  },
+  "MaterialBloodDecalInfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py. Widths are static: _isBlocked u8 and _skillKey u32 from sized reads, and _bloodDecalVariationData from Deriver.list_element, which gives a variable element of 20 + n (a CString plus 16 fixed bytes). ORDER WAS CORRECTED AGAINST THE BYTES. The hot-path branch ranking put _bloodDecalVariationData BEFORE _skillKey, because the list's guard branch sits at 0x14128893F and _skillKey's at 0x141288960, and that order tiles 0 of 13 records. It cannot be right: reading the list first takes the 4 bytes at payload offset 1 as its element count, i.e. 0x00015F90 = 89,999 elements. With the list last, record 0 accounts exactly -- 1 + 4 + 4 + 4*25 = 109 -- and so do all 13. The remaining ambiguity is that _isBlocked and _skillKey are 1 and 4 bytes before a variable field, so swapping them preserves the total and BOTH orders tile 13/13; the data cannot separate them. Two independent things settle it: the hot-path ranking, which is reliable for these two (_isBlocked 0x14128891F precedes _skillKey 0x141288960 and was only wrong about the list), and the format-wide convention that _isBlocked is the first field of very nearly every table. _verified_fields is EMPTY: this proves structure, not meaning.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_skillKey",
+      "_bloodDecalVariationData"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_skillKey": {
+      "type": "u32"
+    },
+    "_bloodDecalVariationData": {
+      "type": "CArray<MaterialBloodDecalInfo_BloodDecalVariationEntry>"
+    }
   }
 }

--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2868,5 +2868,56 @@
     "_bloodDecalVariationData": {
       "type": "CArray<MaterialBloodDecalInfo_BloodDecalVariationEntry>"
     }
+  },
+  "uitalktreeinfo": {
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class UITalkTreeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 175 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'uitalktreeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_no_null_skip": true,
+    "_ordered_fields": [
+      "_isBlocked",
+      "_rootTalkTreeInfo",
+      "_parentTalkTreeInfo",
+      "_childTalkTreeInfoList",
+      "_conditionInfo",
+      "_targetConditionInfo",
+      "_buttonText",
+      "_npcActivityInfo",
+      "_interactionInfo",
+      "_effectInfo",
+      "_resultDataList"
+    ],
+    "_verified_fields": [],
+    "_isBlocked": {
+      "type": "u8"
+    },
+    "_rootTalkTreeInfo": {
+      "type": "u16"
+    },
+    "_parentTalkTreeInfo": {
+      "type": "u16"
+    },
+    "_childTalkTreeInfoList": {
+      "type": "CArray<u16>"
+    },
+    "_conditionInfo": {
+      "type": "u32"
+    },
+    "_targetConditionInfo": {
+      "type": "u32"
+    },
+    "_buttonText": {
+      "type": "LocalizableString"
+    },
+    "_npcActivityInfo": {
+      "type": "u32"
+    },
+    "_interactionInfo": {
+      "type": "u32"
+    },
+    "_effectInfo": {
+      "type": "u32"
+    },
+    "_resultDataList": {
+      "type": "u32"
+    }
   }
 }

--- a/src/cdumm/engine/schema_verify.py
+++ b/src/cdumm/engine/schema_verify.py
@@ -718,3 +718,136 @@ def verify_order_source_relative(candidate: dict[str, list[str]]
             continue
         out.append(relative_order_matches(table, cand))
     return out
+
+
+# ── does the shipped schema actually FRAME this table's records? ──────────
+#
+# Distinct from everything above, and needed for a different reason. The
+# checks above ask whether a candidate ORDER is trustworthy. This asks a
+# blunter question about a table the app is about to display: does the
+# schema account for every byte of a record, on the build in front of us?
+#
+# It matters because the answer is often no. Measured on game buildid
+# 24613230, walking all 135 tables in the install through get_schema() and
+# _consume_field_bytes: 49 tile exactly, 4 partially, and 38 tables whose
+# ONLY decoder is the generic schema frame no record correctly at all --
+# 61,795 records' worth. Those are pre-existing base-schema entries whose
+# widths do not add up on this build.
+#
+# Nothing there is editable: _editable_columns refuses every field when
+# `verified_fields is None`, which is the case for a base-only table. So it
+# is not dangerous. But the grid still renders, and a grid built from a
+# layout that is known-wrong the moment anyone checks reads as data. That is
+# what this exists to label.
+
+@dataclass(frozen=True)
+class LayoutFit:
+    """How much of a table the schema the GRID USES actually accounts for.
+
+    Two different properties, and conflating them is a trap I walked into
+    while writing this. ``exact`` is byte-exact tiling -- the walk consumed
+    the record to its last byte. That is the right gate for DERIVING and
+    SHIPPING a layout, and it is what the whole derivation pipeline is held
+    to. It is the WRONG test for "should the user trust this grid",
+    because a schema that models the first N fields correctly and leaves
+    unmodelled tail bytes shows N correct columns and still fails it.
+    Measured: iteminfo, characterinfo, stageinfo, regioninfo and storeinfo
+    all tile 0 of 200 sampled records while displaying perfectly useful
+    columns.
+
+    ``complete`` is the display-relevant one: did the walk get through the
+    schema's whole field list without a field failing to consume? If it
+    dies at field 2 of 15, every column after that is meaningless, and THAT
+    is what deserves a warning.
+    """
+
+    records: int          # records in the table
+    checked: int          # how many were sampled
+    complete: int         # of those, how many walked the entire field list
+    exact: int            # of those, how many ALSO ended on the last byte
+    schema_fields: int
+    median_fields: int    # typical number of fields the walk gets through
+
+    @property
+    def ratio(self) -> float:
+        return (self.complete / self.checked) if self.checked else 0.0
+
+    @property
+    def usable(self) -> bool:
+        """The walk finishes the field list on every sampled record."""
+        return self.checked > 0 and self.complete == self.checked
+
+    @property
+    def broken(self) -> bool:
+        """The walk finishes on NO sampled record.
+
+        The strong signal: the schema cannot frame this build's data at all,
+        so any column past the failure point is noise. Deliberately not
+        "some records failed" -- a layout that works on most records and
+        stumbles on an edge case still shows a useful grid.
+        """
+        return self.checked > 0 and self.complete == 0
+
+
+def layout_fit(table: str, body: bytes, header: bytes,
+               max_samples: int = 200) -> LayoutFit | None:
+    """Sample records and report how far the display schema actually gets.
+
+    Sampled rather than exhaustive so this is cheap enough for the display
+    path: actionpointinfo has 28,958 records and the answer does not get
+    more true after the two-hundredth. Samples are spread evenly rather than
+    taken from the front, because the first records of a table are the least
+    representative -- a layout that is wrong about a variable-length field
+    often survives the short early ones.
+
+    Returns None when the question cannot be asked (no schema, no index),
+    which the caller must treat as "unknown", not as "broken".
+    """
+    try:
+        # schema_for_table, NOT get_schema. This must measure the schema the
+        # GRID ACTUALLY USES: parse_records_display calls schema_for_table,
+        # which picks the field-order variant that fits this build.
+        schema = schema_for_table(table, body, header)
+        if schema is None or not schema.fields:
+            return None
+        key_size, offsets = parse_pabgh_index(header, table)
+    except Exception:                                       # noqa: BLE001
+        return None
+    if not offsets:
+        return None
+    ent = sorted(offsets.items(), key=lambda kv: kv[1])
+    n = len(ent)
+    step = max(1, n // max_samples)
+    idxs = list(range(0, n, step))[:max_samples]
+    complete = exact = 0
+    depths: list[int] = []
+    for i in idxs:
+        off = ent[i][1]
+        end = ent[i + 1][1] if i + 1 < n else len(body)
+        try:
+            p = _payload_offset(body, off, key_size,
+                                no_null_skip=schema.no_null_skip,
+                                no_entry_header=schema.no_entry_header)
+        except Exception:                                   # noqa: BLE001
+            p = None
+        if p is None:
+            depths.append(0)
+            continue
+        walked = 0
+        for f in schema.fields:
+            try:
+                c = _consume_field_bytes(body, p, f, end)
+            except Exception:                               # noqa: BLE001
+                c = None
+            if c is None:
+                break
+            p += c
+            walked += 1
+        depths.append(walked)
+        if walked == len(schema.fields):
+            complete += 1
+            if p == end:
+                exact += 1
+    return LayoutFit(records=n, checked=len(idxs), complete=complete,
+                     exact=exact, schema_fields=len(schema.fields),
+                     median_fields=int(median(depths)) if depths else 0)

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -496,8 +496,18 @@ class _PreviewWorker(QObject):
                         table, body, header)
                     cols, rows, total, health = _shape_records(
                         recs, sem.get_schema(table), positions)
+                    # Structural check, separate from `health`. `health` is
+                    # a heuristic about VALUES looking unusable; this asks
+                    # whether the schema can frame the record at all on
+                    # this build. Sampled, so it stays cheap even on
+                    # stageinfo's 51,595 records.
+                    try:
+                        from cdumm.engine.schema_verify import layout_fit
+                        fit = layout_fit(table, body, header)
+                    except Exception:  # noqa: BLE001 - never block the view
+                        fit = None
                     res.update(kind="table", table=table, cols=cols,
-                               rows=rows, total=total, health=health,
+                               rows=rows, total=total, health=health, layout=fit,
                                has_pos=bool(positions),
                                gear_stats=_locate_gear_stats(
                                    table, body, header))
@@ -1619,12 +1629,37 @@ class GameDataPage(ToolPageBase):
             total = res.get("total", 0)
             shown = len(res.get("rows", []))
             more = f" (showing first {shown:,})" if shown < total else ""
-            if res.get("health", 0.0) >= 0.9:
-                note = ("\n⚠ field columns didn't parse cleanly for this "
-                        "table on this build — trust _key and _name only")
+            # Structural verdict first: it is measured rather than
+            # heuristic, and it answers something `health` cannot -- whether
+            # the schema can frame this build's records at all.
+            fit = res.get("layout")
+            if fit is not None and fit.broken:
+                note = (f"\n\u26a0 CDUMM cannot read this table's layout on "
+                        f"this game build \u2014 the walk stops after about "
+                        f"{fit.median_fields} of {fit.schema_fields} fields "
+                        f"on every record sampled. Columns past that point "
+                        f"are meaningless; trust _key and _name only")
+            elif res.get("health", 0.0) >= 0.9:
+                note = ("\n\u26a0 field columns didn't parse cleanly for "
+                        "this table on this build \u2014 trust _key and "
+                        "_name only")
+            elif fit is not None and fit.checked and not fit.usable:
+                note = (f"\n\u26a0 this table's layout only reads on "
+                        f"{fit.ratio:.0%} of records sampled \u2014 some "
+                        f"rows' columns will be misaligned; _key and _name "
+                        f"are authoritative")
+            elif fit is not None and fit.usable and not fit.exact:
+                note = ("\nfield columns read consistently, but the schema "
+                        "doesn't account for every byte of a record, so a "
+                        "column may still be misaligned; _key and _name are "
+                        "authoritative")
+            elif fit is not None and fit.exact:
+                note = ("\nfield columns account for every byte of every "
+                        "record sampled \u2014 the strongest signal CDUMM "
+                        "has that this layout fits your build")
             else:
-                note = ("\nfield columns are experimental (from CDUMM's patch "
-                        "parser); _key and _name are authoritative")
+                note = ("\nfield columns are experimental (from CDUMM's "
+                        "patch parser); _key and _name are authoritative")
             if res.get("has_pos"):
                 note += ("\nworld pos (X, Y, Z) = decoded, region-validated "
                          "map coordinates for mod-makers")

--- a/src/cdumm/semantic/pabgb_types.py
+++ b/src/cdumm/semantic/pabgb_types.py
@@ -403,6 +403,31 @@ SUBSTRUCT_DEFS: dict[str, list[tuple[str, str]]] = {
         ("key", "u32"),
         ("message", "LocalizableString"),
     ],
+    # ── Derived variable-length list elements (2026-08-12) ──────────────
+    # Members come from each reader's own loop body via
+    # Deriver.element_parts. Names are anonymous: structure is
+    # derived, meaning is not, so nothing here may be gated to
+    # _verified_fields on the strength of a name.
+    "RoyalSupplyInfo_QuestEntry": [  # sub_1412A1370 element
+        ("u32", "u32"),
+        ("list", "CArray<[u8;20]>"),
+    ],
+    "PartPrefabDyeTexturePalleteInfo_TextureSetArrayEntry": [  # sub_1412A3630 element
+        ("name", "CString"),
+        ("name_2", "CString"),
+        ("name_3", "CString"),
+        ("name_4", "CString"),
+        ("u32", "u32"),
+    ],
+    "MaterialBloodDecalInfo_BloodDecalVariationEntry": [  # sub_1412A4290 element
+        ("name", "CString"),
+        ("u32", "u32"),
+        ("blob", "[u8;12]"),
+    ],
+    "LevelActionPointInfo_LevelActionPointGroupEntry": [  # sub_1412A4450 element
+        ("u32", "u32"),
+        ("list", "CArray<[u8;12]>"),
+    ],
 
     # ── A struct-shaped FIELD reader (2026-08-13) ──────────────────────────
     # Not a list element: _wayPointData is a single struct whose width is not
@@ -420,10 +445,6 @@ SUBSTRUCT_DEFS: dict[str, list[tuple[str, str]]] = {
     # Deriver.element_parts. Names are anonymous: structure is
     # derived, meaning is not, so nothing here may be gated to
     # _verified_fields on the strength of a name.
-    "RoyalSupplyInfo_QuestEntry": [  # sub_1412A1370 element
-        ("u32", "u32"),
-        ("list", "CArray<[u8;20]>"),
-    ],
     "RelationInfo_KeyEntry": [  # sub_1412A1970 element
         ("u32", "u32"),
         ("list", "CArray<u32>"),

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -103,6 +103,16 @@ DERIVED = {
     "EquipTypeInfo": 112,
     "QuestGroupInfo": 42,
     "AIActionAttributeInfo": 2,
+    # ── added 2026-08-13 ─────────────────────────────────────────────────
+    # LevelActionPointInfo came from re-running the substruct wiring after
+    # the .pdata sweep resolved 124 more fields.
+    #
+    # MaterialBloodDecalInfo is the one table on this branch whose ORDER was
+    # corrected against the bytes. The hot-path ranking put the list before
+    # _skillKey and tiled 0 of 13; that reading needs an element count of
+    # 0x15F90 (89,999), so it cannot be right. See its _meta_note.
+    "LevelActionPointInfo": 60,
+    "MaterialBloodDecalInfo": 13,
     # ── added 2026-08-13: a struct-shaped FIELD reader ────────────────────
     # _wayPointData is a single struct, not a list element, whose width is
     # not constant because it ends in a counted list. Decomposed by

--- a/tests/test_derived_table_overrides.py
+++ b/tests/test_derived_table_overrides.py
@@ -113,6 +113,11 @@ DERIVED = {
     # 0x15F90 (89,999), so it cannot be right. See its _meta_note.
     "LevelActionPointInfo": 60,
     "MaterialBloodDecalInfo": 13,
+    # Unlocked by resolving register-carried read widths: MSVC hoists a
+    # literal into a callee-saved register when a deserialiser does many
+    # reads of the same size, so the width is `mov r8d, r15d` rather than an
+    # immediate. Resolved by UNIQUE DEFINITION over the function.
+    "uitalktreeinfo": 175,
     # ── added 2026-08-13: a struct-shaped FIELD reader ────────────────────
     # _wayPointData is a single struct, not a list element, whose width is
     # not constant because it ends in a counted list. Decomposed by

--- a/tests/test_layout_fit.py
+++ b/tests/test_layout_fit.py
@@ -1,0 +1,133 @@
+"""The Game Data grid must say when it cannot read a table's layout.
+
+Measured on game buildid 24613230, walking all 135 tables in an install:
+38 tables whose only decoder is the generic schema frame no record
+correctly, 61,795 records' worth. Nothing there is editable -- the grid
+refuses every field when ``verified_fields is None`` -- so it is not
+dangerous. But it still renders a grid, and a grid built from a layout that
+is wrong the moment anyone checks reads as data. ``layout_fit`` is what
+labels it.
+
+The distinction these tests exist to pin, because getting it wrong produces
+a warning on the app's best tables:
+
+  * ``exact`` (byte-exact tiling) is the right gate for DERIVING and
+    SHIPPING a layout, and the derivation pipeline is held to it.
+  * ``complete`` (the walk gets through the whole field list) is the right
+    signal for DISPLAY. A schema that models the first N fields correctly
+    and leaves unmodelled tail bytes shows N correct columns and still
+    fails tiling -- iteminfo, characterinfo, stageinfo, regioninfo and
+    storeinfo all tile 0 of 200 sampled records.
+
+Only ``complete == 0`` earns the strong warning: the walk dies partway, so
+every column after that point is noise.
+"""
+from __future__ import annotations
+
+import pytest
+
+from cdumm.engine.schema_verify import LayoutFit, layout_fit
+from tests.fixture_loaders import load_vanilla113
+
+
+def _fit(**kw) -> LayoutFit:
+    base = {"records": 100, "checked": 10, "complete": 10, "exact": 10,
+            "schema_fields": 5, "median_fields": 5}
+    base.update(kw)
+    return LayoutFit(**base)
+
+
+# ── the verdict properties ───────────────────────────────────────────────
+
+def test_all_records_walking_the_whole_field_list_is_usable():
+    f = _fit(complete=10, checked=10)
+    assert f.usable
+    assert not f.broken
+    assert f.ratio == 1.0
+
+
+def test_no_record_completing_is_broken():
+    """The strong signal: the schema cannot frame this build's data."""
+    f = _fit(complete=0, exact=0, median_fields=2, schema_fields=15)
+    assert f.broken
+    assert not f.usable
+    assert f.ratio == 0.0
+
+
+def test_a_partial_read_is_neither_usable_nor_broken():
+    """Most records fine, some not -- a caution, not a condemnation.
+
+    iteminfo is the real case: 173 of 200 sampled records walk all 109
+    fields. Calling that broken would slander a table whose grid is
+    overwhelmingly correct.
+    """
+    f = _fit(complete=173, checked=200)
+    assert not f.usable
+    assert not f.broken
+    assert f.ratio == pytest.approx(0.865)
+
+
+def test_completing_without_tiling_is_still_usable():
+    """The distinction the whole feature turns on.
+
+    A schema can walk every field it models and still leave bytes at the end
+    of the record, because the table has fields the schema does not model.
+    The columns it DOES show are fine, so this must not warn as if the
+    layout were wrong.
+    """
+    f = _fit(complete=200, checked=200, exact=0)
+    assert f.usable
+    assert not f.broken
+    assert f.exact == 0
+
+
+def test_nothing_checked_is_neither_verdict():
+    """An empty sample must not read as a clean bill of health."""
+    f = _fit(checked=0, complete=0, exact=0)
+    assert not f.usable
+    assert not f.broken
+    assert f.ratio == 0.0
+
+
+# ── against a committed fixture ──────────────────────────────────────────
+
+def test_layout_fit_reports_on_a_real_table():
+    """It must return a populated verdict for a real table's bytes.
+
+    Uses the committed vanilla 1.13 iteminfo fixture so this runs in CI
+    with no game install.
+    """
+    body = load_vanilla113("iteminfo.pabgb")
+    header = load_vanilla113("iteminfo.pabgh")
+    fit = layout_fit("iteminfo", body, header)
+    assert fit is not None, "iteminfo has a schema; the check must apply"
+    assert fit.records > 1000
+    assert fit.checked > 0
+    assert fit.schema_fields > 0
+    # Whatever the verdict, the counts must be internally consistent:
+    # a record cannot tile without also completing.
+    assert fit.exact <= fit.complete <= fit.checked
+
+
+def test_sampling_is_bounded_and_spread():
+    """The check runs on the display path, so it must stay cheap.
+
+    actionpointinfo has 28,958 records and the answer does not get more
+    true after the two-hundredth.
+    """
+    body = load_vanilla113("iteminfo.pabgb")
+    header = load_vanilla113("iteminfo.pabgh")
+    fit = layout_fit("iteminfo", body, header, max_samples=25)
+    assert fit is not None
+    assert fit.checked <= 25
+
+
+def test_unknown_table_returns_none_rather_than_broken():
+    """No schema means "unknown", never "broken".
+
+    A table CDUMM has no schema for must not be labelled unreadable -- the
+    caller has to be able to tell those two apart.
+    """
+    body = load_vanilla113("iteminfo.pabgb")
+    header = load_vanilla113("iteminfo.pabgh")
+    assert layout_fit("NoSuchTableInfo", body, header) is None

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -73,13 +73,13 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            # Unlocked by the .pdata function-bounds sweep (2026-08-13).
            "AIEventTableInfo", "UIMapTextureInfo", "KnowledgeGroupInfo", "QuestGaugeInfo", "GameAdviceInfo", "CategoryInfo", "GimmickGateInfo", "gimmickgateconnection", "EquipTypeInfo", "QuestGroupInfo", "AIActionAttributeInfo",
            "factionwaypoint", "LevelActionPointInfo",
-           "MaterialBloodDecalInfo"}
+           "MaterialBloodDecalInfo", "uitalktreeinfo"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 54 deliberately: the 47 in DERIVED have an
+    It grew from 7 to 55 deliberately: the 48 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -88,7 +88,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 54
+    assert len(tabs) == 55
 
 
 def test_ground_truth_passes_itself():

--- a/tests/test_schema_verify.py
+++ b/tests/test_schema_verify.py
@@ -72,13 +72,14 @@ DERIVED = {"AIDialogTypeInfo", "BreakableObjectInfo", "CategoryGroupInfo",
            "RelationInfo", "royalsupply",
            # Unlocked by the .pdata function-bounds sweep (2026-08-13).
            "AIEventTableInfo", "UIMapTextureInfo", "KnowledgeGroupInfo", "QuestGaugeInfo", "GameAdviceInfo", "CategoryInfo", "GimmickGateInfo", "gimmickgateconnection", "EquipTypeInfo", "QuestGroupInfo", "AIActionAttributeInfo",
-           "factionwaypoint"}
+           "factionwaypoint", "LevelActionPointInfo",
+           "MaterialBloodDecalInfo"}
 
 
 def test_the_verified_order_set_is_exactly_what_we_expect():
     """A change here must be deliberate, not accidental.
 
-    It grew from 7 to 52 deliberately: the 45 in DERIVED have an
+    It grew from 7 to 54 deliberately: the 47 in DERIVED have an
     `_ordered_fields` proven by exact tiling on 100% of their records, so a
     candidate order source now has to reproduce them too. That is a real
     strengthening of the gate, and the reason it is spelled out rather than
@@ -87,7 +88,7 @@ def test_the_verified_order_set_is_exactly_what_we_expect():
     tabs = tables_with_verified_order()
     assert ITEM in tabs
     assert set(tabs) == HAND_RE | DERIVED
-    assert len(tabs) == 52
+    assert len(tabs) == 54
 
 
 def test_ground_truth_passes_itself():

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -1167,16 +1167,67 @@ class Deriver:
                     break
                 k -= 1
             w = None
+            src_reg = None
             for x in ins[start:j]:
                 oo = x.operands
-                if (x.mnemonic == "mov" and len(oo) == 2
+                if not (x.mnemonic == "mov" and len(oo) == 2
                         and oo[0].type == CS_OP_REG
-                        and oo[1].type == CS_OP_IMM
                         and "r8" in x.op_str.split(",")[0]):
-                    w = oo[1].imm
+                    continue
+                if oo[1].type == CS_OP_IMM:
+                    w, src_reg = oo[1].imm, None
+                elif oo[1].type == CS_OP_REG:
+                    # `mov r8d, r15d` -- the width is in a register. MSVC
+                    # hoists a literal into a callee-saved register when a
+                    # deserialiser performs many reads of the same size, so
+                    # the constant is defined once and reused. After the
+                    # .pdata sweep this accounts for EVERY remaining '?':
+                    # 86 fields, all `mov r8d, <reg>` (r15d 41, r12d 30,
+                    # r13d 12, r14d 2, ebp 1), and zero misalignments.
+                    w, src_reg = None, self.md.reg_name(oo[1].reg)
+            if w is None and src_reg:
+                w = self._const_reg(ins, j, src_reg)
             out.append((fld, "fixed", w) if w is not None
                        else (fld, "?", None))
         return out
+
+    def _const_reg(self, ins: list, before: int, reg: str):
+        """The constant in ``reg`` at instruction ``before``, or None.
+
+        Resolved by UNIQUE DEFINITION: every write to the register anywhere
+        in the function is collected, and a value is returned only when
+        there is exactly one and it is `mov <reg>, <imm>`. Two definitions
+        mean the value depends on a path this scan does not follow, and the
+        honest answer is then "unknown" -- the same unique-or-nothing rule
+        the widths and list elements are held to.
+
+        Deliberately not a backward walk to the nearest assignment: the
+        nearest one in ADDRESS order is not necessarily the one that
+        reaches, and picking it would be exactly the kind of plausible
+        guess this pipeline exists to refuse.
+        """
+        from capstone import CS_OP_IMM, CS_OP_REG
+        q = Frame.q(reg)
+        vals = set()
+        for x in ins[:before]:
+            o = x.operands
+            if len(o) < 1 or o[0].type != CS_OP_REG:
+                continue
+            dst = x.op_str.split(",")[0].strip()
+            if Frame.q(dst) != q:
+                continue
+            if (x.mnemonic == "mov" and len(o) == 2
+                    and o[1].type == CS_OP_IMM):
+                vals.add(o[1].imm)
+            elif x.mnemonic == "xor" and len(o) == 2:
+                b = x.op_str.split(",", 1)[1].strip()
+                vals.add(0 if Frame.q(b) == q else None)
+            else:
+                vals.add(None)              # some other write: not a constant
+        if len(vals) != 1:
+            return None
+        v = next(iter(vals))
+        return v if isinstance(v, int) and 0 < v <= MAX_ELEM else None
 
     # ── the gate ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-on from #362. **48 shipped entries, exact tiling on 100% of records, 61,184 records** (was 46 / 60,636). Full suite 3053 passed, 43 skipped.

## `levelactionpointinfo` (60 records) came free

Re-running the substruct wiring after #362's `.pdata` sweep — which resolved 124 more fields — made its variable list element describable.

## `materialblooddecalinfo`: the hot-path order was wrong

This table had failed the gate twice, and the cause was **not** a width. Every width was already static. The **order** was wrong.

The hot-path branch ranking gives `_isBlocked, _bloodDecalVariationData, _skillKey`, because the list's guard branch sits at `0x14128893F` and `_skillKey`'s at `0x141288960`. That order **tiles 0 of 13 records**, and it cannot be right — reading the list first takes the 4 bytes at payload offset 1 as its element count, i.e. `0x00015F90` = **89,999 elements**. With the list last, record 0 accounts exactly:

```
00                     _isBlocked                1
90 5f 01 00            _skillKey                 4
04 00 00 00            count = 4
  "k6p10" + 16 bytes   element 20 + n   ->  4 x 25 = 100
                                       1 + 4 + 4 + 100 = 109 = rec0
```

and so do all 13.

**So the hot-path ordering is not infallible.** Worth stating plainly, because this line of work leans on it heavily: it is right on 38 of the 40 tables the order oracle can check, and this is a case it gets wrong. Exact tiling is what caught it.

The residual ambiguity is handled rather than ignored. `_isBlocked` (1 byte) and `_skillKey` (4) both precede a variable-length field, so swapping them preserves the total and **both orders tile 13/13** — the same width-preserving blind spot as WantedInfo in #362. The data cannot separate them. Two independent things do: the hot-path ranking, which is reliable for those two (`_isBlocked` at `0x14128891F` precedes `_skillKey` at `0x141288960` — it was only wrong about the *list*), and the format-wide convention that `_isBlocked` is the first field of very nearly every table. Both are recorded in the entry's `_meta_note`.

## Order cannot be recovered by search — tested, and recorded

Before correcting that table by hand I checked whether order could be derived mechanically. For every table whose widths are all static but which does not tile, I permuted the field order under unique-or-nothing, refusing tables with more than 8 fields and refusing any table with fewer than 3 distinct record lengths (a fixed-length table cannot tell permutations apart — that is exactly the WantedInfo trap).

**11 tables tested, 0 recovered.** The blocked tables are blocked by structure, not by order. Recorded so nobody spends the afternoon on it again.

## A real defect ruff caught

`SUBSTRUCT_DEFS` had **`RoyalSupplyInfo_QuestEntry` defined twice** (F601). The two definitions were byte-identical so nothing behaved differently — but a duplicate key silently overrides, and `royalsupply` is a shipped table. Removed, along with four derived substructs no override references (`RelationInfo_GimmickTagDataEntry`, `FieldLevelNameTableInfo_LevelNameInfoDataEntry`, `HouseInfo_HouseRegionDataEntry`, `FailMessageInfo_FailMessageInfoEntry`) — each a stale alias of one that is referenced. An unreferenced definition is dead weight that reads like evidence.

`pabgb_types.py` is back to the 4 ruff findings that are pre-existing on master (import order, SIM103, 2× UP045).

## Verification

```
48 entries, exact tiling on 100% of records, 0 failed, 61,184 records
pytest 170 passed (targeted), full suite 3053 passed / 43 skipped
```

## Where this route stands

The Windows static route is now yielding 1–2 tables per pass, down from 11 in #362. What remains needs a different evidence source, and the routes are ranked with per-table record counts in the tracked tasks. The macOS ask is #363 — it is the only route that supplies the field *names* Windows never emits, which is the actual blocker on `actionpointinfo` (3 named fields for a 232-byte record, 28,958 records).
