### PR TITLE
Fix #383: preserve CD 2.0 vanilla PAPGT placeholder entries 0036-0040

### DIFF
--- a/src/cdumm/archive/papgt_manager.py
+++ b/src/cdumm/archive/papgt_manager.py
@@ -61,6 +61,59 @@ def encode_papgt_entry_flags(
     )
 
 
+def read_papgt_entries(path: Path) -> "list[tuple[str, int, int]] | None":
+    """Parse a PAPGT file into ``[(dir_name, flags, pamt_hash), ...]``.
+
+    Returns ``None`` when the file is missing or malformed — callers use
+    this for *advisory* data (vanilla entry names, reserved dir numbers)
+    and must degrade gracefully rather than crash mid-apply.
+    """
+    try:
+        data = path.read_bytes()
+        if len(data) < 12:
+            return None
+        entry_start = 12
+        entry_count = _find_entry_count(bytearray(data), entry_start)
+        string_table_start = entry_start + entry_count * ENTRY_SIZE + 4
+        out: list[tuple[str, int, int]] = []
+        for i in range(entry_count):
+            pos = entry_start + i * ENTRY_SIZE
+            flags, name_offset, pamt_hash = struct.unpack_from("<III", data, pos)
+            name = _read_string(bytearray(data), string_table_start, name_offset)
+            if name:
+                out.append((name, flags, pamt_hash))
+        return out
+    except (OSError, ValueError, struct.error):
+        return None
+
+
+def reserved_papgt_dir_numbers(game_dir: Path,
+                               vanilla_dir: "Path | None" = None) -> "set[int]":
+    """Numeric dir names claimed by the live and vanilla PAPGT indexes.
+
+    Crimson Desert 2.0 (build 24934353) ships five PLACEHOLDER entries
+    0036-0040 in vanilla meta/0.papgt — optional language-pack slots
+    (is_optional=1, single-bit lang_type) whose directories do not exist
+    on disk for most installs. Any dir number CDUMM allocates for an
+    overlay or standalone mod must not collide with these reserved
+    names, or the game applies the placeholder's optional/language
+    gating to the mod content and silently never mounts it (GitHub
+    #383, EnefFlow).
+    """
+    reserved: set[int] = set()
+    for papgt in (game_dir / "meta" / "0.papgt",
+                  (vanilla_dir / "meta" / "0.papgt") if vanilla_dir else None):
+        if papgt is None:
+            continue
+        entries = read_papgt_entries(papgt)
+        if not entries:
+            continue
+        for name, _flags, _h in entries:
+            if name.isdigit() and len(name) == 4:
+                reserved.add(int(name))
+    return reserved
+
+
 class PapgtManager:
     """Manages PAPGT rebuild from scratch."""
 
@@ -147,6 +200,21 @@ class PapgtManager:
         #   boot). Treat them as already gone so the new PAPGT never
         #   references them.
         excluded = exclude_dirs or set()
+
+        # Vanilla entry set from the pristine snapshot PAPGT. Crimson
+        # Desert 2.0 (build 24934353) ships PLACEHOLDER entries 0036-0040
+        # — optional language-pack slots with no directory on disk — so
+        # "digit < 36" is no longer a valid vanilla test (GitHub #383,
+        # EnefFlow: the old test stripped 4 vanilla entries and let the
+        # overlay squat slot 0037, inheriting is_optional=1 flags the
+        # game uses to skip it). The snapshot is re-taken on every game
+        # update (fingerprint-stamped), so its PAPGT tracks the current
+        # build's entry set.
+        vanilla_entries: dict[str, tuple[int, int]] = {}
+        if self._vanilla_papgt is not None:
+            for _n, _f, _h in (read_papgt_entries(self._vanilla_papgt) or []):
+                vanilla_entries[_n] = (_f, _h)
+
         live_entries: list[tuple[str, int, int]] = []
         removed = []
         for dir_name, flags, pamt_hash in parsed_entries:
@@ -155,17 +223,48 @@ class PapgtManager:
                 continue
             pamt_on_disk = (self._game_dir / dir_name / "0.pamt").exists()
             in_modified = modified_pamts and dir_name in modified_pamts
