### PR TITLE
Fix #395: stop deleting Steam language packs (2.0 optional slots 0036-0040)

### DIFF
--- a/src/cdumm/archive/papgt_manager.py
+++ b/src/cdumm/archive/papgt_manager.py
@@ -114,6 +114,47 @@ def reserved_papgt_dir_numbers(game_dir: Path,
     return reserved
 
 
+def language_pack_dirs(game_dir: Path,
+                       vanilla_dir: "Path | None" = None) -> "set[str]":
+    """Numbered directories on disk that hold Steam-delivered OPTIONAL
+    content, not mod content.
+
+    Crimson Desert 2.0 ("Enhanced") added voice packs for German, French,
+    Spanish, Brazilian Portuguese and Japanese. Steam downloads the
+    selected pack into one of the five reserved slots 0036-0040 -- the
+    PAPGT entries flagged ``is_optional=1`` with a single language bit.
+    Every "0036+ means a mod put it there" rule in CDUMM therefore has
+    to exempt these, or a rescan / health check deletes the user's
+    language pack and the game silently drops back to English (Nexus,
+    Dante1963, 27 Aug 2026).
+
+    A directory qualifies when it exists on disk, the live (or vanilla)
+    PAPGT lists it as optional, and it carries no
+    ``_cdumm_overlay.marker`` -- a CDUMM overlay that squatted one of
+    these slots (pre-3.16.1) is still CDUMM's to clean up.
+    """
+    optional: set[str] = set()
+    for papgt in (game_dir / "meta" / "0.papgt",
+                  (vanilla_dir / "meta" / "0.papgt") if vanilla_dir else None):
+        if papgt is None:
+            continue
+        for name, flags, _h in (read_papgt_entries(papgt) or []):
+            if not (name.isdigit() and len(name) == 4):
+                continue
+            is_optional, _lang, _zero = decode_papgt_entry_flags(flags)
+            if is_optional:
+                optional.add(name)
+    out: set[str] = set()
+    for name in optional:
+        d = game_dir / name
+        try:
+            if d.is_dir() and not (d / "_cdumm_overlay.marker").exists():
+                out.add(name)
+        except OSError:
+            continue
+    return out
+
+
 class PapgtManager:
     """Manages PAPGT rebuild from scratch."""
 

--- a/src/cdumm/engine/snapshot_manager.py
+++ b/src/cdumm/engine/snapshot_manager.py
@@ -467,9 +467,21 @@ class SnapshotWorker(QObject):
         """
         problems = []
 
-        # 1. Check for mod-created directories (0036+)
+        # 1. Check for mod-created directories (0036+). Steam-delivered
+        # language packs (2.0's optional voice packs, slots 0036-0040,
+        # flagged optional in the PAPGT) are NOT mod dirs and must
+        # survive: this check feeds an rmtree in _create_snapshot, and
+        # it was deleting users' installed languages (Nexus, Dante1963).
+        # They are snapshotted like any vanilla dir instead.
+        from cdumm.archive.papgt_manager import language_pack_dirs
+        lang_dirs = language_pack_dirs(self._game_dir)
+        if lang_dirs:
+            logger.info("Pre-snapshot: keeping Steam language-pack dir(s) %s",
+                        sorted(lang_dirs))
         for d in sorted(self._game_dir.iterdir()):
             if not d.is_dir() or not d.name.isdigit() or len(d.name) != 4:
+                continue
+            if d.name in lang_dirs:
                 continue
             if int(d.name) >= 36:
                 files = list(d.iterdir())

--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -1994,6 +1994,11 @@ class CdummWindow(FluentWindow):
             if not snap:
                 return
             actual_size = papgt_path.stat().st_size
+            # Steam language packs live in the optional 0036-0040
+            # slots and are not in an older snapshot; they are not
+            # orphans and must never be deleted here (Nexus, Dante1963).
+            from cdumm.archive.papgt_manager import language_pack_dirs
+            _lang_dirs = language_pack_dirs(self._game_dir, self._vanilla_dir)
             if actual_size == snap[0]:
                 has_orphans = False
                 for d in self._game_dir.iterdir():
@@ -2002,6 +2007,7 @@ class CdummWindow(FluentWindow):
                         and d.name.isdigit()
                         and len(d.name) == 4
                         and int(d.name) >= 36
+                        and d.name not in _lang_dirs
                     ):
                         orphan_check = self._db.connection.execute(
                             "SELECT COUNT(*) FROM snapshots WHERE file_path LIKE ?",
@@ -2019,7 +2025,7 @@ class CdummWindow(FluentWindow):
             for d in sorted(self._game_dir.iterdir()):
                 if not d.is_dir() or not d.name.isdigit() or len(d.name) != 4:
                     continue
-                if int(d.name) < 36:
+                if int(d.name) < 36 or d.name in _lang_dirs:
                     continue
                 orphan_check = self._db.connection.execute(
                     "SELECT COUNT(*) FROM snapshots WHERE file_path LIKE ?",

--- a/src/cdumm/worker_process.py
+++ b/src/cdumm/worker_process.py
@@ -592,9 +592,13 @@ def _run_verify(game_dir: str, db_path: str) -> None:
             else:
                 results["vanilla"].append(file_path)
 
-    # Check for extra directories (>= 0036)
+    # Check for extra directories (>= 0036). Steam language packs occupy
+    # the optional 0036-0040 slots on 2.0 and are vanilla, not extra.
+    from cdumm.archive.papgt_manager import language_pack_dirs
+    _lang_dirs = language_pack_dirs(game_dir)
     for item in sorted(game_dir.iterdir()):
-        if item.is_dir() and item.name.isdigit() and int(item.name) >= 36:
+        if (item.is_dir() and item.name.isdigit() and int(item.name) >= 36
+                and item.name not in _lang_dirs):
             results["extra_dirs"].append(item.name)
 
     db.close()

--- a/tests/test_language_pack_dirs_survive.py
+++ b/tests/test_language_pack_dirs_survive.py
@@ -1,0 +1,96 @@
+"""Crimson Desert 2.0 ("Enhanced") ships five optional voice packs
+(German, French, Spanish, Brazilian Portuguese, Japanese). Steam
+downloads the selected one into a reserved slot 0036-0040 -- the PAPGT
+entries flagged is_optional=1. Every "0036+ is a mod dir" rule in CDUMM
+therefore has to exempt these, or a rescan / health check deletes the
+user's language and the game drops back to English (Nexus, Dante1963,
+27 Aug 2026: "no longer have access to the new languages").
+
+Covers: the language_pack_dirs helper, the pre-snapshot check (which
+feeds an rmtree), and the two other consumers at source level.
+"""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from cdumm.archive.papgt_manager import language_pack_dirs
+from cdumm.engine.snapshot_manager import SnapshotWorker
+
+_OPTIONAL_FR = 0x00010001   # is_optional=1, single language bit (live 0037)
+_VANILLA = 0x007FFF00
+
+
+def _build_papgt(entries: list[tuple[str, int]]) -> bytes:
+    st = bytearray(); offs = []
+    for n, _f in entries:
+        offs.append(len(st)); st += n.encode() + b"\x00"
+    body = bytearray()
+    for (n, f), o in zip(entries, offs):
+        body += struct.pack("<III", f, o, 0)
+    body += struct.pack("<I", len(st)) + st
+    return bytes(b"\x01\x02\x03\x04" + b"\x00" * 4 + bytes([len(entries), 0xFF, 0xFF, 0xFF]) + body)
+
+
+def _game(tmp_path: Path) -> Path:
+    g = tmp_path / "game"
+    (g / "meta").mkdir(parents=True)
+    (g / "meta" / "0.papgt").write_bytes(_build_papgt(
+        [("0000", _VANILLA), ("0035", _VANILLA),
+         ("0036", 0x00008001), ("0037", _OPTIONAL_FR), ("0038", 0x00000401)]))
+    for n in ("0000", "0035"):
+        (g / n).mkdir(); (g / n / "0.pamt").write_bytes(b"\x00" * 16)
+    # French voice pack downloaded by Steam into its reserved slot
+    (g / "0037").mkdir(); (g / "0037" / "0.pamt").write_bytes(b"\x00" * 16)
+    (g / "0037" / "0.paz").write_bytes(b"\x00" * 64)
+    return g
+
+
+def test_helper_recognises_steam_language_pack(tmp_path):
+    g = _game(tmp_path)
+    assert language_pack_dirs(g) == {"0037"}
+
+
+def test_helper_ignores_dangling_optional_slots(tmp_path):
+    g = _game(tmp_path)
+    # 0036 / 0038 are optional in the PAPGT but not on disk
+    assert "0036" not in language_pack_dirs(g)
+
+
+def test_helper_excludes_cdumm_overlay_squatting_a_slot(tmp_path):
+    g = _game(tmp_path)
+    (g / "0037" / "_cdumm_overlay.marker").write_bytes(b"CDUMM overlay marker.")
+    assert language_pack_dirs(g) == set()
+
+
+def test_helper_excludes_real_mod_dirs(tmp_path):
+    g = _game(tmp_path)
+    (g / "0041").mkdir(); (g / "0041" / "0.pamt").write_bytes(b"\x00" * 16)
+    assert language_pack_dirs(g) == {"0037"}
+
+
+def test_pre_snapshot_keeps_language_pack_but_flags_mod_dir(tmp_path):
+    g = _game(tmp_path)
+    (g / "0041").mkdir(); (g / "0041" / "0.pamt").write_bytes(b"\x00" * 16)
+    from cdumm.storage.database import Database
+    db = Database(tmp_path / "cdumm.db")
+    db.initialize()
+    w = SnapshotWorker.__new__(SnapshotWorker)
+    w._game_dir = g
+    w._thread_db = db
+    problems = w._check_pre_snapshot()
+    mod_dir_problems = [p for p in problems if p.startswith("Mod directory")]
+    assert any("0041/" in p for p in mod_dir_problems)
+    assert not any("0037/" in p for p in mod_dir_problems)
+
+
+def test_other_consumers_exempt_language_packs():
+    """Source-level (repo convention): the startup health check and the
+    Verify State worker both consult language_pack_dirs."""
+    root = Path(__file__).parent.parent / "src" / "cdumm"
+    fw = (root / "gui" / "fluent_window.py").read_text(encoding="utf-8")
+    wp = (root / "worker_process.py").read_text(encoding="utf-8")
+    hc = fw.split("Startup health check: game files dirty", 1)
+    assert "language_pack_dirs" in hc[0][-3000:] and "_lang_dirs" in hc[1][:1500]
+    verify = wp.split("def _run_verify", 1)[1].split("\ndef ", 1)[0]
+    assert "language_pack_dirs" in verify and "not in _lang_dirs" in verify


### PR DESCRIPTION
Closes #395. Reported on Nexus by Dante1963: after the 2.0 update, installing CDUMM removed access to the new languages.

2.0 (Enhanced) added voice packs for German, French, Spanish, Brazilian Portuguese and Japanese. Steam downloads the selected pack into one of the five reserved slots `0036`-`0040` (the PAPGT entries flagged `is_optional=1` with a single language bit, the same slots #383 identified).

Three places treated any populated 0036+ directory as mod-created:
- `snapshot_manager._create_snapshot` **deleted** every non-empty 0036+ dir before hashing: first scan or Rescan wiped the language pack
- the startup health check **deleted** 0036+ dirs absent from the snapshot table
- Verify State reported them as extra directories

Fix: new `papgt_manager.language_pack_dirs()` (exists on disk + optional in live/vanilla PAPGT + no CDUMM marker). All three sites exempt those dirs; the snapshot hashes them like any vanilla dir so restore covers them. Fix Everything and apply-time orphan cleanup already protect dirs with PAZ artifacts (#83) and needed no change.

Tests: 6 new (helper on synthetic PAPGT incl. dangling slot, squatted-overlay marker, real mod dir; pre-snapshot check keeps 0037 and still flags 0041; source-level checks on the other two consumers). Full suite 3115 passed, 1 known machine-local failure.

Users who already lost a language need one Steam file verify to re-download it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr