### PR TITLE
fix(format3): accept a key-only record locator (mirror of #125)

### DIFF
--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -368,8 +368,19 @@ def _parse_intents_block(
         # the apply path's _match_record_keys treats a no-condition match as
         # "all records" (all([]) is True) -- so accept it here rather than
         # rejecting the whole mod.
+        #
+        # GitHub #125 made entry-without-key valid (real v3.1 exports treat
+        # entry as the primary locator and leave key unpopulated). donr484's
+        # "Cheap Gold Bars" (targeting iteminfo.pabgb by numeric key alone,
+        # no entry) is the mirror case the fix never covered: key-without-
+        # entry is just as valid a locator -- Format3Intent already defaults
+        # a missing entry to "" (line ~429) and every apply path (storeinfo,
+        # iteminfo, ...) resolves by key first and only falls back to entry
+        # name when the key misses. So entry is required only when NEITHER
+        # a match selector NOR a key locates the record.
         required_keys = (
-            ("field",) if raw_match is not None else ("entry", "field")
+            ("field",) if raw_match is not None or "key" in raw
+            else ("entry", "field")
         )
         for required in required_keys:
             if required not in raw:

--- a/tests/test_format3_op_optional.py
+++ b/tests/test_format3_op_optional.py
@@ -92,8 +92,11 @@ def test_intent_with_unknown_op_keeps_its_value_for_validator(tmp_path):
 
 
 def test_missing_required_key_other_than_op_still_raises(tmp_path):
-    """'op' is the only key we relax. entry, key, field, new must
-    still be present , dropping any of them is malformed JSON."""
+    """'op' is the only key we relax unconditionally. field and new
+    must still be present, dropping either is malformed JSON. entry
+    and key are each individually optional (one locates the record,
+    #125 and its mirror case below), but dropping BOTH leaves no way
+    to find the record at all and must still raise."""
     base = {
         "format": 3,
         "target": "x.pabgb",
@@ -101,9 +104,35 @@ def test_missing_required_key_other_than_op_still_raises(tmp_path):
             {"entry": "x", "key": 1, "field": "y", "new": 0}
         ],
     }
-    # Strip 'entry' , should still raise.
+    # Strip 'field' , should still raise.
+    body = json.loads(json.dumps(base))
+    del body["intents"][0]["field"]
+    p = _write(tmp_path / "nofield.field.json", body)
+    with pytest.raises(ValueError, match="missing required key 'field'"):
+        parse_format3_mod(p)
+    # Strip both 'entry' and 'key' , no locator left, should still raise.
     body = json.loads(json.dumps(base))
     del body["intents"][0]["entry"]
-    p = _write(tmp_path / "noentry.field.json", body)
+    del body["intents"][0]["key"]
+    p = _write(tmp_path / "nolocator.field.json", body)
     with pytest.raises(ValueError, match="missing required key 'entry'"):
         parse_format3_mod(p)
+
+
+def test_missing_entry_alone_is_accepted_when_key_present(tmp_path):
+    """Mirror of GitHub #125: donr484's "Cheap Gold Bars" targets
+    iteminfo.pabgb by numeric key alone, with no entry name. Every
+    apply path resolves by key first and falls back to entry name
+    only when the key misses, so key-without-entry is just as valid a
+    locator as entry-without-key already was."""
+    body = {
+        "format": 3,
+        "target": "x.pabgb",
+        "intents": [
+            {"key": 1, "field": "y", "new": 0}
+        ],
+    }
+    p = _write(tmp_path / "nokey_entry.field.json", body)
+    _, intents = parse_format3_mod(p)
+    assert intents[0].entry == ""
+    assert intents[0].key == 1

--- a/tests/test_format3_v3_1_dmm_dialect.py
+++ b/tests/test_format3_v3_1_dmm_dialect.py
@@ -167,6 +167,43 @@ def test_v3_1_intent_without_key_uses_entry_as_lookup(tmp_path):
     assert intents[0].field == "cost"
 
 
+def test_v3_1_intent_without_entry_uses_key_as_lookup(tmp_path):
+    """donr484's "Cheap Gold Bars" (targeting iteminfo.pabgb by numeric
+    key 53 alone, no entry) is #125's mirror case: the parser accepted
+    entry-without-key but still rejected key-without-entry with
+    'targets[0] (iteminfo.pabgb) intents intent #0 is missing required
+    key entry'. Every apply path resolves by key first and only falls
+    back to entry name when the key misses, so a key-only intent is
+    just as resolvable as an entry-only one.
+
+    Accept missing entry when key is present, default entry to "".
+    """
+    doc = {
+        "format": 3,
+        "format_minor": 1,
+        "modinfo": {"title": "no-entry probe", "version": "1.0"},
+        "targets": [{
+            "file": "iteminfo.pabgb",
+            "intents": [{
+                "key": 53,
+                "field": "price_list[0].price.price",
+                "op": "set",
+                "new": 1,
+            }],
+        }],
+    }
+    p = tmp_path / "no_entry.json"
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    pairs = parse_format3_mod_targets(p)
+    assert len(pairs) == 1
+    target, intents = pairs[0]
+    assert target == "iteminfo.pabgb"
+    assert len(intents) == 1
+    assert intents[0].entry == ""
+    assert intents[0].key == 53
+    assert intents[0].field == "price_list[0].price.price"
+
+
 def test_v3_1_intent_with_explicit_key_still_validates(tmp_path):
     """Old behavior preserved: when key IS present, it must be an
     integer (no bools, no strings). Backwards-compat guard for the


### PR DESCRIPTION
#125 allowed entry-without-key (real v3.1 exports often leave key unpopulated and use entry as the primary locator). This is the mirror case: donr484's "Cheap Gold Bars" targets iteminfo.pabgb by numeric key alone (key: 53, no entry), and the parser rejected it at import with "missing required key 'entry'" before it ever reached the apply path.

Every apply path already resolves a record by key first and only falls back to entry name when the key misses, and Format3Intent already defaults a missing entry to "" — so key-only was always a resolvable locator, just one the import-time validator never accepted. entry is now required only when neither a match selector nor a key can locate the record.

Also updates test_missing_required_key_other_than_op_still_raises, which asserted the old (incomplete) contract by dropping entry alone while key was still present; that case is now valid, so the test asserts the still-invalid case (dropping both) instead.

Ran pytest and ruff on the changed files, both clean.