### PR TITLE
fix(format3): stop raising when iteminfo layout can't be detected

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -326,6 +326,8 @@ def _iteminfo_layout_roots(body: bytes, header: bytes) -> frozenset | None:
         if not off:
             return None
         fields = detect_iteminfo_layout(body, sorted(off.values()))
+        if not fields:
+            return None
         return frozenset(f[0] for f in fields)
     except Exception:  # noqa: BLE001 - never break apply over a guard
         logger.exception("iteminfo: could not resolve the layout's fields")

--- a/tests/test_iteminfo_layout_roots_none_fields.py
+++ b/tests/test_iteminfo_layout_roots_none_fields.py
@@ -1,0 +1,36 @@
+"""Regression: _iteminfo_layout_roots must fail clean when
+detect_iteminfo_layout can't recognize the installed game's iteminfo
+record layout (e.g. a game update the parser doesn't model yet).
+
+Report 2026-08-26: on a game version detect_iteminfo_layout can't
+decode, it returns None, and `frozenset(f[0] for f in fields)` raised
+`TypeError: 'NoneType' object is not iterable`. The broad except already
+caught it and returned None either way (this function is documented as
+a safety net that must fail open), so the only effect was a full
+traceback logged on every apply for affected game versions -- noisy,
+but not a real bug. The fix is a plain early return before the
+iteration.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cdumm.engine.format3_apply import _iteminfo_layout_roots
+
+
+def test_returns_none_without_raising_when_layout_undetected():
+    with patch("cdumm.engine.format3_apply.parse_pabgh_index",
+               return_value=(4, {0: 0})), patch(
+            "cdumm.engine.iteminfo_native_parser.detect_iteminfo_layout",
+            return_value=None):
+        assert _iteminfo_layout_roots(b"\x00" * 32, b"\x00" * 32) is None
+
+
+def test_returns_none_when_layout_detects_as_empty_list():
+    """Same guard, the other falsy value detect_iteminfo_layout could
+    plausibly return instead of None."""
+    with patch("cdumm.engine.format3_apply.parse_pabgh_index",
+               return_value=(4, {0: 0})), patch(
+            "cdumm.engine.iteminfo_native_parser.detect_iteminfo_layout",
+            return_value=[]):
+        assert _iteminfo_layout_roots(b"\x00" * 32, b"\x00" * 32) is None


### PR DESCRIPTION
Fixes a full traceback getting logged on every Apply on a game version whose iteminfo record layout isn't recognized yet (currently 2.0).

The safety-net helper that reports which fields the detected layout supports was raising a TypeError instead of taking its own fail-open path, so the guard still worked, it just logged noisily instead of cleanly. Also covers the case where layout detection returns an empty list, which previously got treated as "zero known fields" and refused edits instead of failing open.