### PR TITLE
fix(gui): post-apply verify false-positives on CD 2.0's optional PAPGT entries

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -170,6 +170,7 @@ def _compute_post_apply_issues(game_dir, conn) -> list[tuple[str, str]]:
     import struct
 
     from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
+    from cdumm.archive.papgt_manager import decode_papgt_entry_flags
     from cdumm.engine.cdmods_paths import get_cdmods_root
 
     issues: list[tuple[str, str]] = []
@@ -192,6 +193,7 @@ def _compute_post_apply_issues(game_dir, conn) -> list[tuple[str, str]]:
             str_table_off = entry_start + entry_count * 12 + 4
             for i in range(entry_count):
                 pos = entry_start + i * 12
+                flags = struct.unpack_from('<I', data, pos)[0]
                 name_off = struct.unpack_from('<I', data, pos + 4)[0]
                 papgt_hash = struct.unpack_from('<I', data, pos + 8)[0]
                 abs_off = str_table_off + name_off
@@ -204,7 +206,17 @@ def _compute_post_apply_issues(game_dir, conn) -> list[tuple[str, str]]:
                         if actual != papgt_hash:
                             issues.append(("PAPGT", f"{dir_name} PAMT hash mismatch"))
                     elif not (game_dir / dir_name).exists():
-                        # Skip vanilla placeholder dirs (< 0036) that don't exist on disk
+                        # GitHub #390: CD 2.0 ships reserved/optional
+                        # placeholder entries (0036-0040 -- language-pack
+                        # slots) that have no folder on disk by design.
+                        # The entry's own is_optional flag is the real,
+                        # version-independent signal for that -- not a
+                        # hardcoded dir-number range, which is exactly
+                        # what false-positived here after #384 taught
+                        # the rest of CDUMM to leave these entries alone.
+                        is_optional, _lang_type, _zero = decode_papgt_entry_flags(flags)
+                        if is_optional:
+                            continue
                         _owners = dir_owners.get(dir_name)
                         _src = ", ".join(sorted(_owners)) if _owners else "PAPGT"
                         try:

--- a/tests/test_post_apply_verify_worker.py
+++ b/tests/test_post_apply_verify_worker.py
@@ -19,8 +19,12 @@ from pathlib import Path
 from cdumm.archive.hashlittle import compute_pamt_hash, compute_papgt_hash
 
 
-def _build_papgt(entries: list[tuple[str, int]]) -> bytes:
-    """entries: list of (dir_name, pamt_hash)."""
+def _build_papgt(entries: list[tuple[str, int]],
+                  flags_by_dir: dict[str, int] | None = None) -> bytes:
+    """entries: list of (dir_name, pamt_hash). ``flags_by_dir`` overrides
+    the default non-optional flags word for specific dir names (e.g.
+    ``{"0037": 0x00010001}`` for an is_optional=1 placeholder)."""
+    flags_by_dir = flags_by_dir or {}
     names = [e[0].encode("ascii") + b"\x00" for e in entries]
     string_table = b"".join(names)
     name_offsets = []
@@ -31,7 +35,8 @@ def _build_papgt(entries: list[tuple[str, int]]) -> bytes:
 
     body = bytearray()
     for (dir_name, pamt_hash), name_off in zip(entries, name_offsets):
-        body += struct.pack("<III", 0x003FFF00, name_off, pamt_hash)
+        flags = flags_by_dir.get(dir_name, 0x003FFF00)
+        body += struct.pack("<III", flags, name_off, pamt_hash)
     body += struct.pack("<I", len(string_table))
     body += string_table
 
@@ -70,6 +75,41 @@ def test_pamt_hash_mismatch_is_reported(tmp_path, db):
     game_dir = _setup_game_dir(tmp_path, corrupt=True)
     issues = _compute_post_apply_issues(game_dir, db.connection)
     assert any("PAMT hash mismatch" in detail for _src, detail in issues)
+
+
+# ── GitHub #390: CD 2.0's reserved placeholder entries ─────────────────
+
+def test_optional_placeholder_missing_dir_is_not_flagged(tmp_path, db):
+    """CD 2.0 ships reserved language-pack placeholder entries
+    (0036-0040) that legitimately have no folder on disk -- is_optional=1
+    in their own PAPGT flags is the real signal for that, confirmed
+    against the live install (all five: is_optional=1, no dir on disk).
+    Report 2026-08-28 (#390): every apply was flagging all five as
+    "Missing directory", warning the game "may crash" over nothing."""
+    from cdumm.gui.fluent_window import _compute_post_apply_issues
+
+    game_dir = tmp_path / "game"
+    (game_dir / "meta").mkdir(parents=True)
+    is_optional_flags = 0x00010001  # is_optional=1, matches a live entry
+    papgt = _build_papgt([("0037", 0)], flags_by_dir={"0037": is_optional_flags})
+    (game_dir / "meta" / "0.papgt").write_bytes(papgt)
+
+    assert _compute_post_apply_issues(game_dir, db.connection) == []
+
+
+def test_non_optional_missing_mod_dir_is_still_flagged(tmp_path, db):
+    """The original protection must survive: a real mod directory
+    (is_optional=0) that PAPGT references but that doesn't exist on
+    disk is genuine corruption, not a placeholder."""
+    from cdumm.gui.fluent_window import _compute_post_apply_issues
+
+    game_dir = tmp_path / "game"
+    (game_dir / "meta").mkdir(parents=True)
+    papgt = _build_papgt([("0037", 0)])  # default flags: is_optional=0
+    (game_dir / "meta" / "0.papgt").write_bytes(papgt)
+
+    issues = _compute_post_apply_issues(game_dir, db.connection)
+    assert any("Missing directory 0037" in detail for _src, detail in issues)
 
 
 # ── PAMT hash cache ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #390. Post-apply verification flagged five directories as missing on every 2.0 apply, warning the game 'may crash', even on a fully clean install.

Those five PAPGT entries (0036-0040) are reserved language-pack placeholder slots that 2.0 ships with no folder on disk by design, #384 already taught the rest of CDUMM to leave them alone, but this specific check still used the old 'any dir number 36 or above without a folder is missing' rule and never learned about them.

It now reads the entry's own is_optional flag, the same signal #384 uses, instead of inferring it from the directory number, so it won't need another fix the next time the game adds more reserved slots.