### PR TITLE
fix(gui): cache PAMT hashes so post-apply verify stops looking like a hang

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -121,6 +121,105 @@ def _papgt_dir_owners(conn):
     return owners
 
 
+def _load_pamt_hash_cache(cache_path) -> dict:
+    """``{abs_path: [mtime_ns, size, hash]}``, or ``{}`` on any read
+    problem (missing file, corrupt JSON) -- a cache miss just means
+    the affected entries get rehashed, never a hard failure."""
+    import json
+    try:
+        return json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_pamt_hash_cache(cache_path, cache: dict) -> None:
+    import json
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache), encoding="utf-8")
+    except OSError as e:
+        logger.debug("post-apply PAMT hash cache write failed: %s", e)
+
+
+def _cached_pamt_hash(pamt_path, cache: dict, compute_pamt_hash) -> int:
+    """PAMT hash for ``pamt_path``, reusing ``cache`` when the file's
+    (mtime, size) fingerprint still matches what was last hashed.
+
+    Almost every mounted directory is untouched between one Apply and
+    the next -- only the CDUMM overlay dir(s) actually change -- so
+    this turns a full rehash of every directory into a full rehash of
+    the one or two that changed, plus a stat() for everything else.
+    """
+    st = pamt_path.stat()
+    key = str(pamt_path)
+    cached = cache.get(key)
+    if cached is not None and cached[0] == st.st_mtime_ns and cached[1] == st.st_size:
+        return cached[2]
+    h = compute_pamt_hash(pamt_path.read_bytes())
+    cache[key] = [st.st_mtime_ns, st.st_size, h]
+    return h
+
+
+def _compute_post_apply_issues(game_dir, conn) -> list[tuple[str, str]]:
+    """PAPGT/PAMT integrity check used after Apply. Runs on the GUI
+    thread (deliberately -- see ``_post_apply_verify``), so it has to
+    stay fast: PAMT hashes for directories whose (mtime, size) haven't
+    changed since the last run are served from a small on-disk cache
+    instead of rehashing every mounted directory every single Apply.
+    """
+    import struct
+
+    from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
+    from cdumm.engine.cdmods_paths import get_cdmods_root
+
+    issues: list[tuple[str, str]] = []
+    dir_owners = _papgt_dir_owners(conn)
+
+    cache_path = get_cdmods_root(None, game_dir) / ".post_apply_hash_cache.json"
+    hash_cache = _load_pamt_hash_cache(cache_path)
+
+    papgt_path = game_dir / "meta" / "0.papgt"
+    if papgt_path.exists():
+        data = papgt_path.read_bytes()
+        if len(data) >= 12:
+            stored = struct.unpack_from('<I', data, 4)[0]
+            computed = compute_papgt_hash(data)
+            if stored != computed:
+                issues.append(("PAPGT", "PAPGT hash is invalid"))
+
+            entry_count = data[8]
+            entry_start = 12
+            str_table_off = entry_start + entry_count * 12 + 4
+            for i in range(entry_count):
+                pos = entry_start + i * 12
+                name_off = struct.unpack_from('<I', data, pos + 4)[0]
+                papgt_hash = struct.unpack_from('<I', data, pos + 8)[0]
+                abs_off = str_table_off + name_off
+                if abs_off < len(data):
+                    end = data.index(0, abs_off) if 0 in data[abs_off:] else len(data)
+                    dir_name = data[abs_off:end].decode('ascii', errors='replace')
+                    pamt_path = game_dir / dir_name / "0.pamt"
+                    if pamt_path.exists():
+                        actual = _cached_pamt_hash(pamt_path, hash_cache, compute_pamt_hash)
+                        if actual != papgt_hash:
+                            issues.append(("PAPGT", f"{dir_name} PAMT hash mismatch"))
+                    elif not (game_dir / dir_name).exists():
+                        # Skip vanilla placeholder dirs (< 0036) that don't exist on disk
+                        _owners = dir_owners.get(dir_name)
+                        _src = ", ".join(sorted(_owners)) if _owners else "PAPGT"
+                        try:
+                            if int(dir_name) >= 36:
+                                issues.append((_src, f"Missing directory {dir_name}"))
+                        except (ValueError, TypeError):
+                            issues.append((_src, f"Missing directory {dir_name}"))
+
+    # PAMT bounds checking skipped, too slow for large installations. The
+    # apply engine already ensures correct offsets/sizes during PAZ
+    # composition.
+    _save_pamt_hash_cache(cache_path, hash_cache)
+    return issues
+
+
 def _quiet_qprocess(proc) -> None:
     """Suppress the brief console window flash when ``QProcess`` spawns
     a Windows subprocess.
@@ -6473,74 +6572,21 @@ class CdummWindow(FluentWindow):
     def _post_apply_verify(self) -> None:
         """Deep verification after Apply -- checks PAPGT/PAMT integrity.
 
