### PR TITLE
nexus: say what 'Check for Mod Updates' actually checked

### DIFF
--- a/src/cdumm/gui/pages/settings_page.py
+++ b/src/cdumm/gui/pages/settings_page.py
@@ -1396,6 +1396,18 @@ class SettingsPage(SmoothScrollArea):
             return
 
         combined = mods + asi_mods
+        # GitHub #379 (vizionblind on Nexus): mods without a Nexus id are
+        # invisible to check_mod_updates, and a result of "no outdated
+        # mods" was rendered as "All mods are up to date!" even when NOT
+        # ONE mod was actually checkable. Count them here (main thread)
+        # so the result slot can say what was really checked.
+        def _linked(m):
+            try:
+                return int(m.get("nexus_mod_id") or 0) > 0
+            except (TypeError, ValueError):
+                return False
+        self._pending_linked = sum(1 for m in combined if _linked(m))
+        self._pending_unlinked = len(combined) - self._pending_linked
         _db = self._db
 
         import threading
@@ -1484,7 +1496,27 @@ class SettingsPage(SmoothScrollArea):
         # outdated mods — filter them out or we claim every matched
         # mod has a newer version on Nexus, with local == latest.
         outdated = filter_outdated(getattr(self, "_pending_updates", []))
+        linked = getattr(self, "_pending_linked", 0)
+        unlinked = getattr(self, "_pending_unlinked", 0)
         if not outdated:
+            # "Up to date" is only an honest summary for mods that were
+            # actually checkable. A mod imported from a manually
+            # downloaded archive has no Nexus id, is skipped entirely by
+            # check_mod_updates, and used to be silently counted into
+            # "All mods are up to date!" -- a user whose whole library
+            # was imported that way got a green success with zero mods
+            # checked (GitHub #379).
+            if linked == 0 and unlinked > 0:
+                self._set_nexus_status(
+                    tr("settings.nexus_none_linked", count=unlinked),
+                    InfoLevel.WARNING)
+                return
+            if unlinked > 0:
+                self._set_nexus_status(
+                    tr("settings.nexus_up_to_date_partial",
+                       checked=linked, unlinked=unlinked),
+                    InfoLevel.SUCCESS)
+                return
             self._set_nexus_status(
                 tr("settings.nexus_all_up_to_date"), InfoLevel.SUCCESS)
             return

--- a/src/cdumm/translations/ar.json
+++ b/src/cdumm/translations/ar.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "تمت إزالة AppData القديمة ({size_mb} م.ب)",
   "stats.outdated": "قديمة",
   "mod_list.click_to_update": "انقر للتحديث",
-  "tooltip.update_available_with_version": "يتوفر تحديث. المثبَّت: {version}. انقر للتحديث."
+  "tooltip.update_available_with_version": "يتوفر تحديث. المثبَّت: {version}. انقر للتحديث.",
+  "settings.nexus_none_linked": "لا يرتبط أيٌّ من تعديلاتك ({count}) بصفحة NexusMods، لذا لا يمكن فحص أيٍّ منها. التعديلات المستوردة من أرشيف منزَّل يدويًا لا تحمل رابط Nexus؛ أعد استيرادها عبر تنزيل Nexus أو أضف الرابط من بطاقة التعديل ليصبح فحصها ممكنًا.",
+  "settings.nexus_up_to_date_partial": "{checked} تعديل مرتبط محدث. {unlinked} تعديل بلا رابط NexusMods ولم يتسنَّ فحصه."
 }

--- a/src/cdumm/translations/de.json
+++ b/src/cdumm/translations/de.json
@@ -1318,5 +1318,7 @@
   "recovery.all_skipped_msg": "Deine Mods wurden deaktiviert, da ihre Originaldateien fehlen. Füge die Archive erneut hinzu, um sie zu importieren.",
   "recovery.partial_skipped_msg": "{count} Mod(s) wurden deaktiviert, da ihre Originaldateien fehlen: {names}",
   "recovery.complete_msg": "Wiederherstellung abgeschlossen. Starte das Spiel. Falls es weiterhin abstürzt, prüfe Nexus auf Updates deiner Mods.",
-  "settings.steam_launch_method_exe": "Spiel-Exe (Steam überspringen)"
+  "settings.steam_launch_method_exe": "Spiel-Exe (Steam überspringen)",
+  "settings.nexus_none_linked": "Keiner deiner {count} Mods ist mit einer NexusMods-Seite verknüpft, daher kann keiner geprüft werden. Aus manuell heruntergeladenen Archiven importierte Mods haben keinen Nexus-Link; importiere sie über den Nexus-Download neu oder ergänze den Link auf der Mod-Karte.",
+  "settings.nexus_up_to_date_partial": "{checked} verknüpfte Mod(s) sind aktuell. {unlinked} Mod(s) haben keinen NexusMods-Link und konnten nicht geprüft werden."
 }

--- a/src/cdumm/translations/en.json
+++ b/src/cdumm/translations/en.json
@@ -1318,5 +1318,7 @@
   "recovery.all_skipped_msg": "Your mods were disabled because their original files are gone. Drop the archives back in CDUMM to re-import them.",
   "recovery.partial_skipped_msg": "{count} mod(s) were disabled because their original files are gone: {names}",
   "recovery.complete_msg": "Recovery complete. Launch the game. If it still crashes, check Nexus for newer versions of your mods.",
-  "settings.steam_launch_method_exe": "Game exe (skip Steam)"
+  "settings.steam_launch_method_exe": "Game exe (skip Steam)",
+  "settings.nexus_none_linked": "None of your {count} mods are linked to a NexusMods page, so none of them can be checked. Mods imported from a manually downloaded archive have no Nexus link; re-import via the Nexus download or add the link on the mod's card to make them checkable.",
+  "settings.nexus_up_to_date_partial": "{checked} linked mod(s) are up to date. {unlinked} mod(s) have no NexusMods link and could not be checked."
 }

--- a/src/cdumm/translations/es.json
+++ b/src/cdumm/translations/es.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "AppData obsoleto eliminado ({size_mb} MB)",
   "stats.outdated": "Desactualizados",
   "mod_list.click_to_update": "Haz clic para actualizar",
-  "tooltip.update_available_with_version": "Actualización disponible. Instalado: {version}. Haz clic para actualizar."
+  "tooltip.update_available_with_version": "Actualización disponible. Instalado: {version}. Haz clic para actualizar.",
+  "settings.nexus_none_linked": "Ninguno de tus {count} mods está vinculado a una página de NexusMods, así que ninguno puede comprobarse. Los mods importados desde un archivo descargado manualmente no tienen enlace de Nexus; reimpórtalos mediante la descarga de Nexus o añade el enlace en la tarjeta del mod.",
+  "settings.nexus_up_to_date_partial": "{checked} mod(s) vinculados están al día. {unlinked} mod(s) no tienen enlace de NexusMods y no pudieron comprobarse."
 }

--- a/src/cdumm/translations/fr.json
+++ b/src/cdumm/translations/fr.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "AppData obsolète supprimé ({size_mb} Mo)",
   "stats.outdated": "Obsolètes",
   "mod_list.click_to_update": "Cliquer pour mettre à jour",
-  "tooltip.update_available_with_version": "Mise à jour disponible. Installé : {version}. Cliquer pour mettre à jour."
+  "tooltip.update_available_with_version": "Mise à jour disponible. Installé : {version}. Cliquer pour mettre à jour.",
+  "settings.nexus_none_linked": "Aucun de vos {count} mods n'est lié à une page NexusMods, donc aucun ne peut être vérifié. Les mods importés depuis une archive téléchargée manuellement n'ont pas de lien Nexus ; réimportez-les via le téléchargement Nexus ou ajoutez le lien sur la carte du mod.",
+  "settings.nexus_up_to_date_partial": "{checked} mod(s) lié(s) sont à jour. {unlinked} mod(s) sans lien NexusMods n'ont pas pu être vérifiés."
 }

--- a/src/cdumm/translations/id.json
+++ b/src/cdumm/translations/id.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "Menghapus AppData kedaluwarsa ({size_mb} MB)",
   "stats.outdated": "Usang",
   "mod_list.click_to_update": "Klik untuk memperbarui",
-  "tooltip.update_available_with_version": "Pembaruan tersedia. Terpasang: {version}. Klik untuk memperbarui."
+  "tooltip.update_available_with_version": "Pembaruan tersedia. Terpasang: {version}. Klik untuk memperbarui.",
+  "settings.nexus_none_linked": "Tidak ada dari {count} mod Anda yang tertaut ke halaman NexusMods, jadi tidak ada yang bisa diperiksa. Mod yang diimpor dari arsip unduhan manual tidak punya tautan Nexus; impor ulang lewat unduhan Nexus atau tambahkan tautannya di kartu mod.",
+  "settings.nexus_up_to_date_partial": "{checked} mod tertaut sudah terbaru. {unlinked} mod tanpa tautan NexusMods tidak dapat diperiksa."
 }

--- a/src/cdumm/translations/it.json
+++ b/src/cdumm/translations/it.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "AppData obsoleto rimosso ({size_mb} MB)",
   "stats.outdated": "Obsoleti",
   "mod_list.click_to_update": "Clicca per aggiornare",
-  "tooltip.update_available_with_version": "Aggiornamento disponibile. Installato: {version}. Clicca per aggiornare."
+  "tooltip.update_available_with_version": "Aggiornamento disponibile. Installato: {version}. Clicca per aggiornare.",
+  "settings.nexus_none_linked": "Nessuna delle tue {count} mod è collegata a una pagina NexusMods, quindi nessuna può essere controllata. Le mod importate da un archivio scaricato manualmente non hanno un collegamento Nexus; reimportale tramite il download di Nexus o aggiungi il collegamento nella scheda della mod.",
+  "settings.nexus_up_to_date_partial": "{checked} mod collegate sono aggiornate. {unlinked} mod senza collegamento NexusMods non hanno potuto essere controllate."
 }

--- a/src/cdumm/translations/ja.json
+++ b/src/cdumm/translations/ja.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "古い AppData を削除しました ({size_mb} MB)",
   "stats.outdated": "古い",
   "mod_list.click_to_update": "クリックで更新",
-  "tooltip.update_available_with_version": "アップデートあり。インストール済み: {version}。クリックで更新。"
+  "tooltip.update_available_with_version": "アップデートあり。インストール済み: {version}。クリックで更新。",
+  "settings.nexus_none_linked": "{count} 個のModのいずれも NexusMods のページにリンクされていないため、更新を確認できません。手動でダウンロードしたアーカイブから取り込んだModには Nexus リンクがありません。Nexus 経由で再インポートするか、Modカードでリンクを追加してください。",
+  "settings.nexus_up_to_date_partial": "リンク済みの {checked} 個のModは最新です。{unlinked} 個は NexusMods リンクがないため確認できませんでした。"
 }

--- a/src/cdumm/translations/ko.json
+++ b/src/cdumm/translations/ko.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "오래된 AppData 제거됨 ({size_mb} MB)",
   "stats.outdated": "구버전",
   "mod_list.click_to_update": "클릭하여 업데이트",
-  "tooltip.update_available_with_version": "업데이트 있음. 설치됨: {version}. 클릭하여 업데이트."
+  "tooltip.update_available_with_version": "업데이트 있음. 설치됨: {version}. 클릭하여 업데이트.",
+  "settings.nexus_none_linked": "{count}개의 모드 중 NexusMods 페이지에 연결된 것이 없어 업데이트를 확인할 수 없습니다. 수동으로 내려받은 압축 파일에서 가져온 모드에는 Nexus 링크가 없습니다. Nexus 다운로드로 다시 가져오거나 모드 카드에서 링크를 추가하세요.",
+  "settings.nexus_up_to_date_partial": "연결된 모드 {checked}개는 최신입니다. NexusMods 링크가 없는 {unlinked}개는 확인할 수 없었습니다."
 }

--- a/src/cdumm/translations/pl.json
+++ b/src/cdumm/translations/pl.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "Usunięto nieaktualne AppData ({size_mb} MB)",
   "stats.outdated": "Nieaktualne",
   "mod_list.click_to_update": "Kliknij, aby zaktualizować",
