### PR TITLE
Fix #386: find and browse to the game when running under Wine/Proton

### DIFF
--- a/src/cdumm/gui/file_dialogs.py
+++ b/src/cdumm/gui/file_dialogs.py
@@ -1,0 +1,33 @@
+"""Directory picker that works under Wine/Proton.
+
+GitHub #386 (NonDScript, Bazzite): Wine's native folder dialog hides
+dot-folders and cannot be told to show them, so a Linux user browsing
+for the game under ``Z:/home/<user>/.local/share/Steam`` literally
+cannot enter ``.local``. When running under Wine we swap to Qt's own
+(non-native) dialog with hidden entries visible; on real Windows the
+native dialog is kept — it's the one users expect.
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QDir
+from PySide6.QtWidgets import QFileDialog, QWidget
+
+from cdumm.platform import is_wine
+
+
+def pick_directory(parent: QWidget | None, title: str,
+                   start_dir: str = "") -> str:
+    """Folder picker; returns the chosen path or "" on cancel."""
+    if not is_wine():
+        return QFileDialog.getExistingDirectory(parent, title, start_dir)
+
+    dlg = QFileDialog(parent, title, start_dir)
+    dlg.setFileMode(QFileDialog.FileMode.Directory)
+    dlg.setOption(QFileDialog.Option.ShowDirsOnly, True)
+    dlg.setOption(QFileDialog.Option.DontUseNativeDialog, True)
+    dlg.setFilter(dlg.filter() | QDir.Filter.Hidden)
+    if dlg.exec():
+        files = dlg.selectedFiles()
+        if files:
+            return files[0]
+    return ""

--- a/src/cdumm/gui/pages/settings_page.py
+++ b/src/cdumm/gui/pages/settings_page.py
@@ -989,7 +989,8 @@ class SettingsPage(SmoothScrollArea):
     def _on_game_dir_browse(self) -> None:
         """Open a folder browser to change the game directory."""
         current = str(self._game_dir) if self._game_dir else ""
-        new_dir = QFileDialog.getExistingDirectory(
+        from cdumm.gui.file_dialogs import pick_directory
+        new_dir = pick_directory(
             self.window(), tr("settings.game_dir_picker_title"), current)
         if not new_dir:
             return
@@ -1610,11 +1611,9 @@ class SettingsPage(SmoothScrollArea):
         except Exception:
             start_dir = ""
 
-        picked = QFileDialog.getExistingDirectory(
-            self,
-            tr("settings.cdmods_path_picker_title"),
-            start_dir,
-        )
+        from cdumm.gui.file_dialogs import pick_directory
+        picked = pick_directory(
+            self, tr("settings.cdmods_path_picker_title"), start_dir)
         if not picked:
             return  # user cancelled
         picked_path = Path(picked)

--- a/src/cdumm/gui/setup_dialog.py
+++ b/src/cdumm/gui/setup_dialog.py
@@ -117,7 +117,8 @@ class SetupDialog(MessageBoxBase):
             logger.info("Auto-detected game directory: %s", candidates[0])
 
     def _on_browse(self) -> None:
-        folder = QFileDialog.getExistingDirectory(self, tr("setup.browse_dialog_title"))
+        from cdumm.gui.file_dialogs import pick_directory
+        folder = pick_directory(self, tr("setup.browse_dialog_title"))
         if folder:
             self._path_edit.setText(folder)
 

--- a/src/cdumm/gui/welcome_wizard.py
+++ b/src/cdumm/gui/welcome_wizard.py
@@ -661,7 +661,8 @@ class WelcomeWizard(QDialog):
 
     def _on_browse(self):
         from cdumm.i18n import tr as _tr
-        folder = QFileDialog.getExistingDirectory(self, _tr("setup.browse_dialog_title"))
+        from cdumm.gui.file_dialogs import pick_directory
+        folder = pick_directory(self, _tr("setup.browse_dialog_title"))
         if folder:
             self._path_edit.setText(folder)
 

--- a/src/cdumm/platform.py
+++ b/src/cdumm/platform.py
@@ -186,3 +186,42 @@ def subprocess_no_window_kwargs() -> dict:
         return {}
     flag = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
     return {"creationflags": flag}
+
+
+_IS_WINE: bool | None = None
+
+
+def is_wine() -> bool:
+    """True when this Windows build is running under Wine / Proton.
+
+    Canonical check: Wine's ntdll exports ``wine_get_version``; real
+    Windows never does. Cached after the first call. Always False on
+    native macOS / Linux builds — those don't run inside a prefix.
+
+    Used to widen game auto-detection to the host filesystem (Proton
+    always maps ``Z:`` to ``/``, so the host's Steam libraries are
+    reachable as ``Z:/home/...``) and to swap file pickers to the Qt
+    dialog that can show hidden dot-folders (GitHub #386, NonDScript
+    on Bazzite: the native Wine picker cannot enter ``.local``).
+    """
+    global _IS_WINE
+    if _IS_WINE is None:
+        detected = False
+        if IS_WINDOWS:
+            try:
+                import ctypes
+                kernel32 = ctypes.windll.kernel32
+                kernel32.GetProcAddress.restype = ctypes.c_void_p
+                kernel32.GetProcAddress.argtypes = (
+                    ctypes.c_void_p, ctypes.c_char_p)
+                kernel32.GetModuleHandleW.restype = ctypes.c_void_p
+                ntdll = kernel32.GetModuleHandleW("ntdll.dll")
+                if ntdll:
+                    detected = bool(
+                        kernel32.GetProcAddress(ntdll, b"wine_get_version"))
+            except Exception as e:  # noqa: BLE001 - ctypes failure = not Wine
+                logger.debug("is_wine detection failed: %s", e)
+        _IS_WINE = detected
+        if detected:
+            logger.info("Running under Wine/Proton (wine_get_version present)")
+    return _IS_WINE

--- a/src/cdumm/storage/game_finder.py
+++ b/src/cdumm/storage/game_finder.py
@@ -125,6 +125,59 @@ def _drive_letters_for_scan() -> str:
     return "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 
+def _wine_host_steam_roots() -> list[Path]:
+    """Steam roots on the HOST filesystem when running under Wine/Proton.
+
+    GitHub #386 (NonDScript, Bazzite): CDUMM.exe run inside a Proton
+    prefix found nothing, because the Windows scan probes drive ROOTS
+    (``Z:/Steam``) and registry-era default paths — but the host's
+    Steam lives at ``/home/<user>/.local/share/Steam``. Proton always
+    symlinks ``dosdevices/z:`` to ``/`` (Proton source, setup_prefix),
+    so every host location is reachable under ``Z:/``. Probe the same
+    per-user locations the native Linux build uses, for every user
+    under ``Z:/home``.
+    """
+    from cdumm.platform import is_wine
+    if not is_wine():
+        return []
+    roots: list[Path] = []
+    rels = [
+        Path(".local/share/Steam"),
+        Path(".steam/steam"),
+        Path(".steam/root"),
+        Path(".var/app/com.valvesoftware.Steam/data/Steam"),
+        Path(".var/app/com.valvesoftware.Steam/.local/share/Steam"),
+        Path("snap/steam/common/.local/share/Steam"),
+    ]
+    home_base = Path("Z:/home")
+    try:
+        homes = [d for d in home_base.iterdir() if d.is_dir()]
+    except OSError:
+        homes = []
+    for home in homes:
+        for rel in rels:
+            p = home / rel
+            try:
+                if p.is_dir():
+                    roots.append(p)
+            except OSError:
+                continue
+    if roots:
+        logger.info("Wine: found host Steam roots via Z:: %s",
+                    [str(r) for r in roots])
+    return roots
+
+
+def _map_host_library_path(raw: Path) -> Path:
+    """Map a POSIX library path from a host libraryfolders.vdf (e.g.
+    ``/run/media/deck/SSD``) onto the Wine ``Z:`` drive. Paths that
+    already carry a drive letter pass through unchanged."""
+    s = str(raw).replace("\\", "/")  # WindowsPath renders '/x' as '\\x'
+    if s.startswith("/"):
+        return Path("Z:" + s)
+    return raw
+
+
 def _find_steam_root() -> Path | None:
     for p in STEAM_DEFAULT_PATHS:
         if p.exists():
@@ -563,6 +616,22 @@ def find_game_directories() -> list[Path]:
                 logger.info("Found Crimson Desert (Steam VDF) at %s", game_dir)
     else:
         logger.info("No Steam root found in default locations")
+
+    # Wine/Proton: also probe the HOST's Steam roots through Z:
+    # (GitHub #386 — the checks above only see Windows-side paths).
+    for wine_root in _wine_host_steam_roots():
+        wine_libs = [wine_root]
+        vdf = wine_root / LIBRARY_FOLDERS_VDF
+        if vdf.exists():
+            wine_libs.extend(
+                _map_host_library_path(p)
+                for p in _parse_library_folders(vdf))
+        for lib_dir in wine_libs:
+            game_dir = lib_dir / "steamapps" / "common" / "Crimson Desert"
+            if (game_dir / GAME_EXE).exists():
+                candidates.append(game_dir)
+                logger.info(
+                    "Found Crimson Desert (Wine host Steam) at %s", game_dir)
 
     # Steam detection — fallback: direct drive scan for common library
     # paths. Catches Steam libraries the primary install's VDF doesn't

--- a/tests/test_wine_host_steam_detection.py
+++ b/tests/test_wine_host_steam_detection.py
@@ -1,0 +1,61 @@
+"""GitHub #386 (NonDScript, Bazzite): CDUMM.exe running inside a Proton
+prefix never found the host's Steam install — the Windows scan probes
+drive roots (Z:/Steam) and Windows default paths, but host Steam lives
+at /home/<user>/.local/share/Steam, reachable only as Z:/home/... via
+Proton's always-created dosdevices/z: -> / symlink."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import cdumm.storage.game_finder as gf
+
+
+def _fake_z(tmp_path: Path, monkeypatch) -> Path:
+    """Redirect Path('Z:/home') to a temp tree."""
+    zhome = tmp_path / "zhome"
+    zhome.mkdir()
+    orig = gf.Path
+
+    def fake_path(*args):
+        if args and str(args[0]).replace("\\", "/").rstrip("/") == "Z:/home":
+            return zhome
+        return orig(*args)
+
+    monkeypatch.setattr(gf, "Path", fake_path)
+    return zhome
+
+
+def test_wine_host_steam_roots_probes_z_home(tmp_path, monkeypatch):
+    zhome = _fake_z(tmp_path, monkeypatch)
+    steam = zhome / "deck" / ".local" / "share" / "Steam"
+    steam.mkdir(parents=True)
+
+    with mock.patch("cdumm.platform.is_wine", return_value=True):
+        roots = gf._wine_host_steam_roots()
+    assert steam in roots
+
+
+def test_wine_host_steam_roots_empty_when_not_wine(tmp_path, monkeypatch):
+    zhome = _fake_z(tmp_path, monkeypatch)
+    (zhome / "deck" / ".local" / "share" / "Steam").mkdir(parents=True)
+    with mock.patch("cdumm.platform.is_wine", return_value=False):
+        assert gf._wine_host_steam_roots() == []
+
+
+def test_map_host_library_path():
+    assert gf._map_host_library_path(Path("/run/media/deck/SSD")) == Path(
+        "Z:/run/media/deck/SSD")
+    win = Path("D:/SteamLibrary")
+    assert gf._map_host_library_path(win) == win
+
+
+def test_pickers_use_wine_aware_dialog():
+    """Source-level check (repo convention): every game/CDMods folder
+    picker goes through pick_directory, not the native-only static."""
+    base = Path(__file__).parent.parent / "src" / "cdumm" / "gui"
+    for rel in ("setup_dialog.py", "welcome_wizard.py",
+                "pages/settings_page.py"):
+        src = (base / rel).read_text(encoding="utf-8")
+        assert "pick_directory" in src, rel
+        assert "QFileDialog.getExistingDirectory" not in src, rel


### PR DESCRIPTION
Two faults for Linux users running CDUMM.exe inside a Proton/Wine prefix (reported on Bazzite):

1. **Auto-detect never looked at the host filesystem.** The Windows scan probes Windows default paths and drive roots (`Z:/Steam`), but host Steam lives at `/home/<user>/.local/share/Steam`. Proton always symlinks `dosdevices/z:` to `/` (verified in Proton's `setup_prefix`), so every host path is reachable as `Z:/...` — CDUMM just never probed there.
2. **Manual browse could not reach the game either.** Wine's native folder dialog hides dot-folders unconditionally, so the picker cannot enter `.local`.

Fix:
- `platform.is_wine()` — canonical Wine detection via the `wine_get_version` ntdll export (never present on real Windows), cached
- Under Wine, auto-detect additionally probes `Z:/home/*/` for every Linux Steam location CDUMM's native Linux build already knows (native, `.steam` symlinks, Flatpak, Snap) and parses each root's `libraryfolders.vdf`, mapping POSIX library paths (e.g. `/run/media/deck/SSD`) onto `Z:`
- New `gui/file_dialogs.pick_directory()` — under Wine uses Qt's non-native dialog with hidden entries visible; real Windows keeps the native dialog. All four folder pickers (setup dialog, welcome wizard, settings game-dir, settings CDMods-path) switched to it

Tests: 4 new (Z:/home probing, not-wine no-op, POSIX->Z: mapping, source-level picker check). Full suite 3090 passed, 1 known machine-local failure.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr