### PR TITLE
fix(gui): RescanPage never learns when its own rescan finishes

### DIFF
--- a/src/cdumm/gui/pages/tool_page.py
+++ b/src/cdumm/gui/pages/tool_page.py
@@ -11,7 +11,7 @@ import math
 import os
 from pathlib import Path
 
-from PySide6.QtCore import QEasingCurve, QThread, Qt, Signal, Slot
+from PySide6.QtCore import QEasingCurve, QThread, QTimer, Qt, Signal, Slot
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import (
     QFileDialog,
@@ -2072,6 +2072,11 @@ class RescanPage(ToolPageBase):
         self._run_btn.setEnabled(False)
         self._run_btn.setToolTip(tr("tools.rescan.enable_hint"))
 
+        # See _start_completion_poll: this page hands the actual work
+        # off to the main window (it owns the SnapshotWorker QProcess)
+        # and has no direct callback for when that work finishes.
+        self._rescan_poll_timer: QTimer | None = None
+
     def set_managers(self, **kwargs) -> None:
         super().set_managers(**kwargs)
         self._refresh_stats()
@@ -2109,6 +2114,7 @@ class RescanPage(ToolPageBase):
             return
 
         self._clear_results()
+        self._set_running(True)
         self._set_status(tr("tools.rescan.initiating"))
         self._add_result_card(
             tr("tools.rescan.requested"),
@@ -2117,3 +2123,38 @@ class RescanPage(ToolPageBase):
 
         # Signal parent to do the actual rescan
         self.rescan_requested.emit(True)
+        self._start_completion_poll()
+
+    def _start_completion_poll(self) -> None:
+        """This page only emits ``rescan_requested`` -- the actual
+        SnapshotWorker QProcess is owned and run by the main window,
+        so there's no direct callback here for when that work
+        finishes. Poll the main window's busy flag instead, the same
+        technique RecoveryFlow already uses to track the same
+        QProcess (see recovery_flow.py's ``_main_window_active_worker``).
+
+        Without this the page was stuck showing "Initiating rescan..."
+        forever even after the snapshot genuinely completed (the
+        success toast fired and the snapshot was real) -- report
+        2026-08-26, the run button never re-enabled and the status
+        text never updated because this page never learned the work
+        was done.
+        """
+        if self._rescan_poll_timer is not None:
+            self._rescan_poll_timer.stop()
+        timer = QTimer(self)
+        timer.setInterval(500)
+        timer.timeout.connect(self._check_rescan_poll)
+        self._rescan_poll_timer = timer
+        timer.start()
+
+    def _check_rescan_poll(self) -> None:
+        worker = getattr(self.window(), "_active_worker", None)
+        if worker is not None:
+            return
+        if self._rescan_poll_timer is not None:
+            self._rescan_poll_timer.stop()
+            self._rescan_poll_timer = None
+        self._refresh_stats()
+        self._set_running(False)
+        self._set_status(tr("tools.rescan.complete"), "#A3BE8C")

--- a/src/cdumm/translations/ar.json
+++ b/src/cdumm/translations/ar.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "تم طلب إعادة المسح",
   "tools.rescan.requested_desc": "تم بدء تحديث اللقطة. قد يستغرق هذا لحظة حسب حجم ملفات اللعبة.",
   "tools.rescan.enable_hint": "حدد المربع أعلاه للتفعيل",
+  "tools.rescan.complete": "اكتملت إعادة المسح!",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/src/cdumm/translations/de.json
+++ b/src/cdumm/translations/de.json
@@ -774,6 +774,7 @@
   "tools.rescan.requested": "Scan angefordert",
   "tools.rescan.requested_desc": "Der Snapshot wird aktualisiert. Das kann je nach Dateigröße etwas dauern.",
   "tools.rescan.enable_hint": "Oben aktivieren, um fortzufahren",
+  "tools.rescan.complete": "Scan abgeschlossen!",
   "tools.stat.never": "Nie",
   "tools.error": "Fehler: {detail}",
   "tools.progress.checking": "Prüfe {name}...",

--- a/src/cdumm/translations/en.json
+++ b/src/cdumm/translations/en.json
@@ -774,6 +774,7 @@
   "tools.rescan.requested": "Rescan Requested",
   "tools.rescan.requested_desc": "The snapshot refresh has been initiated. This may take a moment depending on game file sizes.",
   "tools.rescan.enable_hint": "Check the box above to enable",
+  "tools.rescan.complete": "Rescan complete!",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/src/cdumm/translations/es.json
+++ b/src/cdumm/translations/es.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "Reescaneo Solicitado",
   "tools.rescan.requested_desc": "La actualización del snapshot ha sido iniciada. Puede tardar un momento según el tamaño de los archivos del juego.",
   "tools.rescan.enable_hint": "Marca la casilla de arriba para activar",
+  "tools.rescan.complete": "¡Reescaneo completo!",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/src/cdumm/translations/fr.json
+++ b/src/cdumm/translations/fr.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "Rebalayage Demandé",
   "tools.rescan.requested_desc": "L'actualisation du snapshot a été lancée. Cela peut prendre un moment selon la taille des fichiers du jeu.",
   "tools.rescan.enable_hint": "Cochez la case ci-dessus pour activer",
+  "tools.rescan.complete": "Rebalayage terminé !",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/src/cdumm/translations/id.json
+++ b/src/cdumm/translations/id.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Pemindaian Ulang Diminta",
   "tools.rescan.requested_desc": "Penyegaran snapshot telah dimulai. Ini mungkin memerlukan waktu tergantung ukuran berkas game.",
   "tools.rescan.enable_hint": "Centang kotak di atas untuk mengaktifkan",
+  "tools.rescan.complete": "Pemindaian ulang selesai!",
   "tools.stat.never": "Belum Pernah",
   "tools.error": "Galat: {detail}",
   "tools.progress.checking": "Memeriksa {name}...",

--- a/src/cdumm/translations/it.json
+++ b/src/cdumm/translations/it.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Riscansione richiesta",
   "tools.rescan.requested_desc": "L'aggiornamento dello snapshot è stato avviato. Potrebbe richiedere un momento a seconda della dimensione dei file di gioco.",
   "tools.rescan.enable_hint": "Seleziona la casella sopra per abilitare",
+  "tools.rescan.complete": "Riscansione completata!",
   "tools.stat.never": "Mai",
   "tools.error": "Errore: {detail}",
   "tools.progress.checking": "Verifica di {name}...",

--- a/src/cdumm/translations/ja.json
+++ b/src/cdumm/translations/ja.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "再スキャンをリクエストしました",
   "tools.rescan.requested_desc": "スナップショットの更新を開始しました。ゲームファイルのサイズによっては時間がかかる場合があります。",
   "tools.rescan.enable_hint": "上のチェックボックスをオンにしてください",
+  "tools.rescan.complete": "再スキャン完了！",
   "tools.stat.never": "なし",
   "tools.error": "エラー：{detail}",
   "tools.progress.checking": "{name} を確認中...",

--- a/src/cdumm/translations/ko.json
+++ b/src/cdumm/translations/ko.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "재스캔 요청됨",
   "tools.rescan.requested_desc": "스냅샷 새로고침이 시작되었습니다. 게임 파일 크기에 따라 시간이 걸릴 수 있습니다.",
   "tools.rescan.enable_hint": "위의 체크박스를 선택하세요",
+  "tools.rescan.complete": "재스캔 완료!",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/src/cdumm/translations/pl.json
+++ b/src/cdumm/translations/pl.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Żądanie ponownego skanowania",
   "tools.rescan.requested_desc": "Odświeżenie migawki zostało zainicjowane. Może to chwilę potrwać w zależności od rozmiaru plików gry.",
   "tools.rescan.enable_hint": "Zaznacz pole powyżej, aby włączyć",
+  "tools.rescan.complete": "Ponowne skanowanie zakończone!",
   "tools.stat.never": "Nigdy",
   "tools.error": "Błąd: {detail}",
   "tools.progress.checking": "Sprawdzanie {name}...",

--- a/src/cdumm/translations/pt-BR.json
+++ b/src/cdumm/translations/pt-BR.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "Reescaneamento Solicitado",
   "tools.rescan.requested_desc": "A atualização do snapshot foi iniciada. Pode demorar um momento dependendo do tamanho dos arquivos do jogo.",
   "tools.rescan.enable_hint": "Marque a caixa acima para ativar",
+  "tools.rescan.complete": "Reescaneamento completo!",
   "tools.stat.never": "Nunca",
   "tools.error": "Erro: {detail}",
   "tools.progress.checking": "Verificando {name}...",

--- a/src/cdumm/translations/ru.json
+++ b/src/cdumm/translations/ru.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Пересканирование запрошено",
   "tools.rescan.requested_desc": "Обновление снимка запущено. Это может занять некоторое время в зависимости от размера файлов игры.",
   "tools.rescan.enable_hint": "Установите флажок выше для включения",
+  "tools.rescan.complete": "Пересканирование завершено!",
   "tools.stat.never": "Никогда",
   "tools.error": "Ошибка: {detail}",
   "tools.progress.checking": "Проверка {name}...",

--- a/src/cdumm/translations/tr.json
+++ b/src/cdumm/translations/tr.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Yeniden Tarama İstendi",
   "tools.rescan.requested_desc": "Anlık görüntü yenilemesi başlatıldı. Oyun dosya boyutlarına bağlı olarak biraz zaman alabilir.",
   "tools.rescan.enable_hint": "Etkinleştirmek için yukarıdaki kutuyu işaretleyin",
+  "tools.rescan.complete": "Yeniden tarama tamamlandı!",
   "tools.stat.never": "Hiçbir zaman",
   "tools.error": "Hata: {detail}",
   "tools.progress.checking": "{name} kontrol ediliyor...",

--- a/src/cdumm/translations/uk.json
+++ b/src/cdumm/translations/uk.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "Пересканування запитано",
   "tools.rescan.requested_desc": "Оновлення знімка розпочато. Це може зайняти деякий час залежно від розміру файлів гри.",
   "tools.rescan.enable_hint": "Поставте прапорець вище для увімкнення",
+  "tools.rescan.complete": "Пересканування завершено!",
   "tools.stat.never": "Ніколи",
   "tools.error": "Помилка: {detail}",
   "tools.progress.checking": "Перевірка {name}...",

--- a/src/cdumm/translations/zh-CN.json
+++ b/src/cdumm/translations/zh-CN.json
@@ -662,6 +662,7 @@
   "tools.rescan.requested": "已请求重新扫描",
   "tools.rescan.requested_desc": "快照刷新已启动。这可能需要一些时间，具体取决于游戏文件大小。",
   "tools.rescan.enable_hint": "勾选上方复选框以启用",
+  "tools.rescan.complete": "重新扫描完成！",
   "tools.stat.never": "从未",
   "tools.error": "错误：{detail}",
   "tools.progress.checking": "正在检查 {name}...",

--- a/src/cdumm/translations/zh-TW.json
+++ b/src/cdumm/translations/zh-TW.json
@@ -657,6 +657,7 @@
   "tools.rescan.requested": "已請求重新掃描",
   "tools.rescan.requested_desc": "快照更新已啟動。根據遊戲檔案大小，可能需要一點時間。",
   "tools.rescan.enable_hint": "勾選上方核取方塊以啟用",
+  "tools.rescan.complete": "重新掃描完成！",
   "tools.stat.never": "Never",
   "tools.error": "Error: {detail}",
   "tools.progress.checking": "Checking {name}...",

--- a/tests/test_rescan_page_completion.py
+++ b/tests/test_rescan_page_completion.py
@@ -1,0 +1,98 @@
+"""RescanPage never learned when its own rescan actually finished.
+
+Report 2026-08-26: after updating and running Rescan, the snapshot
+genuinely completed (the "Snapshot Complete" toast fired, twice --
+the user re-clicked because the page looked stuck), but the Rescan
+page itself stayed on "Initiating rescan..." forever and its stat
+cards (file count, last scan date) never refreshed.
+
+Root cause: RescanPage only emits ``rescan_requested`` into the main
+window, which owns the actual SnapshotWorker QProcess. Every other
+tool page on this base class runs its own worker and calls
+``_set_running(False)`` when it completes; RescanPage never did,
+so ``_set_running(True)`` was never called either -- the Rescan
+button stayed enabled the whole time, which is how the user's
+"looks frozen" click landed a second, real rescan instead of being a
+no-op.
+
+Fix: RescanPage now calls `_set_running(True)` before emitting the
+signal, and polls the main window's `_active_worker` (the same
+technique RecoveryFlow already uses to track the same QProcess) to
+detect completion, then refreshes its stat cards and resets its own
+status/button.
+
+No qtbot in this environment (see test_rescan_blocks_modded_disk.py's
+own "Wiring guard" section for the same constraint), so this is a
+source-text guard rather than a widget-level test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _tool_page_src() -> str:
+    return (Path(__file__).resolve().parents[1]
+            / "src" / "cdumm" / "gui" / "pages" / "tool_page.py").read_text(
+                encoding="utf-8")
+
+
+def _rescan_page_body(src: str) -> str:
+    anchor = src.find("class RescanPage(")
+    assert anchor != -1, "RescanPage class not found"
+    next_class = src.find("\nclass ", anchor + 10)
+    return src[anchor:next_class if next_class != -1 else len(src)]
+
+
+def test_on_run_clicked_disables_the_button_before_delegating():
+    """Without _set_running(True), the button stays clickable for the
+    whole (possibly long) rescan, which is how the user ended up
+    triggering it twice."""
+    body = _rescan_page_body(_tool_page_src())
+    clicked_anchor = body.find("def _on_run_clicked")
+    assert clicked_anchor != -1
+    next_def = body.find("\n    def ", clicked_anchor + 20)
+    clicked_body = body[clicked_anchor:next_def if next_def != -1 else clicked_anchor + 2000]
+    set_running_idx = clicked_body.find("_set_running(True)")
+    emit_idx = clicked_body.find("rescan_requested.emit")
+    assert set_running_idx != -1, (
+        "_on_run_clicked must call _set_running(True) so the button "
+        "disables and Rescan can't be double-triggered")
+    assert emit_idx != -1
+    assert set_running_idx < emit_idx, (
+        "_set_running(True) must run before the signal is emitted")
+
+
+def test_completion_poll_checks_the_main_window_worker():
+    body = _rescan_page_body(_tool_page_src())
+    assert "_start_completion_poll" in body
+    assert "_check_rescan_poll" in body
+    assert '"_active_worker"' in body, (
+        "completion poll must check the main window's _active_worker, "
+        "the same flag RecoveryFlow polls for this exact QProcess")
+
+
+def test_completion_poll_resets_status_and_refreshes_stats():
+    body = _rescan_page_body(_tool_page_src())
+    poll_anchor = body.find("def _check_rescan_poll")
+    assert poll_anchor != -1
+    next_def = body.find("\n    def ", poll_anchor + 20)
+    poll_body = body[poll_anchor:next_def if next_def != -1 else poll_anchor + 1000]
+    assert "_refresh_stats()" in poll_body, (
+        "must refresh the file-count/last-scan stat cards, not just "
+        "the status label")
+    assert "_set_running(False)" in poll_body
+    assert "tools.rescan.complete" in poll_body
+
+
+def test_complete_translation_key_exists_in_every_locale():
+    import json
+    translations_dir = (Path(__file__).resolve().parents[1]
+                        / "src" / "cdumm" / "translations")
+    locale_files = sorted(translations_dir.glob("*.json"))
+    assert len(locale_files) >= 15, "sanity check: expected the full locale set"
+    missing = []
+    for f in locale_files:
+        data = json.loads(f.read_text(encoding="utf-8"))
+        if "tools.rescan.complete" not in data:
+            missing.append(f.name)
+    assert not missing, f"tools.rescan.complete missing from: {missing}"


### PR DESCRIPTION
Fixes the Rescan page staying on "Initiating rescan..." forever, with the button never re-enabling, even after the snapshot genuinely completed (the success toast fires correctly, but the page itself never learns).

The page only emits a signal into the main window, which owns the actual snapshot worker, and had no path back to report completion, so the button also never got disabled up front, which is how a user who thought it was frozen ended up triggering a second real rescan by clicking again.

It now disables itself immediately and polls the main window's worker flag, the same technique already used elsewhere for this exact process, to learn when the work is done and refresh its own status and stat cards.