-  "tooltip.update_available_with_version": "Aktualizacja dostępna. Zainstalowane: {version}. Kliknij, aby zaktualizować."
+  "tooltip.update_available_with_version": "Aktualizacja dostępna. Zainstalowane: {version}. Kliknij, aby zaktualizować.",
+  "settings.nexus_none_linked": "Żaden z Twoich {count} modów nie jest powiązany ze stroną NexusMods, więc żadnego nie można sprawdzić. Mody zaimportowane z ręcznie pobranego archiwum nie mają łącza Nexus; zaimportuj je ponownie przez pobranie z Nexusa albo dodaj łącze na karcie moda.",
+  "settings.nexus_up_to_date_partial": "{checked} powiązanych modów jest aktualnych. {unlinked} modów bez łącza NexusMods nie udało się sprawdzić."
 }

--- a/src/cdumm/translations/pt-BR.json
+++ b/src/cdumm/translations/pt-BR.json
@@ -1016,5 +1016,7 @@
   "preset.customize": "Personalizar…",
   "stats.outdated": "Desatualizado",
   "mod_list.click_to_update": "Clique para atualizar",
-  "tooltip.update_available_with_version": "Atualização disponível. Instalado: {version}. Clique para atualizar."
+  "tooltip.update_available_with_version": "Atualização disponível. Instalado: {version}. Clique para atualizar.",
+  "settings.nexus_none_linked": "Nenhum dos seus {count} mods está vinculado a uma página do NexusMods, então nenhum pode ser verificado. Mods importados de um arquivo baixado manualmente não têm link do Nexus; reimporte-os pelo download do Nexus ou adicione o link no cartão do mod.",
+  "settings.nexus_up_to_date_partial": "{checked} mod(s) vinculados estão atualizados. {unlinked} mod(s) sem link do NexusMods não puderam ser verificados."
 }

--- a/src/cdumm/translations/ru.json
+++ b/src/cdumm/translations/ru.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "Удалены устаревшие AppData ({size_mb} МБ)",
   "stats.outdated": "Устаревшие",
   "mod_list.click_to_update": "Нажмите для обновления",
-  "tooltip.update_available_with_version": "Доступно обновление. Установлено: {version}. Нажмите для обновления."
+  "tooltip.update_available_with_version": "Доступно обновление. Установлено: {version}. Нажмите для обновления.",
+  "settings.nexus_none_linked": "Ни один из ваших {count} модов не привязан к странице NexusMods, поэтому проверить нечего. У модов, импортированных из скачанного вручную архива, нет ссылки на Nexus; импортируйте их заново через загрузку с Nexus или добавьте ссылку в карточке мода.",
+  "settings.nexus_up_to_date_partial": "{checked} привязанных мода(ов) актуальны. {unlinked} мод(ов) без ссылки на NexusMods проверить не удалось."
 }

--- a/src/cdumm/translations/tr.json
+++ b/src/cdumm/translations/tr.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "Eski AppData silindi ({size_mb} MB)",
   "stats.outdated": "Güncel Değil",
   "mod_list.click_to_update": "Güncellemek için tıkla",
-  "tooltip.update_available_with_version": "Güncelleme mevcut. Yüklü: {version}. Güncellemek için tıkla."
+  "tooltip.update_available_with_version": "Güncelleme mevcut. Yüklü: {version}. Güncellemek için tıkla.",
+  "settings.nexus_none_linked": "{count} modunuzdan hiçbiri bir NexusMods sayfasına bağlı değil, bu yüzden hiçbiri denetlenemiyor. Elle indirilen arşivden içe aktarılan modların Nexus bağlantısı yoktur; Nexus indirmesiyle yeniden içe aktarın veya mod kartından bağlantı ekleyin.",
+  "settings.nexus_up_to_date_partial": "Bağlı {checked} mod güncel. NexusMods bağlantısı olmayan {unlinked} mod denetlenemedi."
 }

--- a/src/cdumm/translations/uk.json
+++ b/src/cdumm/translations/uk.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "Видалено застарілі AppData ({size_mb} МБ)",
   "stats.outdated": "Застарілі",
   "mod_list.click_to_update": "Натисніть для оновлення",
-  "tooltip.update_available_with_version": "Доступне оновлення. Встановлено: {version}. Натисніть для оновлення."
+  "tooltip.update_available_with_version": "Доступне оновлення. Встановлено: {version}. Натисніть для оновлення.",
+  "settings.nexus_none_linked": "Жоден із ваших {count} модів не пов'язаний зі сторінкою NexusMods, тому перевірити нічого. Моди, імпортовані з завантаженого вручну архіву, не мають посилання на Nexus; імпортуйте їх повторно через завантаження з Nexus або додайте посилання в картці мода.",
+  "settings.nexus_up_to_date_partial": "{checked} пов'язаних модів актуальні. {unlinked} модів без посилання на NexusMods перевірити не вдалося."
 }

--- a/src/cdumm/translations/zh-CN.json
+++ b/src/cdumm/translations/zh-CN.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "已移除过期 AppData ({size_mb} MB)",
   "stats.outdated": "已过时",
   "mod_list.click_to_update": "点击更新",
-  "tooltip.update_available_with_version": "有可用更新。已安装: {version}。点击更新。"
+  "tooltip.update_available_with_version": "有可用更新。已安装: {version}。点击更新。",
+  "settings.nexus_none_linked": "你的 {count} 个 Mod 都没有关联 NexusMods 页面，因此无法检查任何更新。从手动下载的压缩包导入的 Mod 没有 Nexus 链接；请通过 Nexus 下载重新导入，或在 Mod 卡片上补充链接。",
+  "settings.nexus_up_to_date_partial": "{checked} 个已关联的 Mod 均为最新。{unlinked} 个 Mod 没有 NexusMods 链接，无法检查。"
 }

--- a/src/cdumm/translations/zh-TW.json
+++ b/src/cdumm/translations/zh-TW.json
@@ -980,5 +980,7 @@
   "activity.msg_removed_stale_appdata": "已移除過期 AppData ({size_mb} MB)",
   "stats.outdated": "已過時",
   "mod_list.click_to_update": "點擊更新",
-  "tooltip.update_available_with_version": "有可用更新。已安裝: {version}。點擊更新。"
+  "tooltip.update_available_with_version": "有可用更新。已安裝: {version}。點擊更新。",
+  "settings.nexus_none_linked": "你的 {count} 個 Mod 都未連結 NexusMods 頁面，因此無法檢查任何更新。從手動下載的壓縮檔匯入的 Mod 沒有 Nexus 連結；請透過 Nexus 下載重新匯入，或在 Mod 卡片上補上連結。",
+  "settings.nexus_up_to_date_partial": "{checked} 個已連結的 Mod 皆為最新。{unlinked} 個 Mod 沒有 NexusMods 連結，無法檢查。"
 }

--- a/tests/test_settings_nexus_check_visibility.py
+++ b/tests/test_settings_nexus_check_visibility.py
@@ -77,6 +77,7 @@ def test_translation_keys_exist_in_english():
     en = _en()
     assert "settings.nexus_none_linked" in en
     assert "settings.nexus_up_to_date_partial" in en
-    # tr() falls back to English for other languages, so en.json alone
-    # is sufficient for correctness; other locales pick it up later.
     assert "{count}" in en["settings.nexus_none_linked"]
+    # All 15 locales carry the keys too -- test_i18n_key_parity enforces
+    # it repo-wide, and its CI failure on this branch's first push is
+    # what corrected the "en-only is fine via fallback" assumption.

--- a/tests/test_settings_nexus_check_visibility.py
+++ b/tests/test_settings_nexus_check_visibility.py
@@ -1,0 +1,82 @@
+"""GitHub #379: 'Check for Mod Updates' must say what it actually checked.
+
+Nexus report (vizionblind): with an API key configured and every mod
+imported from manually downloaded archives, the check always said
+"All mods are up to date!". Those mods have no ``nexus_mod_id``, so
+``check_mod_updates`` skips them entirely -- the check was reporting
+success while checking nothing.
+
+The fix counts linked vs unlinked mods when the check starts and picks
+the summary from that:
+
+* 0 linked, some unlinked -> a WARNING saying nothing was checkable;
+* some of each            -> success that names both counts;
+* all linked              -> the original message.
+
+Source-level tests, matching this suite's convention for settings-page
+behavior (see test_settings_view_patch_notes_button.py).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _src() -> str:
+    return (_ROOT / "src" / "cdumm" / "gui" / "pages" / "settings_page.py"
+            ).read_text(encoding="utf-8")
+
+
+def _en() -> dict:
+    return json.loads((_ROOT / "src" / "cdumm" / "translations" / "en.json"
+                       ).read_text(encoding="utf-8"))
+
+
+def test_linked_and_unlinked_are_counted_when_the_check_starts():
+    src = _src()
+    assert "_pending_linked" in src and "_pending_unlinked" in src
+    # The count must happen where the mod list is built (main thread),
+    # not in the worker -- the worker only sees what it was handed.
+    build = src.find("combined = mods + asi_mods")
+    assert build != -1
+    assert src.find("_pending_linked", build) - build < 1500, (
+        "linked/unlinked must be counted right after `combined` is "
+        "assembled")
+
+
+def test_zero_linked_mods_is_a_warning_not_a_success():
+    src = _src()
+    anchor = src.find("def _show_nexus_results")
+    body = src[anchor:anchor + 6000]
+    assert "nexus_none_linked" in body, (
+        "a library with no Nexus-linked mods must get its own message "
+        "instead of 'All mods are up to date!'")
+    none_at = body.find("nexus_none_linked")
+    assert "WARNING" in body[none_at - 200:none_at + 200], (
+        "'nothing was checkable' is a warning state, not a success")
+    # The all-up-to-date success must come AFTER the guarded cases so it
+    # can only be reached when every mod really was checked.
+    assert none_at < body.find("nexus_all_up_to_date")
+
+
+def test_partial_coverage_names_both_counts():
+    src = _src()
+    anchor = src.find("def _show_nexus_results")
+    body = src[anchor:anchor + 6000]
+    assert "nexus_up_to_date_partial" in body
+    en = _en()
+    partial = en["settings.nexus_up_to_date_partial"]
+    assert "{checked}" in partial and "{unlinked}" in partial, (
+        "the partial message must state how many mods were checked AND "
+        "how many were not checkable, or it repeats the #379 ambiguity")
+
+
+def test_translation_keys_exist_in_english():
+    en = _en()
+    assert "settings.nexus_none_linked" in en
+    assert "settings.nexus_up_to_date_partial" in en
+    # tr() falls back to English for other languages, so en.json alone
+    # is sufficient for correctness; other locales pick it up later.
+    assert "{count}" in en["settings.nexus_none_linked"]


### PR DESCRIPTION
Refs #379 (vizionblind's Nexus report: always 'all up to date' despite known updates).

Root cause found in the summary path, not the API path: `check_mod_updates` silently excludes every mod without a `nexus_mod_id` (mods imported from manually downloaded archives have none), and `_show_nexus_results` rendered an empty outdated-list as **"All mods are up to date!"** regardless of whether anything was checkable. A library imported entirely by hand: zero mods checked, green success. That is exactly the reported behaviour.

## Fix

Linked/unlinked are counted when the check starts (main thread, where the mod list is built), and the summary is three-state:

| state | message |
|---|---|
| 0 linked, some unlinked | WARNING: none of your N mods can be checked, and how to fix that |
| some of each | success naming both counts |
| all linked | the original message, now honest |

Translation keys in en.json only -- `tr()` falls back to English for other locales.

## Scope honesty

This makes the real state visible; it does not prove it was the whole story. If the reporter's mods ARE linked and a genuine update went undetected, that is a second fault -- #379 stays open until they confirm on Nexus.

4 source-level tests (repo's settings-page convention), new test file ruff-clean, settings_page findings unchanged from master (26). Targeted suites 145 passed.