### PR TITLE
fix(storeinfo): allow adding stock records on CD 1.16.1

### DIFF
--- a/src/cdumm/engine/storeinfo_native_parser.py
+++ b/src/cdumm/engine/storeinfo_native_parser.py
@@ -150,17 +150,30 @@ class StoreLayout:
     #: 2026 patch cut it to 67 without moving anything ahead of it, which
     #: is why ``const_off`` is unchanged on that build (GitHub #365).
     vgap_size: int = VGAP_SIZE
-    #: Whether the three mapped fields INSIDE the interior (``raw_e`` at
-    #: vgap[41], ``raw_g`` at vgap[57], ``raw_q`` at vgap[59]) are known to
-    #: sit at those indices on this build.
+    #: vgap-relative offsets of the three fields the writer maps INSIDE
+    #: the opaque interior for a NEW record: raw_e (u32), raw_g (u16),
+    #: raw_q (u32). Constant at 41/57/59 from CD 1.10 through CD 1.16.
     #:
-    #: False on CD 1.16.1: the four bytes that patch removed came out of
-    #: the middle of the interior, not off its end, and at two different
-    #: points -- comparing all 6,376 shared records against CD 1.16, the
-    #: interiors first diverge at index 37 on 4,749 of them and index 53
-    #: on the other 1,627. So a single fixed mapping cannot be right for
-    #: both, and writing to the old indices would land in the wrong bytes.
-    #: Reading is unaffected: the interior is carried verbatim.
+    #: On CD 1.16.1 these move to 37/53/55. Naive first-divergence against
+    #: CD 1.16 lands at index 37 for 4,749 of the 6,376 shared records and
+    #: at 53 for the other 1,627 -- which is what first made this look
+    #: like two different removal points needing two different mappings.
+    #: It isn't: for literally all 6,376, re-derived by SHIFT (not first
+    #: difference) -- keep vgap[:37], drop 4, keep the rest -- reproduces
+    #: the CD 1.16 interior byte-exact. The 53-only-look records are not a
+    #: second layout; every one of them has vgap[37:57] == 0 in both
+    #: builds, so shifting at 53 instead is *also* consistent for them by
+    #: coincidence of zero-padding, never because shifting at 37 is wrong.
+    #: No record in the shared table ever contradicts 37. See
+    #: ``test_vgap_shift_is_uniformly_at_37`` for the check across the
+    #: committed fixtures.
+    raw_e_off: int = 41
+    raw_g_off: int = 57
+    raw_q_off: int = 59
+    #: Whether ``raw_e_off`` / ``raw_g_off`` / ``raw_q_off`` are known to
+    #: be correct for this build, i.e. safe to write a NEW record with.
+    #: Reading is unaffected by this flag either way: the interior is
+    #: always carried through verbatim for records that already exist.
     vgap_map_verified: bool = True
 
     @property
@@ -194,9 +207,15 @@ LAYOUTS: tuple[StoreLayout, ...] = (
     # 4 x record_count bytes, with zero exceptions, and this layout reads
     # 398 located + 39 provably empty = 437/437, 6378 records, 0 not-found
     # and 0 mis-round-tripped.
+    #
+    # The interior's removed 4 bytes are at vgap offset 37 for every one
+    # of those records (see raw_e_off's docstring and
+    # test_vgap_shift_is_uniformly_at_37) -- so raw_e/raw_g/raw_q move to
+    # 37/53/55 and adding a stock record is safe again.
     StoreLayout("CD 1.16.1", 44, 34, 38, 41, 42,
                 low_price_threshold=True, vgap_size=67,
-                vgap_map_verified=False),
+                raw_e_off=37, raw_g_off=53, raw_q_off=55,
+                vgap_map_verified=True),
     # CD 1.16: a u32 (_lowPriceThresholdCount) inserted after raw_c pushed
     # everything below it down another four bytes. Under the CD 1.13 shape
     # the live 1.16 table decodes ZERO entries; under this one, 397 of 432

