### PR TITLE
fix(storeinfo): matched stock records must take the mod's fields too

### DIFF
--- a/src/cdumm/engine/storeinfo_writer.py
+++ b/src/cdumm/engine/storeinfo_writer.py
@@ -11,17 +11,22 @@ Safety model (the value-struct interior is only partially mapped, see
 storeinfo_native_parser):
 
 * Records in the intent that MATCH a vanilla record (same
-  ``value.payload.body``, which doubles as ``raw_q``) keep the vanilla
-  bytes verbatim, reordered per the intent. Their pinned fields were
-  validated identical across the whole ground-truth entry; interior
-  diffs observed in real mods are stale-export noise from older game
-  versions, which must NOT be written over current vanilla data.
+  ``value.payload.body``, which doubles as ``raw_q``) take the mod's
+  per-slot fields (quantity, flags, restock/sort order -- everything
+  the head maps), falling back to the vanilla value for any field the
+  mod's JSON omits (GitHub #365 residual: a matched record used to keep
+  100% vanilla bytes, so a mod bumping the stock of an item a store
+  already carried had no effect). The value-struct interior (``vgap``)
+  and ``effect_list`` stay vanilla unconditionally: interior diffs
+  observed in real mods are stale-export noise from older game
+  versions.
 * NEW records are built from the pinned fields plus sub_data, with the
   unmapped value interior zeroed. If a new record carries a NON-zero
   value in any unmapped interior field, the whole intent is refused,
   we cannot place the value, and a wrong placement corrupts the table
   (the game crashes on store open).