-            # Keep vanilla entries (dirs < 0036) even if not on disk — they may
-            # be placeholders for DLC/patches. Only remove mod-added dirs (0036+).
-            is_vanilla_dir = True
-            try:
-                is_vanilla_dir = int(dir_name) < 36
-            except (ValueError, TypeError):
-                pass
-            if pamt_on_disk or in_modified or is_vanilla_dir:
+            # Keep vanilla entries even if not on disk — 2.0 ships
+            # placeholder entries whose dirs don't exist. Fall back to
+            # the historical "digit < 36" floor when no snapshot PAPGT
+            # is available. Only remove mod-added dirs.
+            is_vanilla_dir = dir_name in vanilla_entries
+            if not is_vanilla_dir:
+                try:
+                    is_vanilla_dir = int(dir_name) < 36
+                except (ValueError, TypeError):
+                    is_vanilla_dir = True
+            # DANGLING entries (no dir on disk at all) are also kept,
+            # independent of the snapshot: CDUMM's own removals always
+            # go through ``exclude_dirs`` while the dir still exists
+            # (deletion is deferred to post-commit), so a dangling entry
+            # cannot be a CDUMM leftover — it is a vanilla placeholder
+            # (2.0 ships five: 0036-0040) or an external tool's entry.
+            # This keeps placeholders alive even when the vanilla
+            # snapshot is stale (snapshot only refreshes on apply, so a
+            # pre-2.0 snapshot is common right after the game update).
+            dir_missing = not (self._game_dir / dir_name).exists()
+            if pamt_on_disk or in_modified or is_vanilla_dir or dir_missing:
                 live_entries.append((dir_name, flags, pamt_hash))
             else:
                 removed.append(dir_name)
+
+        # Restore vanilla entries missing from the base (heals installs
+        # mutilated by the pre-fix "digit < 36" removal, and installs
+        # whose squatted placeholder dir is being deleted this apply —
+        # the ENTRY must survive with its vanilla flags+hash even though
+        # the dir goes away, because that is exactly how vanilla ships).
+        restored: list[str] = []
+        _present = {e[0] for e in live_entries}
+        for _n, (_f, _h) in vanilla_entries.items():
+            if _n in _present:
+                continue
+            if modified_pamts and _n in modified_pamts:
+                continue  # actively rewritten this apply; added below
+            live_entries.append((_n, _f, _h))
+            restored.append(_n)
+        if restored:
+            logger.info("PAPGT: restored %d vanilla entries: %s",
+                        len(restored), restored)
 
         if removed:
             logger.info("PAPGT: removing %d stale entries: %s", len(removed), removed)
@@ -251,12 +350,24 @@ class PapgtManager:
         # directories may be stale (mod built on older game version).
         # Always verify existing hashes against the actual PAMT on disk.
         existing_hashes = {d: h for d, _, h in parsed_entries}
+        # Restored vanilla entries aren't in the parsed base — carry
+        # their vanilla hashes so the hash loop below doesn't zero them.
+        for _n in restored:
+            existing_hashes.setdefault(_n, vanilla_entries[_n][1])
         modified_set = set(modified_pamts.keys()) if modified_pamts else set()
         is_mod_base = mod_papgt is not None
         rehashed = 0
 
+        restored_set = set(restored)
         for dir_name, flags in all_entries:
-            if dir_name in modified_set:
+            if dir_name in restored_set and dir_name in excluded:
+                # Vanilla entry restored over a squatted placeholder dir
+                # that is deleted right after commit — its pamt is still
+                # on disk NOW, so the rehash branches below would pin the
+                # hash of a file about to vanish. Use the vanilla hash:
+                # that is the exact end-state the game ships.
+                pamt_hash = vanilla_entries[dir_name][1]
+            elif dir_name in modified_set:
                 # PAMT was modified — recompute hash from new data
                 pamt_data = modified_pamts[dir_name]
                 pamt_hash = compute_pamt_hash(pamt_data) if len(pamt_data) >= 12 else 0

--- a/src/cdumm/engine/apply_engine.py
+++ b/src/cdumm/engine/apply_engine.py
@@ -5078,6 +5078,17 @@ class ApplyWorker(QObject):
                 num = int(d)
                 if num > max_num:
                     max_num = num
+        # Never collide with dir numbers the live or vanilla PAPGT
+        # already claims. Crimson Desert 2.0 ships placeholder entries
+        # 0036-0040 (optional language-pack slots with NO dir on disk);
+        # squatting one hands the overlay the placeholder's
+        # is_optional=1 flags and the game silently never mounts it
+        # (GitHub #383). Both indexes are scanned because a pre-fix
+        # apply may have stripped the placeholders from the live one.
+        from cdumm.archive.papgt_manager import reserved_papgt_dir_numbers
+        for num in reserved_papgt_dir_numbers(self._game_dir, self._vanilla_dir):
+            if num > max_num:
+                max_num = num
         overlay_num = max_num + 1
         return f"{overlay_num:04d}"
 

--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -2273,6 +2273,18 @@ def _next_paz_directory(game_dir: Path, db=None) -> str:
             existing.add(int(d.name))
     existing |= _assigned_dirs
 
+    # Dir numbers claimed by the live/vanilla PAPGT even with no dir on
+    # disk: Crimson Desert 2.0 ships placeholder entries 0036-0040
+    # (optional language-pack slots). A standalone mod remapped onto one
+    # of those numbers inherits the placeholder's is_optional flags at
+    # PAPGT rebuild and the game never mounts it (GitHub #383).
+    from cdumm.archive.papgt_manager import reserved_papgt_dir_numbers
+    try:
+        vanilla_root = get_cdmods_root(None, game_dir) / "vanilla"
+    except Exception:
+        vanilla_root = None
+    existing |= reserved_papgt_dir_numbers(game_dir, vanilla_root)
+
     if db is not None:
         try:
             rows = db.connection.execute(

--- a/tests/test_papgt_cd20_placeholder_entries.py
+++ b/tests/test_papgt_cd20_placeholder_entries.py
@@ -1,0 +1,166 @@
+"""GitHub #383 (EnefFlow): Crimson Desert 2.0 ships PLACEHOLDER entries
+0036-0040 in vanilla meta/0.papgt — optional language-pack slots whose
+directories do not exist on disk. The pre-fix rebuild treated every digit
+entry >= 0036 without a 0.pamt as a stale mod dir and removed it
+("PAPGT rebuilt: 35 entries (4 removed, 0 added)" in EnefFlow's report),
+and the overlay allocator squatted slot 0037, inheriting the
+placeholder's is_optional=1 flags — the game then silently never mounted
+the overlay: apply "succeeds", zero in-game effect.
+
+Covers:
+- rebuild keeps dangling placeholder entries (snapshot-independent rule)
+- rebuild restores placeholders stripped by a pre-fix apply (heal)
+- restored entry over an excluded squatted dir gets vanilla flags+hash
+- overlay allocator skips PAPGT-reserved numbers -> 0041
+"""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from cdumm.archive.papgt_manager import (
+    PapgtManager,
+    read_papgt_entries,
+    reserved_papgt_dir_numbers,
+)
+
+# Live 2.0 placeholder flags (build 24934353): is_optional=1 low byte,
+# single-bit lang_type. Exact values measured from a clean install.
+_PLACEHOLDERS = [
+    ("0036", 0x00008001, 0x5BB5F227),
+    ("0037", 0x00010001, 0x9E7C2F72),
+    ("0038", 0x00000401, 0xBBDA9FF9),
+    ("0039", 0x00080001, 0x65639AB3),
+    ("0040", 0x00002001, 0x03FC3F20),
+]
+
+
+def _build_papgt(entries: list[tuple[str, int, int]]) -> bytes:
+    """Minimal PAPGT with (dir_name, flags, pamt_hash) entries."""
+    string_table = bytearray()
+    offsets: list[int] = []
+    for dir_name, _f, _h in entries:
+        offsets.append(len(string_table))
+        string_table += dir_name.encode("ascii") + b"\x00"
+
+    body = bytearray()
+    for (dir_name, f, h), off in zip(entries, offsets):
+        body += struct.pack("<III", f, off, h)
+    body += struct.pack("<I", len(string_table))
+    body += string_table
+
+    out = bytearray()
+    out += b"\x01\x02\x03\x04"
+    out += b"\x00\x00\x00\x00"
+    out += bytes([len(entries), 0xFF, 0xFF, 0xFF])
+    out += body
+    return bytes(out)
+
+
+def _entries_by_name(papgt_path: Path) -> dict[str, tuple[int, int]]:
+    entries = read_papgt_entries(papgt_path)
+    assert entries is not None
+    return {n: (f, h) for n, f, h in entries}
+
+
+def _make_game(tmp_path: Path, papgt_entries) -> Path:
+    game = tmp_path / "game"
+    (game / "meta").mkdir(parents=True)
+    (game / "meta" / "0.papgt").write_bytes(_build_papgt(papgt_entries))
+    for name, _f, _h in papgt_entries:
+        if name.isdigit() and int(name) < 36:
+            d = game / name
+            d.mkdir()
+            (d / "0.pamt").write_bytes(b"\x00" * 16)
+    return game
+
+
+_VANILLA_REAL = [("0000", 0x007FFF00, 0x11111111),
+                 ("0035", 0x00200000, 0x22222222)]
+
+
+def test_rebuild_keeps_dangling_placeholders_without_snapshot(tmp_path):
+    """Dangling entries survive even with NO vanilla snapshot (the
+    snapshot is stale/absent right after a game update)."""
+    game = _make_game(tmp_path, _VANILLA_REAL + _PLACEHOLDERS)
+
+    mgr = PapgtManager(game, vanilla_dir=None)
+    rebuilt = mgr.rebuild(modified_pamts=None)
+    (game / "meta" / "0.papgt").write_bytes(rebuilt)
+
+    by_name = _entries_by_name(game / "meta" / "0.papgt")
+    for name, flags, h in _PLACEHOLDERS:
+        assert name in by_name, f"placeholder {name} removed"
+        assert by_name[name] == (flags, h), f"placeholder {name} mutated"
+
+
+def test_rebuild_restores_placeholders_stripped_by_prefix_apply(tmp_path):
+    """Heal: base papgt already mutilated (35-entry state) — vanilla
+    snapshot brings the placeholders back with vanilla flags+hash."""
+    game = _make_game(tmp_path, _VANILLA_REAL)  # placeholders missing
+
+    vanilla = tmp_path / "vanilla"
+    (vanilla / "meta").mkdir(parents=True)
+    (vanilla / "meta" / "0.papgt").write_bytes(
+        _build_papgt(_VANILLA_REAL + _PLACEHOLDERS))
+
+    mgr = PapgtManager(game, vanilla_dir=vanilla)
+    rebuilt = mgr.rebuild(modified_pamts=None)
+    (game / "meta" / "0.papgt").write_bytes(rebuilt)
+
+    by_name = _entries_by_name(game / "meta" / "0.papgt")
+    for name, flags, h in _PLACEHOLDERS:
+        assert name in by_name, f"placeholder {name} not restored"
+        assert by_name[name] == (flags, h)
+
+
+def test_restored_entry_over_excluded_squatted_dir_gets_vanilla_form(tmp_path):
+    """EnefFlow's exact state: CDUMM overlay squatted 0037 (dir with
+    marker + pamt on disk, entry carries placeholder flags). Next apply
+    excludes the stale overlay dir — the entry must come back as the
+    vanilla placeholder, not keep the doomed pamt's hash."""
+    game = _make_game(tmp_path, _VANILLA_REAL + _PLACEHOLDERS)
+    squat = game / "0037"
+    squat.mkdir()
+    (squat / "0.pamt").write_bytes(b"\xAA" * 32)
+    (squat / "_cdumm_overlay.marker").write_bytes(b"CDUMM overlay marker.")
+
+    vanilla = tmp_path / "vanilla"
+    (vanilla / "meta").mkdir(parents=True)
+    (vanilla / "meta" / "0.papgt").write_bytes(
+        _build_papgt(_VANILLA_REAL + _PLACEHOLDERS))
+
+    mgr = PapgtManager(game, vanilla_dir=vanilla)
+    rebuilt = mgr.rebuild(modified_pamts=None, exclude_dirs={"0037"})
+    (game / "meta" / "0.papgt").write_bytes(rebuilt)
+
+    by_name = _entries_by_name(game / "meta" / "0.papgt")
+    assert by_name["0037"] == (0x00010001, 0x9E7C2F72)
+
+
+def test_reserved_papgt_dir_numbers_sees_placeholders(tmp_path):
+    game = _make_game(tmp_path, _VANILLA_REAL + _PLACEHOLDERS)
+    reserved = reserved_papgt_dir_numbers(game)
+    assert {36, 37, 38, 39, 40} <= reserved
+
+
+def test_overlay_allocator_skips_reserved_numbers(tmp_path):
+    """Allocator must return 0041 on a 2.0 install even though no
+    0036+ directory exists on disk."""
+    game = _make_game(tmp_path, _VANILLA_REAL + _PLACEHOLDERS)
+
+    from cdumm.engine.apply_engine import ApplyWorker
+    eng = ApplyWorker.__new__(ApplyWorker)  # allocator needs only these attrs
+    eng._game_dir = game
+    eng._vanilla_dir = tmp_path / "no-snapshot"
+    assert eng._allocate_overlay_dir() == "0041"
+
+
+def test_import_next_dir_skips_reserved_numbers(tmp_path):
+    game = _make_game(tmp_path, _VANILLA_REAL + _PLACEHOLDERS)
+    import cdumm.engine.import_handler as ih
+    ih._assigned_dirs.clear()
+    try:
+        assert ih._next_paz_directory(game) == "0041"
+    finally:
+        ih._assigned_dirs.clear()


### PR DESCRIPTION
## Root cause

Crimson Desert 2.0 (build 24934353) ships five placeholder entries `0036`-`0040` in vanilla `meta/0.papgt`. They are optional language-pack slots (is_optional=1, single-bit lang_type) whose directories do not exist on disk. Measured from a clean 2.0 install:

```
0036 flags=0x00008001  0037 flags=0x00010001  0038 flags=0x00000401
0039 flags=0x00080001  0040 flags=0x00002001
```

CDUMM's rebuild used a hardcoded 'digit < 36 means vanilla' test, so on 2.0 every apply:
1. removed four vanilla placeholder entries as 'stale mod dirs' (EnefFlow's report log: `PAPGT rebuilt: 35 entries (4 removed, 0 added)`)
2. allocated the overlay at slot 0037, which is already a vanilla entry, so the overlay inherited the placeholder's is_optional=1 language-gated flags and the game silently never mounted it.

Apply reports success, mods have zero in-game effect. Exactly the #383 symptom.

## Fix

- **rebuild** keeps dangling entries (no dir on disk) unconditionally. CDUMM's own removals always flow through `exclude_dirs` while the dir still exists (deletion deferred post-commit), so a dangling entry can never be a CDUMM leftover. This protects the placeholders even when the vanilla snapshot is stale right after a game update.
- **rebuild** restores vanilla entries missing from the base with their vanilla flags+hash, healing installs mutilated by pre-fix applies, including the entry for a squatted placeholder dir that is deleted this apply.
- **overlay allocator** (`_allocate_overlay_dir`) and **standalone import numbering** (`_next_paz_directory`) now skip every dir number claimed by the live or vanilla PAPGT, so overlays land at 0041+ on 2.0.

## Testing

- 6 new tests in `tests/test_papgt_cd20_placeholder_entries.py` including a reproduction of EnefFlow's exact squatted-0037 state
- full suite: 3083 passed, 1 pre-existing machine-local failure (`test_script_import_consent_gate`)
- helpers verified against the live 2.0 install (39-entry PAPGT parses, reserved set includes 36-40)

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr