### PR TITLE
fix(snapshot): stop pinning the PAPGT sanity check to one game version

### DIFF
--- a/src/cdumm/engine/snapshot_manager.py
+++ b/src/cdumm/engine/snapshot_manager.py
@@ -477,15 +477,37 @@ class SnapshotWorker(QObject):
                     problems.append(
                         f"Mod directory {d.name}/ exists ({len(files)} files)")
 
-        # 2. Check PAPGT for mod entries (vanilla has 33 entries, ~577 bytes)
+        # 2. Check PAPGT structural integrity. This used to be a raw
+        # entry-count threshold ("vanilla has 33 entries"), which
+        # false-positived the instant a content update legitimately grew
+        # the table (2.0: 39 entries on a clean install, confirmed
+        # empirically) and permanently blocked Reset/Rescan for every
+        # user on the new version. That threshold never added real
+        # detection power in the first place: papgt_manager.rebuild only
+        # ever adds a PAPGT entry for a directory that has real content
+        # on disk (see its is_vanilla_dir/pamt_on_disk gate), so "a mod
+        # added entries" and "a mod directory exists on disk" are the
+        # same fact -- check #1 above already catches that precisely and
+        # version-independently, no assumed count needed.
+        #
+        # What's left to check here is PAPGT's own structural validity,
+        # which a count threshold was never a sound tool for anyway (a
+        # single corrupted byte can undershoot just as easily as
+        # overshoot). Verify the declared entry table plus the
+        # string-table-size field actually fit inside the file; if
+        # entry_count is corrupt, this arithmetic runs past the file's
+        # real length regardless of what game version produced it.
         game_papgt = self._game_dir / "meta" / "0.papgt"
         if game_papgt.exists():
             papgt_data = game_papgt.read_bytes()
             if len(papgt_data) >= 12:
                 entry_count = papgt_data[8]
-                if entry_count > 35:  # vanilla has 33 entries
+                entry_start = 12
+                str_table_len_off = entry_start + entry_count * 12
+                if str_table_len_off + 4 > len(papgt_data):
                     problems.append(
-                        f"PAPGT has {entry_count} entries (vanilla has ~33)")
+                        f"PAPGT is corrupt: {entry_count} entries "
+                        f"don't fit in a {len(papgt_data)}-byte file")
 
         # 3. Check if CDMods/vanilla backup exists (means mods were applied before).
         # If backups have different sizes from game files, the backups are

--- a/tests/test_snapshot_manager.py
+++ b/tests/test_snapshot_manager.py
@@ -15,13 +15,16 @@ def _create_fake_game_dir(tmp_path: Path) -> Path:
         (d / "0.pamt").write_bytes(b"PAMT_DATA_" + dir_name.encode())
         (d / "0.paz").write_bytes(b"PAZ_DATA_" + dir_name.encode() + b"\x00" * 100)
 
-    # Create PAPGT. Byte 8 encodes the entry count; real vanilla has 33
-    # entries. snapshot_manager aborts with "appears modded" if it sees
-    # more than 35, so the fixture writes a valid vanilla-like count.
+    # Create PAPGT. Byte 8 encodes the entry count; snapshot_manager's
+    # structural check requires the declared entry table + string-table
+    # size field to actually fit in the file (real corruption detection,
+    # independent of any particular vanilla entry count), so an
+    # entry_count of 0 keeps this fixture trivially valid without having
+    # to build real 12-byte entries + a string table.
     meta = game_dir / "meta"
     meta.mkdir()
     (meta / "0.papgt").write_bytes(
-        b"\x00" * 8 + bytes([33]) + b"\x00" * 51
+        b"\x00" * 8 + bytes([0]) + b"\x00" * 51
     )
 
     # Create game exe for validation

--- a/tests/test_snapshot_papgt_threshold.py
+++ b/tests/test_snapshot_papgt_threshold.py
@@ -1,0 +1,86 @@
+"""Regression for the PAPGT integrity check in snapshot_manager.
+
+GitHub context: the old `entry_count > 35` threshold was pinned to one
+game version's vanilla count (33 entries pre-2.0). The Crimson Desert 2.0
+update legitimately raised that to 39 (confirmed against a clean post-2.0
+install with no CDUMM mod directories present), and the tight threshold
+treated every clean 2.0 install as "modded", permanently blocking
+Reset/Rescan since Steam Verify can't lower a legitimately-higher vanilla
+count.
+
+A wider hardcoded threshold (e.g. 100) has the same underlying flaw --
+it's still an assumed count, just a bigger one, and would eventually
+false-positive again on some future version's legitimate growth (or worse,
+stay loose enough to miss real corruption on an OLDER version where the
+true baseline is much lower). The check isn't a vanilla-count tracker any
+more: papgt_manager.rebuild only ever adds a PAPGT entry for a directory
+that has real content on disk, so "extra entries" and "a mod directory
+exists on disk" are the same fact -- the mod-directory check right above
+this one in the same function already catches that precisely, for any
+entry count, on any game version. What's left here is PAPGT's own
+structural validity (does the declared entry table actually fit in the
+file), which is a real, version-independent corruption signal regardless
+of how many entries a given game version's vanilla PAPGT legitimately has.
+"""
+import struct
+from pathlib import Path
+
+from cdumm.engine.snapshot_manager import SnapshotWorker
+from cdumm.storage.database import Database
+
+
+def _make_valid_papgt(entry_count: int) -> bytes:
+    """A structurally well-formed PAPGT with ``entry_count`` entries, each
+    naming a distinct (fake) directory, and a matching string table --
+    exactly what the entry-count field promises actually follows it."""
+    header = bytearray(12)
+    header[8] = entry_count
+    body = bytearray()
+    names = [f"{i:04d}\x00".encode("ascii") for i in range(entry_count)]
+    string_table = b"".join(names)
+    off = 0
+    for i, name in enumerate(names):
+        body += struct.pack("<III", 0x003FFF00, off, 0)
+        off += len(name)
+    body += struct.pack("<I", len(string_table))
+    body += string_table
+    return bytes(header) + bytes(body)
+
+
+def _worker(tmp_path: Path, db: Database, papgt_bytes: bytes) -> SnapshotWorker:
+    game_dir = tmp_path / "game"
+    (game_dir / "meta").mkdir(parents=True)
+    (game_dir / "meta" / "0.papgt").write_bytes(papgt_bytes)
+    worker = SnapshotWorker(game_dir, tmp_path / "unused.db")
+    worker._thread_db = db
+    return worker
+
+
+def test_pre_2_0_install_is_not_flagged(tmp_path, db):
+    worker = _worker(tmp_path, db, _make_valid_papgt(33))
+    assert worker._check_pre_snapshot() == []
+
+
+def test_clean_2_0_install_is_not_flagged(tmp_path, db):
+    worker = _worker(tmp_path, db, _make_valid_papgt(39))
+    assert worker._check_pre_snapshot() == []
+
+
+def test_large_but_well_formed_entry_count_is_not_flagged(tmp_path, db):
+    """A big entry count is not, by itself, evidence of anything -- only
+    entries backed by an actual on-disk directory (check #1) are. A
+    structurally valid PAPGT with many entries must pass regardless of
+    the number, since there's no version-specific baseline to compare
+    against any more."""
+    worker = _worker(tmp_path, db, _make_valid_papgt(90))
+    assert worker._check_pre_snapshot() == []
+
+
+def test_corrupt_entry_count_is_flagged(tmp_path, db):
+    """entry_count claims more entries than the file actually has room
+    for -- real corruption, independent of any game version."""
+    papgt = bytearray(_make_valid_papgt(5))
+    papgt[8] = 200  # now claims 200 entries in a file sized for 5
+    worker = _worker(tmp_path, db, bytes(papgt))
+    problems = worker._check_pre_snapshot()
+    assert any("PAPGT is corrupt" in p for p in problems)


### PR DESCRIPTION
Fixes Reset/Rescan permanently failing on Crimson Desert 2.0 with "game files appear to be modded".

The check compared PAPGT's entry count against a threshold pinned to the pre-2.0 vanilla baseline (33 entries), and 2.0 legitimately raised that to 39 on a clean install. Replaced the version-pinned count with a structural check: does the declared entry table actually fit inside the file. Mod-added content is already caught precisely by the directory-listing check right next to it, which never depended on any particular entry count.