--- a/src/cdumm/engine/storeinfo_writer.py
+++ b/src/cdumm/engine/storeinfo_writer.py
@@ -149,15 +149,23 @@ def _build_new_record(j: dict, idx: int,
         body=int(_record_identity(j) or 0),
     )
     # Mapped interior fields live inside the opaque value-struct blob
-    # (vgap). These indices are vgap-relative and stay stable across the
-    # CD 1.11 layout shift: is_restore_item was inserted before the vgap,
-    # so the blob's contents and internal offsets did not move (only the
-    # vgap's record-relative start did, 38 -> 39). raw_e -> vgap[41],
-    # raw_g u16 -> vgap[57], raw_q u32 -> vgap[59].
-    vgap = bytearray(rec.vgap)
-    struct.pack_into("<I", vgap, 41, int(v.get("raw_e") or 0))
-    struct.pack_into("<H", vgap, 57, int(v.get("raw_g") or 0) & 0xFFFF)
-    struct.pack_into("<I", vgap, 59, int(v.get("raw_q") or 0))
+    # (vgap), at the layout's raw_e_off / raw_g_off / raw_q_off. These
+    # stayed at 41/57/59 across the CD 1.11 layout shift (is_restore_item
+    # was inserted before the vgap, so the blob's contents and internal
+    # offsets did not move, only the vgap's record-relative start did,
+    # 38 -> 39) but moved to 37/53/55 on CD 1.16.1 (GitHub #365) -- see
+    # StoreLayout.raw_e_off for how that was derived.
+    #
+    # Sized from the layout, not from the StockRecord dataclass default
+    # (71, the pre-1.16.1 VGAP_SIZE): that default only ever matched by
+    # coincidence, because every layout before 1.16.1 also happened to be
+    # 71 bytes. On a shorter interior it silently built an oversized
+    # vgap that write_stock_record then refused outright.
+    vgap = bytearray(layout.vgap_size)
+    struct.pack_into("<I", vgap, layout.raw_e_off, int(v.get("raw_e") or 0))
+    struct.pack_into("<H", vgap, layout.raw_g_off,
+                     int(v.get("raw_g") or 0) & 0xFFFF)
+    struct.pack_into("<I", vgap, layout.raw_q_off, int(v.get("raw_q") or 0))
     rec.vgap = bytes(vgap)
     sd = j.get("sub_data")
     if sd is not None:

--- a/tests/test_storeinfo_native_parser.py
+++ b/tests/test_storeinfo_native_parser.py
@@ -355,6 +355,82 @@ def test_older_layouts_lose_decisively_on_committed_fixture(
             f"longer decisive")
 
 