-        Runs on the GUI thread, keep it fast or skip heavy checks.
+        Deliberately synchronous and blocking: this is the gate between
+        "Apply reported success" and "it's safe to Launch". Running it in
+        the background would let the user launch the game before it's
+        cleared the install, which defeats the point of checking at all.
+        Runs on the GUI thread, so the check itself (`_compute_post_apply_
+        issues`) has to stay fast -- see that function's docstring for the
+        cache that keeps repeated PAMT hashing cheap.
         """
         if not self._game_dir or not self._db:
             return
         import time as _t
         _t0 = _t.perf_counter()
-        import struct
-        from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
-
-        issues = []
-        # GitHub #225: map dirs -> owning mod so a 'Missing directory'
-        # issue can name the mod (the dialog promises a mod name).
-        dir_owners = _papgt_dir_owners(self._db.connection)
-
-        # 1. Check PAPGT hash
-        papgt_path = self._game_dir / "meta" / "0.papgt"
-        if papgt_path.exists():
-            data = papgt_path.read_bytes()
-            if len(data) >= 12:
-                stored = struct.unpack_from('<I', data, 4)[0]
-                computed = compute_papgt_hash(data)
-                if stored != computed:
-                    issues.append(("PAPGT", "PAPGT hash is invalid"))
-
-                entry_count = data[8]
-                entry_start = 12
-                str_table_off = entry_start + entry_count * 12 + 4
-                for i in range(entry_count):
-                    pos = entry_start + i * 12
-                    name_off = struct.unpack_from('<I', data, pos + 4)[0]
-                    papgt_hash = struct.unpack_from('<I', data, pos + 8)[0]
-                    abs_off = str_table_off + name_off
-                    if abs_off < len(data):
-                        end = data.index(0, abs_off) if 0 in data[abs_off:] else len(data)
-                        dir_name = data[abs_off:end].decode('ascii', errors='replace')
-                        pamt_path = self._game_dir / dir_name / "0.pamt"
-                        if pamt_path.exists():
-                            actual = compute_pamt_hash(pamt_path.read_bytes())
-                            if actual != papgt_hash:
-                                issues.append(("PAPGT", f"{dir_name} PAMT hash mismatch"))
-                        elif not (self._game_dir / dir_name).exists():
-                            # Skip vanilla placeholder dirs (< 0036) that don't exist on disk
-                            _owners = dir_owners.get(dir_name)
-                            _src = ", ".join(sorted(_owners)) if _owners else "PAPGT"
-                            try:
-                                if int(dir_name) >= 36:
-                                    issues.append((_src, f"Missing directory {dir_name}"))
-                            except (ValueError, TypeError):
-                                issues.append((_src, f"Missing directory {dir_name}"))
-
-        # 2. Get all files modified by enabled mods
-        modded_files = self._db.connection.execute(
-            "SELECT DISTINCT md.file_path, m.name "
-            "FROM mod_deltas md JOIN mods m ON md.mod_id = m.id "
-            "WHERE m.enabled = 1 AND md.file_path NOT LIKE 'meta/%'"
-        ).fetchall()
-
-        mod_by_file = {}
-        modded_dirs = set()
-        for fp, mod_name in modded_files:
-            parts = fp.split("/")
-            if len(parts) >= 2 and parts[0].isdigit():
-                modded_dirs.add(parts[0])
-            mod_by_file.setdefault(fp, []).append(mod_name)
-
-        # 3. PAMT bounds checking skipped, runs on GUI thread and is too slow
-        #    for large installations. The apply engine already ensures correct
-        #    offsets/sizes during PAZ composition.
+        issues = _compute_post_apply_issues(self._game_dir, self._db.connection)
+        _dt = _t.perf_counter() - _t0
+        logger.info("Post-apply verify took %.1fs, found %d issue(s)", _dt, len(issues))
 
         # F3: the version-hash comparison used to live here and
         # append "may be outdated" to every mod that was imported on
@@ -6552,9 +6598,6 @@ class CdummWindow(FluentWindow):
         # surfaced as apply errors). Successful apply now auto-stamps
         # mods with the current fingerprint so the orange "outdated"
         # badge self-heals (see stamp_enabled_mods_as_current).
-
-        _dt = _t.perf_counter() - _t0
-        logger.info("Post-apply verify took %.1fs, found %d issue(s)", _dt, len(issues))
 
         if issues:
             issue_lines = []

--- a/tests/test_post_apply_verify_no_version_noise.py
+++ b/tests/test_post_apply_verify_no_version_noise.py
@@ -34,7 +34,7 @@ def _fluent_src() -> str:
 
 def test_post_apply_verify_does_not_append_version_mismatch():
     src = _fluent_src()
-    anchor = src.find("def _post_apply_verify")
+    anchor = src.find("def _compute_post_apply_issues")
     assert anchor != -1
     next_def = src.find("\n    def ", anchor + 20)
     body = src[anchor:next_def if next_def != -1 else anchor + 8000]
@@ -56,7 +56,7 @@ def test_post_apply_verify_still_reports_papgt_issues():
     """Regression: PAPGT/PAMT integrity checks must stay in the
     dialog — those ARE real crash risks."""
     src = _fluent_src()
-    anchor = src.find("def _post_apply_verify")
+    anchor = src.find("def _compute_post_apply_issues")
     assert anchor != -1
     next_def = src.find("\n    def ", anchor + 20)
     body = src[anchor:next_def if next_def != -1 else anchor + 8000]

--- a/tests/test_post_apply_verify_worker.py
+++ b/tests/test_post_apply_verify_worker.py
@@ -1,0 +1,133 @@
+"""Regression: post-apply PAPGT/PAMT verification hung the Apply dialog at
+100% for several seconds on a real install.
+
+Report 2026-08-26. `_post_apply_verify` runs synchronously on the GUI
+thread by design -- it's the gate between "Apply reported success" and
+"it's safe to Launch", so it can't be backgrounded without letting the
+user launch the game before the install has been cleared. The actual fix
+is to make the check itself fast: `_cached_pamt_hash` skips rehashing a
+directory's PAMT when its (mtime, size) fingerprint hasn't changed since
+the last run, persisted in a small on-disk cache. Only the directory (or
+two) an Apply actually touches ever needs rehashing; everything else is
+just a stat() call.
+"""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
+
+
+def _build_papgt(entries: list[tuple[str, int]]) -> bytes:
+    """entries: list of (dir_name, pamt_hash)."""
+    names = [e[0].encode("ascii") + b"\x00" for e in entries]
+    string_table = b"".join(names)
+    name_offsets = []
+    off = 0
+    for n in names:
+        name_offsets.append(off)
+        off += len(n)
+
+    body = bytearray()
+    for (dir_name, pamt_hash), name_off in zip(entries, name_offsets):
+        body += struct.pack("<III", 0x003FFF00, name_off, pamt_hash)
+    body += struct.pack("<I", len(string_table))
+    body += string_table
+
+    header = bytearray(12)
+    header[8] = len(entries)
+    papgt_hash = compute_papgt_hash(bytes(header) + bytes(body))
+    struct.pack_into("<I", header, 4, papgt_hash)
+    return bytes(header) + bytes(body)
+
+
+def _setup_game_dir(tmp_path: Path, *, corrupt: bool) -> Path:
+    game_dir = tmp_path / "game"
+    (game_dir / "meta").mkdir(parents=True)
+    (game_dir / "0000").mkdir(parents=True)
+
+    pamt_bytes = b"\x00" * 12 + b"some pamt content"
+    (game_dir / "0000" / "0.pamt").write_bytes(pamt_bytes)
+    real_hash = compute_pamt_hash(pamt_bytes)
+    recorded_hash = real_hash + 1 if corrupt else real_hash
+
+    papgt = _build_papgt([("0000", recorded_hash)])
+    (game_dir / "meta" / "0.papgt").write_bytes(papgt)
+    return game_dir
+
+
+def test_clean_install_reports_no_issues(tmp_path, db):
+    from cdumm.gui.fluent_window import _compute_post_apply_issues
+
+    game_dir = _setup_game_dir(tmp_path, corrupt=False)
+    assert _compute_post_apply_issues(game_dir, db.connection) == []
+
+
+def test_pamt_hash_mismatch_is_reported(tmp_path, db):
+    from cdumm.gui.fluent_window import _compute_post_apply_issues
+
+    game_dir = _setup_game_dir(tmp_path, corrupt=True)
+    issues = _compute_post_apply_issues(game_dir, db.connection)
+    assert any("PAMT hash mismatch" in detail for _src, detail in issues)
+
+
+# ── PAMT hash cache ─────────────────────────────────────────────────────
+
+def test_cached_pamt_hash_reuses_entry_for_unchanged_file(tmp_path):
+    from cdumm.gui.fluent_window import _cached_pamt_hash
+
+    pamt_path = tmp_path / "0.pamt"
+    pamt_path.write_bytes(b"\x00" * 12 + b"content")
+    calls = []
+
+    def counting_hasher(data: bytes) -> int:
+        calls.append(data)
+        return 42
+
+    cache: dict = {}
+    first = _cached_pamt_hash(pamt_path, cache, counting_hasher)
+    second = _cached_pamt_hash(pamt_path, cache, counting_hasher)
+
+    assert first == 42 and second == 42
+    assert len(calls) == 1, (
+        "second call must be served from cache -- the underlying hash "
+        "function must not run again for an unchanged file")
+
+
+def test_cached_pamt_hash_recomputes_when_file_changes(tmp_path):
+    from cdumm.gui.fluent_window import _cached_pamt_hash
+
+    pamt_path = tmp_path / "0.pamt"
+    pamt_path.write_bytes(b"\x00" * 12 + b"content")
+    cache: dict = {}
+    _cached_pamt_hash(pamt_path, cache, compute_pamt_hash)
+
+    pamt_path.write_bytes(b"\x00" * 12 + b"different content, different size")
+    real = compute_pamt_hash(pamt_path.read_bytes())
+    got = _cached_pamt_hash(pamt_path, cache, compute_pamt_hash)
+
+    assert got == real, "a changed file must be rehashed, not served stale"
+
+
+def test_compute_post_apply_issues_writes_a_persistent_cache(tmp_path, db):
+    """End-to-end: a verify pass must leave an on-disk cache entry for
+    the directory it hashed, so the NEXT pass (this run or a future
+    CDUMM launch) can skip rehashing it if it hasn't changed."""
+    from cdumm.engine.cdmods_paths import get_cdmods_root
+    from cdumm.gui.fluent_window import (
+        _compute_post_apply_issues,
+        _load_pamt_hash_cache,
+    )
+
+    game_dir = _setup_game_dir(tmp_path, corrupt=False)
+    assert _compute_post_apply_issues(game_dir, db.connection) == []
+
+    cache_path = get_cdmods_root(None, game_dir) / ".post_apply_hash_cache.json"
+    cache = _load_pamt_hash_cache(cache_path)
+    pamt_path = game_dir / "0000" / "0.pamt"
+    st = pamt_path.stat()
+
+    entry = cache.get(str(pamt_path))
+    assert entry is not None, "verify must record a cache entry for the hashed PAMT"
+    assert entry[0] == st.st_mtime_ns and entry[1] == st.st_size


### PR DESCRIPTION
Fixes the Apply dialog reaching 100% and then sitting there for several seconds looking hung.

Post-apply verification checks PAPGT/PAMT integrity on the GUI thread on purpose, since it's the gate before Launch is safe to use, but it was rehashing every mounted directory's PAMT on every single Apply. Almost every directory is untouched between one Apply and the next, only the mod overlay actually changes, so PAMT hashes are now cached on disk by path, size and modified time, and only the directory that actually changed gets rehashed.