### PR TITLE
fix(apply): don't strand a stale overlay when every json_source mod is disabled

### DIFF
--- a/src/cdumm/engine/apply_engine.py
+++ b/src/cdumm/engine/apply_engine.py
@@ -1923,7 +1923,25 @@ class ApplyWorker(QObject):
             "SELECT 1 FROM mods WHERE enabled = 1 "
             "AND json_source IS NOT NULL AND json_source != '' "
             "LIMIT 1").fetchone() is not None
-        if not file_deltas and not revert_files and not has_enabled_json:
+        # _get_files_to_revert only tracks mod_type='paz' deltas, so it's
+        # blind to json_source mods entirely (they never write a
+        # mod_deltas row — their overlay is built fresh at mount time).
+        # Disabling every json_source mod at once made file_deltas,
+        # revert_files, AND has_enabled_json all empty, so Apply bailed
+        # out here before reaching Phase 4's orphan-cleanup, leaving the
+        # previous overlay (built by the mods that are now disabled)
+        # mounted forever (report 2026-08-26). If a CDUMM-managed overlay
+        # dir is still on disk, there's real cleanup work to do even with
+        # nothing to apply or revert -- don't bail, let the normal apply
+        # flow reach orphan-cleanup so it can remove it.
+        has_stale_overlay = any(
+            (d / "_cdumm_overlay.marker").exists()
+            for d in self._game_dir.iterdir()
+            if d.is_dir() and d.name.isdigit() and len(d.name) == 4
+            and int(d.name) >= 36
+        )
+        if (not file_deltas and not revert_files and not has_enabled_json
+                and not has_stale_overlay):
             self.error_occurred.emit("No mod changes to apply or revert.")
             return
 

--- a/tests/test_apply_engine.py
+++ b/tests/test_apply_engine.py
@@ -149,6 +149,51 @@ def test_apply_no_enabled_mods(tmp_path: Path) -> None:
     db.close()
 
 
+def test_apply_disabling_every_json_mod_does_not_bail_with_stale_overlay(
+        tmp_path: Path) -> None:
+    """Report 2026-08-26: disabling every json_source mod at once
+    ("No mod changes to apply or revert") left the PREVIOUS overlay
+    mounted forever. _get_files_to_revert only tracks mod_type='paz'
+    deltas, so it's blind to json_source mods -- with every mod disabled
+    and none of them 'paz', file_deltas/revert_files/has_enabled_json
+    were all empty and Apply bailed before reaching orphan-cleanup.
+
+    A CDUMM-managed overlay dir (marked with _cdumm_overlay.marker) left
+    on disk from a prior apply must NOT hit that bail -- there's real
+    cleanup work to do even with nothing to apply or revert.
+    """
+    game_dir, vanilla_dir, db = _setup_apply_test(tmp_path)
+
+    # A disabled json_source mod. json_source mods never write a
+    # mod_deltas row (their overlay is built fresh at mount time), so
+    # _get_files_to_revert's JOIN against mod_deltas can't see it
+    # regardless of mod_type.
+    db.connection.execute(
+        "INSERT INTO mods (name, mod_type, enabled, json_source, priority) "
+        "VALUES ('JsonMod', 'paz', 0, 'C:/fake/JsonMod.json', 1)"
+    )
+    db.connection.commit()
+
+    # Stale overlay from when that mod was still enabled.
+    overlay_dir = game_dir / "0038"
+    overlay_dir.mkdir()
+    (overlay_dir / "_cdumm_overlay.marker").write_bytes(b"cdumm")
+
+    worker = ApplyWorker(game_dir, vanilla_dir, db.db_path)
+    errors = []
+    finished = []
+    worker.error_occurred.connect(lambda e: errors.append(e))
+    worker.finished.connect(lambda: finished.append(True))
+    worker.run()
+
+    assert errors == [], f"Apply must not bail with a stale overlay present: {errors}"
+    assert len(finished) == 1
+    assert not overlay_dir.exists(), (
+        "reaching orphan-cleanup must actually remove the stale overlay, "
+        "not just avoid the early bail")
+    db.close()
+
+
 def test_revert_no_backups(tmp_path: Path) -> None:
     game_dir = tmp_path / "game"
     game_dir.mkdir()


### PR DESCRIPTION
Fixes disabling every JSON-source mod at once and hitting Apply doing nothing except showing "No mod changes to apply or revert", while the game kept loading the changes from the mods that were just disabled.

The revert-tracking query only looks at old-style PAZ delta mods, so it's blind to JSON-source mods entirely, they never write that kind of record. With every mod disabled, Apply had nothing to apply and nothing it recognized to revert, so it bailed out before ever reaching the step that actually removes the leftover mod overlay from disk.