+@pytest.mark.skipif(
+    not (has_vanilla116("storeinfo.pabgb") and has_vanilla1161("storeinfo.pabgb")),
+    reason="vanilla116/vanilla1161 storeinfo fixtures absent")
+def test_vgap_shift_is_uniformly_at_37():
+    """GitHub #365: the CD 1.16.1 interior shrink is one point, not two.
+
+    Naive first-byte-divergence between the CD 1.16 (71-byte) and CD
+    1.16.1 (67-byte) interior lands at index 37 for 4,749 of the 6,376
+    records shared between the two builds and at 53 for the other 1,627
+    -- which is what originally made this look like two different
+    layouts needing two different ``raw_e``/``raw_g``/``raw_q``
+    mappings (see StoreLayout.raw_e_off).
+
+    It isn't. This pins the stronger claim directly: shifting at 37 --
+    keep vgap[:37], drop exactly 4 bytes, keep the rest -- reproduces
+    the CD 1.16 interior byte-exact for EVERY one of the 6,376 shared
+    records, with zero exceptions. The 1,627 that merely *look*
+    consistent with a shift at 53 too are not a second layout; they are
+    records whose vgap[37:57] is all zero in both builds, so shifting at
+    53 is also consistent for them by coincidence, never because
+    shifting at 37 is wrong for them.
+    """
+    layout116 = _BY_LABEL["CD 1.16"]
+    layout1161 = _BY_LABEL["CD 1.16.1"]
+    body116, entries116 = _committed_entries(load_vanilla116, "vanilla116")
+    body1161, entries1161 = _committed_entries(load_vanilla1161, "vanilla1161")
+
+    def _records(body, entries, layout):
+        by_store: dict[int, dict[int, StockRecord]] = {}
+        for key, (payload, end) in entries.items():
+            try:
+                recs, _s, _e = locate_stock_list(body, payload, end, key, layout)
+            except StoreListNotFound:
+                continue
+            by_store[key] = {}
+            for r in recs:
+                by_store[key].setdefault(r.body, []).append(r)
+        return by_store
+
+    stores116 = _records(body116, entries116, layout116)
+    stores1161 = _records(body1161, entries1161, layout1161)
+
+    common_stores = set(stores116) & set(stores1161)
+    assert len(common_stores) == 397
+
+    checked = 0
+    zero_window_ambiguous = 0
+    for key in common_stores:
+        pool1161 = {b: list(rs) for b, rs in stores1161[key].items()}
+        for body_id, recs116 in stores116[key].items():
+            cands = pool1161.get(body_id)
+            if not cands:
+                continue
+            for r116 in recs116:
+                if not cands:
+                    break
+                r1161 = cands.pop(0)
+                checked += 1
+                v116, v1161 = r116.vgap, r1161.vgap
+                assert v116[:37] == v1161[:37] and v116[41:] == v1161[37:], (
+                    f"store {key} body {body_id}: shift-at-37 does not "
+                    f"reproduce the CD 1.16 interior byte-exact -- a "
+                    f"real second layout, not zero-padding coincidence")
+                window = v116[37:57]
+                if v116[:53] == v1161[:53] and v116[57:] == v1161[53:]:
+                    assert not any(window), (
+                        f"store {key} body {body_id}: shift-at-53 is "
+                        f"ALSO consistent but vgap[37:57] is non-zero "
+                        f"({window.hex()}) -- this would be genuine "
+                        f"evidence of a second layout")
+                    zero_window_ambiguous += 1
+
+    assert checked == 6376
+    assert zero_window_ambiguous == 1627
+
+
 def test_parsing_an_older_shape_with_the_default_layout_refuses():
     """The #351 bug class, pinned so it cannot come back silently.
 

--- a/tests/test_storeinfo_writer.py
+++ b/tests/test_storeinfo_writer.py
@@ -20,11 +20,15 @@ Safety contract pinned here:
 from __future__ import annotations
 
 import json
+import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+from tests.fixture_loaders import has_vanilla1161 as _have_vanilla1161
+from tests.fixture_loaders import load_vanilla1161 as _load_vanilla1161
 
 _BASE = Path(__file__).resolve().parents[1] / "issue_repro" / "183"
 _BODY = _BASE / "vanilla" / "storeinfo.pabgb"
@@ -211,3 +215,72 @@ def test_unknown_store_key_yields_no_changes():
     intent.entry = "NoSuchStore_zzz"
     changes, hdr_change = build_storeinfo_changes(body, header, [intent])
     assert changes == [] and hdr_change is None
+
+
+@pytest.mark.skipif(
+    not _have_vanilla1161("storeinfo.pabgb"),
+    reason="vanilla1161 storeinfo fixture absent")
+def test_new_record_applies_on_cd1161():
+    """GitHub #365 follow-up: adding a stock record works again.
+
+    Before the raw_e_off/raw_g_off/raw_q_off fix, every ADD on this
+    layout refused outright ("the CD 1.16.1 value interior has not been
+    re-derived"). This targets the committed vanilla1161 fixture
+    directly (not the gitignored issue_repro snapshot from #183, which
+    predates this layout), adds one brand-new stock record with distinct
+    non-zero raw_e/raw_g/raw_q, and checks it comes back at exactly
+    those values -- i.e. they landed at vgap[37]/[53]/[55], not the
+    stale pre-1.16.1 vgap[41]/[57]/[59].
+    """
+    from cdumm.engine.storeinfo_native_parser import LAYOUTS, locate_stock_list
+    from cdumm.engine.storeinfo_writer import build_storeinfo_changes
+    from cdumm.semantic.parser import _parse_entry_header, parse_pabgh_index
+
+    layout = next(ly for ly in LAYOUTS if ly.label == "CD 1.16.1")
+    body = _load_vanilla1161("storeinfo.pabgb")
+    header = _load_vanilla1161("storeinfo.pabgh")
+
+    ks, offs = parse_pabgh_index(header, "storeinfo")
+    key = 1  # Store_Her_Equipment on this fixture
+    sorted_offs = sorted(offs.values()) + [len(body)]
+    entry_end = sorted_offs[sorted_offs.index(offs[key]) + 1]
+    _, ename, payload = _parse_entry_header(body, offs[key], ks)
+    vrecords, _s, _e = locate_stock_list(body, payload, entry_end, key, layout)
+
+    new_body_id = max(r.body for r in vrecords) + 1
+    new_record = {
+        "lookup_a": vrecords[0].lookup_a,
+        "raw_a": 0, "raw_b": 0, "raw_c": 0, "raw_d": 0, "raw_e": 0,
+        "order_index_113": 0xFFFFFFFF,
+        "low_price_threshold_count": 0xFFFFFFFF,
+        "flag_a": 0, "flag_b": 0, "flag_c": 0, "is_restore_item": 0,
+        "value": {
+            "payload": {"body": new_body_id},
+            "raw_e": 0xDEAD1E, "raw_g": 0xBEEF, "raw_q": new_body_id,
+        },
+    }
+    intent = _Intent(entry=ename, key=key, field="stock_data_list", op="set",
+                     new=[{"value": {"payload": {"body": r.body}}}
+                          for r in vrecords] + [new_record])
+
+    pabgb_changes, pabgh_change = build_storeinfo_changes(body, header, [intent])
+    assert pabgb_changes, "the add must not be refused"
+
+    patched = _apply(body, pabgb_changes)
+    new_header = bytes.fromhex(pabgh_change["patched"]) if pabgh_change else header
+    _, noffs = parse_pabgh_index(new_header, "storeinfo")
+    nsorted_offs = sorted(noffs.values()) + [len(patched)]
+    nentry_end = nsorted_offs[nsorted_offs.index(noffs[key]) + 1]
+    _, _, npayload = _parse_entry_header(patched, noffs[key], ks)
+    out_records, _s, _e = locate_stock_list(
+        patched, npayload, nentry_end, key, layout)
+
+    added = next(r for r in out_records if r.body == new_body_id)
+    assert struct.unpack_from(
+        "<I", added.vgap, layout.raw_e_off)[0] == 0xDEAD1E
+    assert struct.unpack_from(
+        "<H", added.vgap, layout.raw_g_off)[0] == 0xBEEF
+    assert struct.unpack_from(
+        "<I", added.vgap, layout.raw_q_off)[0] == new_body_id
+    # And nowhere near the stale pre-1.16.1 indices.
+    assert struct.unpack_from("<I", added.vgap, 41)[0] != 0xDEAD1E


### PR DESCRIPTION
Fixes #365 (the part that was still broken after the layout fix landed).

The CD 1.16.1 fix re-derived the layout for reading/editing existing storeinfo entries, but adding a new stock record still refused — the writer wasn't sure where raw_e/raw_g/raw_q sit inside the opaque vgap interior on this build. First-byte divergence against CD 1.16 landed at two different indices (37 for most records, 53 for the rest), which looked like two incompatible layouts.

It's actually one layout. Checked shift-consistency instead of first divergence against the committed vanilla116/vanilla1161 fixtures: shifting at vgap offset 37 reproduces the CD 1.16 interior byte-exact for all 6,376 shared records, no exceptions. The 1,627 that also look consistent with a shift at 53 aren't a second layout — every one of them has vgap[37:57] == 0 in both builds, so 53 only works for them by coincidence of zero-padding. See test_vgap_shift_is_uniformly_at_37.

So raw_e/raw_g/raw_q move to 37/53/55 and vgap_map_verified goes back to True. Also fixes a latent bug where _build_new_record sized its vgap buffer from the dataclass default (71) instead of the layout's vgap_size (67).

Ran the full suite (pytest, ruff) and verified against donr484's Shop Smart mod — its 9 previously-refused store intents apply now.