-* Non-empty ``effect_list`` refuses (element layout not decoded).
+* A new record's non-empty ``effect_list`` refuses (element layout not
+  decoded); a matched record's carries over from vanilla verbatim.
 """
 from __future__ import annotations
 
@@ -96,6 +101,57 @@ def _check_new_record_buildable(j: dict, idx: int) -> None:
                 f"new stock record [{idx}]: value.raw_q={v['raw_q']!r} "
                 f"differs from value.payload.body; in every "
                 f"ground-truth record they are the same value")
+
+
+def _build_matched_record(j: dict, van: StockRecord) -> StockRecord:
+    """A mod record whose item id matches an existing vanilla stock
+    entry at this store.
+
+    Applies the mod's per-slot fields (quantity, flags, restock/sort
+    order) -- they are exactly as mapped as they are for a brand-new
+    record, and a Format 3 'set' intent means them as an authoritative
+    replacement, not noise. A field the mod's JSON omits falls back to
+    the vanilla value instead of a hardcoded default, since a vanilla
+    record to fall back to actually exists here (unlike the new-record
+    case).
+
+    Keeps vanilla's value-struct interior (``vgap``) and ``effect_list``
+    verbatim rather than trusting the mod's ``value.*`` -- this is the
+    #183 protection, unchanged: interior diffs seen in real mods are
+    stale-export noise from an older layout, and the interior encodes
+    the ITEM's own definition (price/type), which does not vary by
+    which store sells it.
+    """
+    def field(name: str) -> int:
+        v = j.get(name)
+        return int(v) if v is not None else getattr(van, name)
+
+    order_index = j.get("order_index_113", j.get("order_index"))
+    order_index = (int(order_index) & 0xFFFFFFFF if order_index is not None
+                   else van.order_index)
+    low_thr = j.get("low_price_threshold_count")
+    low_thr = (int(low_thr) & 0xFFFFFFFF if low_thr is not None
+               else van.low_price_threshold_count)
+
+    return StockRecord(
+        lookup_a=field("lookup_a"),
+        raw_a=field("raw_a"),
+        raw_b=field("raw_b"),
+        raw_c=field("raw_c"),
+        low_price_threshold_count=low_thr,
+        raw_d=field("raw_d"),
+        raw_e=field("raw_e"),
+        order_index=order_index,
+        flag_a=field("flag_a"),
+        flag_b=field("flag_b"),
+        flag_c=field("flag_c"),
+        is_restore_item=field("is_restore_item"),
+        const33=van.const33,
+        body=van.body,
+        vgap=van.vgap,
+        sub_data=van.sub_data,
+        effect_list=van.effect_list,
+    )
 
 
 def _build_new_record(j: dict, idx: int,
@@ -309,9 +365,12 @@ def build_storeinfo_changes(
         # sub_data, the always-zero effect_list count) is written back
         # verbatim by write_stock_record, and any byte pattern outside
         # the verified disc-0 shape raises StoreinfoParseError above
-        # (caught as a refusal) instead of parsing lossily. Matched
-        # vanilla records therefore reproduce their bytes exactly;
-        # tests/test_storeinfo_writer.py pins this on the real table.
+        # (caught as a refusal) instead of parsing lossily. A matched
+        # record whose mod JSON reproduces vanilla's head fields
+        # therefore round-trips byte-exact too (see
+        # _build_matched_record for the fields that always stay
+        # vanilla); tests/test_storeinfo_writer.py pins this on the
+        # real table.
         if list_end > entry_end:
             raise StoreinfoWriteRefused(
                 f"store entry {key}: parsed list overruns the entry "
@@ -325,7 +384,7 @@ def build_storeinfo_changes(
             ident = _record_identity(j)
             van = by_body.get(ident) if ident is not None else None
             if van is not None:
-                out_records.append(van)
+                out_records.append(_build_matched_record(j, van))
             else:
                 out_records.append(
                     _build_new_record(j, idx, layout))

--- a/tests/test_storeinfo_writer.py
+++ b/tests/test_storeinfo_writer.py
@@ -7,9 +7,11 @@ which sets store 3101's stock list to 42 records. On the 1.11 build 37
 of those match a vanilla record by identity and 5 are new.
 
 Safety contract pinned here:
-* matched records keep their vanilla bytes verbatim (interior diffs in
-  the mod JSON are stale-export noise from an older game version and
-  must not overwrite current data),
+* matched records take the mod's mapped per-slot fields (quantity,
+  flags, restock/sort order), falling back to vanilla for any field
+  the mod's JSON omits, but keep the vanilla value-struct interior
+  (interior diffs in the mod JSON are stale-export noise from an older
+  game version and must not overwrite current data),
 * new records build from the mapped fields with the unmapped value
   interior zeroed,
 * a new record carrying a non-zero unmapped field REFUSES the intent,
@@ -137,24 +139,16 @@ def test_hernandpets_applies_end_to_end():
         assert r.lookup_a == j["lookup_a"]
         assert (r.sub_data is None) == (j["sub_data"] is None)
 
-    # Matched records keep vanilla bytes verbatim: each parsed record
-    # whose body matches a vanilla record re-serializes to that vanilla
-    # record's exact bytes (the mod's interior diffs must NOT have been
-    # written).
+    # Matched records keep vanilla's value-struct interior verbatim
+    # (the mod's ``value.*`` diffs must NOT have been written -- the
+    # #183 protection this fixture exists for) even though their
+    # mapped head fields now come from the mod's JSON.
     vby_body = {r.body: r for r in vrecords}
     for r in records:
         if r.body in vbodies:
-            from cdumm.engine.storeinfo_native_parser import _Writer
-            wa, wb = _Writer(), _Writer()
-            from cdumm.engine.storeinfo_native_parser import write_stock_record
-            # Named, not defaulted. This is the #351 trap the fixture
-            # helper above exists to avoid, and it caught this line when
-            # CD 1.16.1 became the newest layout: these records come from
-            # a CD 1.11 snapshot with a 71-byte interior, and the default
-            # had moved to a layout whose interior is 67.
-            write_stock_record(wa, r, layout)
-            write_stock_record(wb, vby_body[r.body], layout)
-            assert bytes(wa.out) == bytes(wb.out), r.body
+            van = vby_body[r.body]
+            assert r.vgap == van.vgap, r.body
+            assert r.effect_list == van.effect_list, r.body
 
     # Every entry offset after store 3101 shifted by exactly +growth.
     for key, voff in voffs.items():
@@ -284,3 +278,74 @@ def test_new_record_applies_on_cd1161():
         "<I", added.vgap, layout.raw_q_off)[0] == new_body_id
     # And nowhere near the stale pre-1.16.1 indices.
     assert struct.unpack_from("<I", added.vgap, 41)[0] != 0xDEAD1E
+
+
+@pytest.mark.skipif(
+    not _have_vanilla1161("storeinfo.pabgb"),
+    reason="vanilla1161 storeinfo fixture absent")
+def test_matched_record_applies_the_mods_quantity_on_cd1161():
+    """GitHub #365 residual: a Format 3 'set' on stock_data_list is
+    meant to replace a slot's fields outright, including ones an item
+    already had before the mod. Before this fix, any record whose item
+    id matched an existing vanilla record discarded the mod's fields
+    wholesale and kept the vanilla bytes verbatim, so bumping the stock
+    of an item a store already carried (as opposed to adding a
+    brand-new one) silently did nothing.
+    """
+    from cdumm.engine.storeinfo_native_parser import LAYOUTS, locate_stock_list
+    from cdumm.engine.storeinfo_writer import build_storeinfo_changes
+    from cdumm.semantic.parser import _parse_entry_header, parse_pabgh_index
+
+    layout = next(ly for ly in LAYOUTS if ly.label == "CD 1.16.1")
+    body = _load_vanilla1161("storeinfo.pabgb")
+    header = _load_vanilla1161("storeinfo.pabgh")
+
+    ks, offs = parse_pabgh_index(header, "storeinfo")
+    key = 3101
+    sorted_offs = sorted(offs.values()) + [len(body)]
+    entry_end = sorted_offs[sorted_offs.index(offs[key]) + 1]
+    _, ename, payload = _parse_entry_header(body, offs[key], ks)
+    vrecords, _s, _e = locate_stock_list(body, payload, entry_end, key, layout)
+
+    target = vrecords[0]
+    assert target.raw_c == 1  # pinned: what the fix needs to change
+
+    # Reproduce the whole list (a Format 3 'set' exports every record,
+    # matched or new); bump only the target's quantity.
+    new_records = []
+    for r in vrecords:
+        j = {"value": {"payload": {"body": r.body}}}
+        if r.body == target.body:
+            j["raw_c"] = 999
+        new_records.append(j)
+
+    intent = _Intent(entry=ename, key=key, field="stock_data_list",
+                     op="set", new=new_records)
+    pabgb_changes, pabgh_change = build_storeinfo_changes(body, header, [intent])
+    assert pabgb_changes, "the quantity bump must not be a no-op"
+
+    patched = _apply(body, pabgb_changes)
+    new_header = bytes.fromhex(pabgh_change["patched"]) if pabgh_change else header
+    _, noffs = parse_pabgh_index(new_header, "storeinfo")
+    nsorted_offs = sorted(noffs.values()) + [len(patched)]
+    nentry_end = nsorted_offs[nsorted_offs.index(noffs[key]) + 1]
+    _, _, npayload = _parse_entry_header(patched, noffs[key], ks)
+    out_records, _s, _e = locate_stock_list(
+        patched, npayload, nentry_end, key, layout)
+
+    out = next(r for r in out_records if r.body == target.body)
+    assert out.raw_c == 999
+    # Untouched fields, and the whole opaque interior, still match
+    # vanilla -- only the field the mod actually set moved.
+    assert out.vgap == target.vgap
+    assert out.lookup_a == target.lookup_a
+    assert out.flag_a == target.flag_a and out.flag_c == target.flag_c
+    assert out.sub_data == target.sub_data
+
+    # Every other slot in the store, none of which the mod touched,
+    # is untouched too.
+    out_by_body = {r.body: r for r in out_records}
+    for r in vrecords:
+        if r.body != target.body:
+            assert out_by_body[r.body].raw_c == r.raw_c
+            assert out_by_body[r.body].vgap == r.vgap


### PR DESCRIPTION
On Store_Her_General (Olden's shop in Shop Smart. Shop H-Mart) 5 of 41 slots -- Wool, Animal_Bone, Fang, Feather, Clout -- stayed at their vanilla count (1-3) instead of the mod's 999. Cause is in the storeinfo writer: whenever a mod intent's record matched an existing item id already sold at that store, the writer discarded the mod's JSON wholesale and wrote the vanilla bytes back as-is, quantity included. That protects against stale exports (issue #183), but it was also silently dropping deliberate edits to items a store already carried, not just noise.

Matched records now take the mod's quantity/flags/sort order (same as new records already did), falling back to the vanilla value per field when the mod's JSON omits it. The item's opaque value-struct interior still always comes from vanilla, so the #183 protection is unchanged.