### PR TITLE
bug report: stop flagging 'running as administrator' under Wine

### DIFF
--- a/src/cdumm/gui/bug_report.py
+++ b/src/cdumm/gui/bug_report.py
@@ -563,11 +563,24 @@ def generate_bug_report(db: Database | None, game_dir: Path | None,
     body.append(f"Python: {_short_python_version()} "
                  f"({'frozen' if frozen else 'source'})")
     admin_state = _is_admin_windows()
+    from cdumm.platform import is_wine
+    under_wine = is_wine()
+    if under_wine:
+        body.append("Environment: Wine/Proton prefix")
     body.append(f"Running as administrator: {admin_state}")
     if admin_state == "yes":
-        tldr_flags.append(
-            "CDUMM is running as administrator — drag-drop and mod install "
-            "will often fail. Close CDUMM and relaunch WITHOUT 'Run as admin'.")
+        if under_wine:
+            # Wine prefixes always report the user as administrator and
+            # UAC does not exist there, so the drag-drop/install failure
+            # modes the flag warns about don't apply (GitHub #388,
+            # NonDScript's report led with this false alarm).
+            body.append(
+                "  (Wine artifact — the prefix user always reports as "
+                "admin; not a real problem)")
+        else:
+            tldr_flags.append(
+                "CDUMM is running as administrator — drag-drop and mod install "
+                "will often fail. Close CDUMM and relaunch WITHOUT 'Run as admin'.")
     elif admin_state == "no":
         tldr_ok.append("Not running as admin (good)")
 

--- a/tests/test_bug_report_wine_admin.py
+++ b/tests/test_bug_report_wine_admin.py
@@ -1,0 +1,18 @@
+"""GitHub #388 (NonDScript): Wine prefixes always run programs with the
+admin token, so the bug report's 'running as administrator' TL;DR flag
+is a false alarm on every Wine/Proton setup. Under Wine the report now
+labels it a Wine artifact instead of leading with bogus advice."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_admin_flag_suppressed_under_wine():
+    src = (Path(__file__).parent.parent / "src" / "cdumm" / "gui" /
+           "bug_report.py").read_text(encoding="utf-8")
+    assert "under_wine = is_wine()" in src
+    # The admin TL;DR flag must be gated on NOT running under Wine.
+    flag_pos = src.index("CDUMM is running as administrator")
+    gate_pos = src.index("if under_wine:")
+    assert gate_pos < flag_pos
+    assert "Wine artifact" in src


### PR DESCRIPTION
Wine runs Windows programs with the admin token by default (`IsUserAnAdmin` returns TRUE for the prefix user), so every Wine/Proton bug report led with the 'running as administrator' TL;DR flag and its relaunch-without-admin advice — wrong and unactionable there. Seen at the top of NonDScript's #388 report.

Under Wine the report now:
- adds an explicit `Environment: Wine/Proton prefix` line
- labels the admin state a Wine artifact instead of raising the TL;DR flag

Real Windows behavior unchanged. Uses the `is_wine()` helper from #387.

Refs #388 (report noise only — the crash itself is still under investigation with the reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr