### PR TITLE
Fix #371: sweep leftover _import_staging folders at startup

### DIFF
--- a/src/cdumm/engine/import_handler.py
+++ b/src/cdumm/engine/import_handler.py
@@ -195,6 +195,48 @@ def import_staging_dir(game_dir: Path, config: "Config | None" = None):
                 staging, e)
 
 
+def cleanup_import_staging(game_dir: Path,
+                           config: "Config | None" = None) -> int:
+    """Delete leftover extraction folders under CDMods/_import_staging/.
+
+    Each import extracts into a fresh <uuid> subfolder there and removes
+    it when done — but a crash or force-kill mid-import leaves the
+    extracted archive behind, and repeated experimenting accumulates
+    tens of GB (GitHub #371, SyDant: +25 GB). Nothing ever reads a
+    staging folder after its import ends, and the GUI holds the
+    single-instance .gui_lock when this runs at startup, so no import
+    can be in flight.
+
+    Returns the number of bytes freed (0 when there was nothing).
+    """
+    try:
+        base = get_cdmods_root(config, game_dir) / "_import_staging"
+    except Exception:
+        return 0
+    if not base.is_dir():
+        return 0
+    freed = 0
+    for child in base.iterdir():
+        try:
+            if child.is_dir():
+                size = sum(f.stat().st_size for f in child.rglob("*")
+                           if f.is_file())
+            else:
+                size = child.stat().st_size
+            if child.is_dir():
+                shutil.rmtree(child, ignore_errors=True)
+            else:
+                child.unlink(missing_ok=True)
+            if not child.exists():
+                freed += size
+        except OSError as e:
+            logger.debug("cleanup_import_staging: skipping %s: %s", child, e)
+    if freed:
+        logger.info("cleanup_import_staging: freed %.1f MB from %s",
+                    freed / 1048576, base)
+    return freed
+
+
 def _validate_modified_pamt(modified_bytes: bytes, rel_path: str) -> None:
     """Parse ``modified_bytes`` as a PAMT to validate it before import.
 

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -1811,6 +1811,17 @@ class CdummWindow(FluentWindow):
 
     def _deferred_startup(self) -> None:
         """Run after window is visible. Heavy checks happen here."""
+        # Sweep leftover import-extraction folders (GitHub #371: crashed
+        # or force-killed imports leave the extracted archive under
+        # CDMods/_import_staging/ and users accumulated 25+ GB). Safe
+        # here: the single-instance .gui_lock is held, so no import is
+        # in flight.
+        if self._game_dir:
+            try:
+                from cdumm.engine.import_handler import cleanup_import_staging
+                cleanup_import_staging(self._game_dir)
+            except Exception as e:
+                logger.warning("Import-staging cleanup failed (non-fatal): %s", e)
         # Retroactive configurable-mod scan: covers imports that predate the
         # configurable-detection logic. Cheap for mods whose source_path is
         # already a directory; rescues old ZIP-backed entries by extracting

--- a/tests/test_import_staging_cleanup.py
+++ b/tests/test_import_staging_cleanup.py
@@ -1,0 +1,44 @@
+"""GitHub #371 (SyDant): crashed or force-killed imports leave extracted
+archives under CDMods/_import_staging/ forever — 25+ GB accumulated.
+Startup now sweeps the folder (safe: single-instance .gui_lock held)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cdumm.engine.import_handler import cleanup_import_staging, get_cdmods_root
+
+
+def _staging(game_dir: Path) -> Path:
+    return get_cdmods_root(None, game_dir) / "_import_staging"
+
+
+def test_cleanup_removes_leftover_staging_dirs(tmp_path):
+    game = tmp_path / "game"
+    st = _staging(game)
+    (st / "deadbeef" / "nested").mkdir(parents=True)
+    (st / "deadbeef" / "nested" / "0.paz").write_bytes(b"x" * 4096)
+    (st / "cafebabe").mkdir()
+    (st / "cafebabe" / "mod.zip").write_bytes(b"y" * 1024)
+    (st / "loose.tmp").write_bytes(b"z" * 100)
+
+    freed = cleanup_import_staging(game)
+
+    assert freed == 4096 + 1024 + 100
+    assert st.is_dir()
+    assert list(st.iterdir()) == []
+
+
+def test_cleanup_noop_when_missing(tmp_path):
+    game = tmp_path / "game"
+    game.mkdir()
+    assert cleanup_import_staging(game) == 0
+
+
+def test_startup_calls_cleanup():
+    """Source-level check (repo convention): _deferred_startup wires the
+    sweep in."""
+    src = (Path(__file__).parent.parent / "src" / "cdumm" / "gui" /
+           "fluent_window.py").read_text(encoding="utf-8")
+    body = src.split("def _deferred_startup", 1)[1]
+    body = body.split("\n    def ", 1)[0]
+    assert "cleanup_import_staging" in body


### PR DESCRIPTION
Crashed or force-killed imports leave the extracted archive under `CDMods/_import_staging/<uuid>/` forever. SyDant accumulated 25+ GB this way (#371).

Startup (`_deferred_startup`) now deletes everything under `_import_staging/`. Safe because the single-instance `.gui_lock` is held at that point, so no import can be in flight. Logs MB freed; any failure is non-fatal.

3 new tests (sweep, no-op when absent, source-level wiring check).

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr