### PR TITLE
fix(apply): tables renamed to .staticinfobody, every JSON mod became a no-op

### DIFF
--- a/src/cdumm/archive/format_parsers/base.py
+++ b/src/cdumm/archive/format_parsers/base.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 # Map file path patterns to parsers
 _PARSERS = {
     ".pabgb": identify_pabgb_records,
+    # Same container, renamed by the 2026-09-04 client update.
+    ".staticinfobody": identify_pabgb_records,
     ".paac": identify_paac_records,
     ".pamt": identify_pamt_records,
 }

--- a/src/cdumm/archive/overlay_builder.py
+++ b/src/cdumm/archive/overlay_builder.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Optional
 
 from cdumm.archive.hashlittle import hashlittle
 from cdumm.archive.paz_crypto import lz4_compress
+from cdumm.archive.table_ext import header_path_for, is_body_path, is_header_path
 from cdumm.engine.cdmods_paths import get_cdmods_root
 
 if TYPE_CHECKING:
@@ -540,8 +541,10 @@ def _get_vanilla_pabgh(
     if not pamt_dir or not game_dir:
         return None
 
-    # Derive PABGH path from PABGB path
-    pabgh_path = pabgb_entry_path.replace(".pabgb", ".pabgh")
+    # Derive PABGH path from PABGB path, keeping the naming family the
+    # live PAMT uses — post-2026-09-04 installs store the pair as
+    # .staticinfoheader / .staticinfobody (cdumm.archive.table_ext).
+    pabgh_path = header_path_for(pabgb_entry_path)
     pabgh_filename = pabgh_path.rsplit("/", 1)[-1] if "/" in pabgh_path else pabgh_path
 
     game_dir = Path(game_dir)
@@ -628,7 +631,7 @@ def build_overlay(
     _added_pabgh: set[str] = set()
     for _c, _m in entries:
         _ep = _m.get("entry_path", "")
-        if _ep.lower().endswith(".pabgh"):
+        if is_header_path(_ep):
             _added_pabgh.add(_ep.lower())
     total_entries = len(entries)
 
@@ -645,10 +648,10 @@ def build_overlay(
         the mod silently broke after the first apply (audit finding
         C6, 2026-06-10).
         """
-        if not (filename.endswith(".pabgb") and game_dir):
+        if not (is_body_path(filename) and game_dir):
             return
-        pabgh_name = filename.replace(".pabgb", ".pabgh")
-        companion_entry_path = entry_path.rsplit(".", 1)[0] + ".pabgh"
+        pabgh_name = header_path_for(filename)
+        companion_entry_path = header_path_for(entry_path)
         pabgh_dedupe_key = companion_entry_path.lower()
         if pabgh_dedupe_key in _added_pabgh:
             return

--- a/src/cdumm/archive/table_ext.py
+++ b/src/cdumm/archive/table_ext.py
@@ -1,0 +1,162 @@
+"""Extension aliases for the game's static-info data tables.
+
+Crimson Desert shipped every game-data table as an index + body pair
+named ``<table>.pabgh`` / ``<table>.pabgb`` until the 2026-09-04 client
+update renamed the pair to ``<table>.staticinfoheader`` /
+``<table>.staticinfobody``. Only the extensions changed — the header is
+still ``u16 count`` + ``count x (key, u32 offset)`` and the body is
+still the same record stream, verified by feeding the post-update
+``gamedata/*.staticinfoheader`` blobs to
+:func:`cdumm.semantic.parser.parse_pabgh_index` (every key size, record
+count and offset resolves inside its companion body).
+
+Every mod on Nexus, every mod already imported into a user's CDMods
+library and every Format 3 document in the wild declares its target as
+``<table>.pabgb``, so CDUMM keeps ``.pabgb`` / ``.pabgh`` as the
+*logical* names throughout the codebase and resolves both families
+wherever a name meets the archive: the PAMT index, the sibling-header
+lookups and the overlay writer. Overlay entries are still emitted under
+whatever name the live PAMT actually carries (``PazEntry.path``), so a
+patched table lands where the game looks for it.
+
+Without this shim the 2026-09-04 update makes every JSON / Format 3 mod
+apply cleanly and change nothing: ``_find_pamt_entry`` misses, and the
+apply ends in ``APPLY_SILENT_FAILURE``.
+"""
+
+# Body ("blob") extensions, newest naming last-resort-free: the legacy
+# name stays first because it is the one mods declare.
+LEGACY_BODY_EXT = ".pabgb"
+LEGACY_HEADER_EXT = ".pabgh"
+STATIC_BODY_EXT = ".staticinfobody"
+STATIC_HEADER_EXT = ".staticinfoheader"
+
+BODY_EXTS = (LEGACY_BODY_EXT, STATIC_BODY_EXT)
+HEADER_EXTS = (LEGACY_HEADER_EXT, STATIC_HEADER_EXT)
+TABLE_EXTS = BODY_EXTS + HEADER_EXTS
+
+# ext -> the matching header/body in the SAME naming family, so a path
+# derived from a live PAMT entry keeps that entry's naming and a path
+# derived from a mod's declared target keeps the mod's naming.
+_BODY_TO_HEADER = {
+    LEGACY_BODY_EXT: LEGACY_HEADER_EXT,
+    STATIC_BODY_EXT: STATIC_HEADER_EXT,
+}
+_HEADER_TO_BODY = {v: k for k, v in _BODY_TO_HEADER.items()}
+
+# ext -> its equivalent in the other family, for alias generation.
+_CROSS_FAMILY = {
+    LEGACY_BODY_EXT: STATIC_BODY_EXT,
+    STATIC_BODY_EXT: LEGACY_BODY_EXT,
+    LEGACY_HEADER_EXT: STATIC_HEADER_EXT,
+    STATIC_HEADER_EXT: LEGACY_HEADER_EXT,
+}
+
+
+def split_table_ext(path: str) -> tuple[str, str | None]:
+    """Return ``(stem, lowercased table extension)``.
+
+    The extension is ``None`` when ``path`` is not a data table, in
+    which case ``stem`` is ``path`` unchanged.
+    """
+    dot = path.rfind(".")
+    if dot < 0:
+        return path, None
+    ext = path[dot:].lower()
+    if ext in _CROSS_FAMILY:
+        return path[:dot], ext
+    return path, None
+
+
+def is_body_path(path: str) -> bool:
+    """True for ``foo.pabgb`` and its post-update ``foo.staticinfobody``."""
+    return path.lower().endswith(BODY_EXTS)
+
+
+def is_header_path(path: str) -> bool:
+    """True for ``foo.pabgh`` and its post-update ``foo.staticinfoheader``."""
+    return path.lower().endswith(HEADER_EXTS)
+
+
+def is_table_path(path: str) -> bool:
+    """True for either half of a data-table pair, in either naming."""
+    return path.lower().endswith(TABLE_EXTS)
+
+
+def header_path_for(body_path: str) -> str:
+    """Companion header path for ``body_path``, keeping its naming family.
+
+    Returns ``body_path`` unchanged when it isn't a table body, so
+    callers can hand it any path without pre-checking.
+    """
+    stem, ext = split_table_ext(body_path)
+    header_ext = _BODY_TO_HEADER.get(ext)
+    return stem + header_ext if header_ext else body_path
+
+
+def body_path_for(header_path: str) -> str:
+    """Companion body path for ``header_path``, keeping its naming family."""
+    stem, ext = split_table_ext(header_path)
+    body_ext = _HEADER_TO_BODY.get(ext)
+    return stem + body_ext if body_ext else header_path
+
+
+def alias_paths(path: str) -> list[str]:
+    """Every name this file could be stored or declared under.
+
+    ``path`` itself always comes first, so callers that index or match
+    in order keep their existing "real name wins" semantics. Non-table
+    paths return a single-element list — this runs once per PAMT entry
+    over millions of entries during an index build, so the common case
+    stays a string compare and a list literal.
+    """
+    stem, ext = split_table_ext(path)
+    if ext is None:
+        return [path]
+    return [path, stem + _CROSS_FAMILY[ext]]
+
+
+def to_legacy_name(path: str) -> str:
+    """Rewrite a table path to the ``.pabgb`` / ``.pabgh`` naming.
+
+    CDUMM's internal target names, dispatch tables and user-facing
+    warnings all speak the legacy naming, and so does every mod in the
+    wild. Normalising a mod-declared target through here means a mod
+    that starts shipping the post-update name still hits the same
+    whole-table writers. Non-table paths are returned unchanged.
+    """
+    stem, ext = split_table_ext(path)
+    if ext == STATIC_BODY_EXT:
+        return stem + LEGACY_BODY_EXT
+    if ext == STATIC_HEADER_EXT:
+        return stem + LEGACY_HEADER_EXT
+    return path
+
+
+def strip_body_ext(name: str) -> str:
+    """Lowercase ``name`` with a table BODY extension removed, path kept.
+
+    The path-preserving counterpart to :func:`strip_table_ext`. Some
+    callers deliberately keep the directory (``gamedata/iteminfo``) and
+    have downstream guards built around that; widening only the
+    extension keeps their behaviour bit-for-bit on a pre-update install
+    while still accepting the post-2026-09-04 name.
+    """
+    stem, ext = split_table_ext(name)
+    if ext in _BODY_TO_HEADER:
+        return stem.lower()
+    return name.lower()
+
+
+def strip_table_ext(name: str) -> str:
+    """Lowercased table name: ``gamedata/iteminfo.pabgb`` -> ``iteminfo``.
+
+    Accepts a full path, a bare filename, or an already-stripped table
+    name, in either naming family.
+    """
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    if "\\" in name:
+        name = name.rsplit("\\", 1)[-1]
+    stem, _ext = split_table_ext(name)
+    return stem.lower()

--- a/src/cdumm/engine/apply_engine.py
+++ b/src/cdumm/engine/apply_engine.py
@@ -169,8 +169,9 @@ def invalidate_apply_fingerprint(
 # entries fired on overlapping DDS textures and produced a corrupt
 # Frankenstein file that froze the game on the loading screen.
 _BYTE_MERGEABLE_EXTS = frozenset({
-    # PABGB tables and their headers
-    "pabgb", "pabgh",
+    # PABGB tables and their headers, under both the pre- and
+    # post-2026-09-04 names (cdumm.archive.table_ext).
+    "pabgb", "pabgh", "staticinfobody", "staticinfoheader",
     # Pearl Abyss XML / sequencer formats
     "pac_xml", "pamb_xml", "paseq", "paac", "xml",
     # UI text formats
@@ -227,6 +228,9 @@ def _dirs_losing_pamt(deferred_file_deletions: "list[Path]") -> "set[str]":
     return out
 
 from cdumm.archive.papgt_manager import PapgtManager
+from cdumm.archive.table_ext import (
+    alias_paths, header_path_for, BODY_EXTS, HEADER_EXTS,
+)
 from cdumm.archive.transactional_io import TransactionalIO
 from cdumm.engine.delta_engine import (
     SPARSE_MAGIC, apply_delta_from_file,
@@ -740,9 +744,7 @@ def _make_format3_vanilla_extractor(
             body = get_vanilla_entry_content(file_path, target)
             if body is None:
                 return None
-            header_path = target
-            if header_path.endswith(".pabgb"):
-                header_path = header_path[:-len(".pabgb")] + ".pabgh"
+            header_path = header_path_for(target)
             header = extract_sibling_entry(pamt_dir, header_path)
             if header is None:
                 return None
@@ -3690,7 +3692,7 @@ class ApplyWorker(QObject):
                     from cdumm.semantic.engine import SemanticEngine
                     engine = SemanticEngine(self._db)
 
-                    header_entry_path = entry_path.replace(".pabgb", ".pabgh")
+                    header_entry_path = header_path_for(entry_path)
                     header_bytes = self._extract_sibling_entry(
                         pamt_dir, header_entry_path)
                     vanilla_content = self._get_vanilla_entry_content(
@@ -3905,7 +3907,8 @@ class ApplyWorker(QObject):
         if not hasattr(self, "_pamt_entries_cache"):
             self._pamt_entries_cache: dict[str, list] = {}
 
-        entry_basename = entry_path.rsplit("/", 1)[-1]
+        wanted_paths = set(alias_paths(entry_path.lower()))
+        wanted_names = {a.rsplit("/", 1)[-1] for a in wanted_paths}
         for base in [self._vanilla_dir, self._game_dir]:
             pamt_path = base / pamt_dir / "0.pamt"
             if not pamt_path.exists():
@@ -3926,11 +3929,14 @@ class ApplyWorker(QObject):
                 # (#61 fix only covered the other call site).
                 self._pamt_entries_cache[cache_key] = entries
             try:
+                # Alias-aware: a caller-derived "iteminfo.pabgh" must
+                # also match the post-update
+                # "gamedata/iteminfo.staticinfoheader" (table_ext).
                 for e in entries:
-                    if e.path == entry_path:
+                    if e.path.lower() in wanted_paths:
                         return _extract_from_paz(e)
                 for e in entries:
-                    if e.path.rsplit("/", 1)[-1] == entry_basename:
+                    if e.path.rsplit("/", 1)[-1].lower() in wanted_names:
                         return _extract_from_paz(e)
             except Exception as e:
                 # R2: same #62 visibility fix — log the real cause
@@ -3974,7 +3980,7 @@ class ApplyWorker(QObject):
         # xml_patch_handler.process_xml_patches_for_overlay, which does
         # structural merging; byte-merging its output would undo that.
         # Stick to last-wins (priority-ordered) for everything else.
-        _MERGEABLE_EXTS = (".pabgb", ".pabgh", ".pamt")
+        _MERGEABLE_EXTS = BODY_EXTS + HEADER_EXTS + (".pamt",)
         # CDUMM priority: lower number wins. Entries now carry a
         # 'priority' key in their meta (stamped at the JSON / XML
         # extend sites). Resolve ties by meta priority instead of
@@ -4141,7 +4147,8 @@ class ApplyWorker(QObject):
         from cdumm.engine.json_patch_handler import _extract_from_paz
 
         pamt_dir = file_path.split("/")[0]
-        entry_basename = entry_path.rsplit("/", 1)[-1]
+        wanted_paths = set(alias_paths(entry_path.lower()))
+        wanted_names = {a.rsplit("/", 1)[-1] for a in wanted_paths}
 
         if not hasattr(self, "_pamt_entries_cache"):
             self._pamt_entries_cache: dict[str, list] = {}
@@ -4162,16 +4169,20 @@ class ApplyWorker(QObject):
                     continue
                 self._pamt_entries_cache[cache_key] = entries
             try:
-                # Prefer exact path match.
+                # Prefer exact path match. Matching runs over the
+                # entry's alias set so a mod-declared
+                # "gamedata/iteminfo.pabgb" still resolves against the
+                # post-2026-09-04 "gamedata/iteminfo.staticinfobody"
+                # the live PAMT actually stores (table_ext).
                 for e in entries:
-                    if e.path == entry_path:
+                    if e.path.lower() in wanted_paths:
                         return _extract_from_paz(e)
                 # Fall back to basename match — mirrors
                 # _find_pamt_entry's behavior (json_patch_handler.py
                 # :1462) so callers passing a Format-3 basename
                 # target resolve correctly.
                 for e in entries:
-                    if e.path.rsplit("/", 1)[-1] == entry_basename:
+                    if e.path.rsplit("/", 1)[-1].lower() in wanted_names:
                         return _extract_from_paz(e)
             except Exception as e:
                 # GitHub #62 (UnLuckyLust, 2026-05-02): the prior

--- a/src/cdumm/engine/conflict_detector.py
+++ b/src/cdumm/engine/conflict_detector.py
@@ -9,6 +9,7 @@ import logging
 from dataclasses import dataclass
 
 from cdumm.archive.format_parsers import identify_records_for_file
+from cdumm.archive.table_ext import alias_paths
 from cdumm.storage.database import Database
 
 logger = logging.getLogger(__name__)
@@ -100,10 +101,17 @@ class ConflictDetector:
         """A Format 3 target is a bare name (iteminfo.pabgb); an entry_path
         may be the full game path. Compare on the basename -- the same trap
         that made `match` select zero records (#275) and array_append a
-        no-op (#278)."""
+        no-op (#278).
+
+        Compare on the alias set, not the literal basename: mods declare
+        ``iteminfo.pabgb`` while a post-2026-09-04 entry_path reads
+        ``gamedata/iteminfo.staticinfobody``. A literal compare misses,
+        and two Format 3 mods editing the same table stop being seen as
+        touching the same file (cdumm.archive.table_ext).
+        """
         t = (target or "").lower().replace("\\", "/").rsplit("/", 1)[-1]
         e = (entry_path or "").lower().replace("\\", "/").rsplit("/", 1)[-1]
-        return bool(t) and t == e
+        return bool(t) and e in alias_paths(t)
 
     def _semantic_conflict_info(
         self, entry_path: str,

--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -38,6 +38,10 @@ import struct
 from pathlib import Path
 from typing import Callable, NamedTuple
 
+from cdumm.archive.table_ext import (
+    header_path_for, strip_body_ext, to_legacy_name,
+)
+
 # The writer's field-name resolver, shared on purpose: a `match` key must
 # accept exactly the spellings a `field` key accepts, and copying the rule
 # would let the two drift apart silently.
@@ -762,6 +766,14 @@ def expand_format3_into_aggregated(
         n_mods_processed += 1
 
         for target, intents in target_pairs:
+            # Speak one naming internally: _WHOLE_TABLE_TARGETS, the
+            # per-table writer dispatch and the user-facing warnings
+            # are all keyed on "<table>.pabgb". A mod that declares the
+            # post-2026-09-04 "<table>.staticinfobody" resolves to the
+            # same file either way (table_ext), and normalising here
+            # keeps it on the whole-table writer path instead of
+            # silently falling through to a byte-level no-op.
+            target = to_legacy_name(target)
             try:
                 # Validate intents against the schema + community field_schema
                 validation = validate_intents(target, intents)
@@ -893,7 +905,7 @@ def expand_format3_into_aggregated(
                     body_change["_source_mod_ids"] = [mod_id]
                     aggregated.setdefault(target, []).append(body_change)
                     if companion is not None:
-                        comp_target = target.replace(".pabgb", ".pabgh")
+                        comp_target = header_path_for(target)
                         companion["_target_file"] = comp_target
                         companion["_source_mod_ids"] = [mod_id]
                         aggregated.setdefault(
@@ -1612,7 +1624,7 @@ def expand_format3_into_aggregated(
                         return (_f in ("stock_data_list",
                                        "_exchangeItemInfoListForSell")
                                 or _slot_re.match(_f) is not None)
-                _companion = target.replace(".pabgb", ".pabgh")
+                _companion = header_path_for(target)
                 # Per-intent mod attribution (index-aligned with the
                 # original batched list, built BEFORE any filtering).
                 _intent_mods = whole_table_intent_mods.get(target, [])
@@ -2467,7 +2479,7 @@ def _route_pabgh_companion(change: dict, target: str, out: list) -> None:
     companion = change.pop("_pabgh_companion", None)
     if companion is None:
         return
-    companion["_target_file"] = target.replace(".pabgb", ".pabgh")
+    companion["_target_file"] = header_path_for(target)
     out.append(companion)
 
 
@@ -3012,9 +3024,11 @@ def _entry_name(body: bytes, entry_off: int,
 
 
 def _strip_pabgb(target: str) -> str:
-    name = target
-    if "/" in name:
-        name = name.rsplit("/", 1)[-1]
-    if name.lower().endswith(".pabgb"):
-        name = name[: -len(".pabgb")]
-    return name.lower()
+    """Table name for a body target, in either naming family (table_ext).
+
+    Body extensions only, matching the pre-rename behaviour exactly: a
+    header path is returned with its extension intact so the caller
+    still fails the table lookup it always failed.
+    """
+    name = target.rsplit("/", 1)[-1] if "/" in target else target
+    return strip_body_ext(name)

--- a/src/cdumm/engine/format3_handler.py
+++ b/src/cdumm/engine/format3_handler.py
@@ -46,6 +46,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from cdumm.archive.table_ext import (
+    is_body_path, strip_body_ext, strip_table_ext,
+)
 from cdumm.engine.characterinfo_writer import (
     SUPPORTED_FIELDS as _CHARACTERINFO_FIELDS,
 )
@@ -507,9 +510,7 @@ def _apply_field_aliases(
     replaced with a fresh dataclasses.replace() copy rather than
     mutated in place.
     """
-    tname = target.lower()
-    if not (tname == "iteminfo.pabgb"
-            or tname.endswith("/iteminfo.pabgb")):
+    if not is_body_path(target) or strip_table_ext(target) != "iteminfo":
         return
     import dataclasses
     for i, intent in enumerate(intents):
@@ -655,15 +656,21 @@ def parse_format3_mod(path: Path) -> tuple[str, list[Format3Intent]]:
 
 
 def _table_name_from_target(target: str) -> str:
-    """Strip ``.pabgb`` and normalize to the schema's lowercase key.
+    """Strip the table body extension and lowercase.
 
     ``parser.has_schema`` looks up by the lowercase filename stem —
-    same convention CDUMM uses everywhere else.
+    same convention CDUMM uses everywhere else. Both the mod-declared
+    ``.pabgb`` name and the post-2026-09-04 ``.staticinfobody`` the
+    game now ships strip to the same key (cdumm.archive.table_ext).
+
+    Deliberately keeps any leading directory: a path-qualified target
+    comes back as ``gamedata/iteminfo``. Two callers in
+    ``format3_apply`` are built around that and re-derive the bare
+    name themselves (see the comments at the ``array_append`` and
+    ``match`` routers), so stripping the path here would silently
+    change which intents those routers expand.
     """
-    name = target
-    if name.lower().endswith(".pabgb"):
-        name = name[: -len(".pabgb")]
-    return name.lower()
+    return strip_body_ext(target)
 
 
 _SUPPORTED_OPS = frozenset({"set"})
@@ -1259,7 +1266,7 @@ def _diagnose_unsupported_intent(
         # those at validation , the apply-time helper does the real
         # resolution and emits zero-bytes-cleanly when an item is
         # behind an unknown variant tag.
-        tn = (table_name or "").lower().replace(".pabgb", "")
+        tn = strip_body_ext(table_name or "")
         if tn == "buffinfo" and (field or "").startswith(
                 "buff_data_list["):
             return None
@@ -1332,7 +1339,7 @@ def _diagnose_unsupported_intent(
     if isinstance(new_value, list) and new_value and isinstance(
             new_value[0], dict):
         # Table-specific list-writer registered? Allow.
-        tn = (table_name or "").lower().replace(".pabgb", "")
+        tn = strip_body_ext(table_name or "")
         if (tn, field) in LIST_WRITERS:
             return None
         return (
@@ -1465,7 +1472,7 @@ def _classify_intent(
     # resolve, so a typo in the nested path produces a clean
     # "0 byte changes" warning rather than a misleading
     # "add a field_schema entry" instruction the author can't act on.
-    tn_norm = (table_name or "").lower().replace(".pabgb", "")
+    tn_norm = strip_body_ext(table_name or "")
     if tn_norm == "buffinfo" and intent.field.startswith(
             "buff_data_list["):
         return None

--- a/src/cdumm/engine/game_index.py
+++ b/src/cdumm/engine/game_index.py
@@ -24,8 +24,11 @@ import struct
 import time
 from typing import Any, Callable, Iterable
 
-# Data-table blob (.pabgb) + schema/header (.pabgh) extensions.
-TABLE_EXTS = (".pabgb", ".pabgh")
+from cdumm.archive.table_ext import BODY_EXTS, HEADER_EXTS
+
+# Data-table blob + schema/header extensions, under both the pre- and
+# post-2026-09-04 names (see cdumm.archive.table_ext).
+TABLE_EXTS = BODY_EXTS + HEADER_EXTS
 
 # The game's own verbose reflection-serialized formats — these embed a real
 # field / type / object name schema as text (readable via decode_reflection /
@@ -143,8 +146,9 @@ def write_stats(con: sqlite3.Connection, **extra: Any) -> dict:
     # One data table == one .pabgb blob (+ its .pabgh key index). Count the
     # blobs only, so the paired header file isn't tallied as a second table.
     distinct = con.execute(
-        "SELECT COUNT(DISTINCT name) FROM data_tables "
-        "WHERE name LIKE '%.pabgb'").fetchone()[0]
+        "SELECT COUNT(DISTINCT name) FROM data_tables WHERE "
+        + " OR ".join("name LIKE ?" for _ in BODY_EXTS),
+        tuple("%" + e for e in BODY_EXTS)).fetchone()[0]
     stats: dict[str, Any] = {
         "assets_total": total,
         "archives": archives,

--- a/src/cdumm/engine/json_patch_handler.py
+++ b/src/cdumm/engine/json_patch_handler.py
@@ -56,6 +56,9 @@ from typing import TYPE_CHECKING
 from cdumm.archive.paz_parse import parse_pamt, PazEntry
 from cdumm.archive.paz_crypto import decrypt, encrypt, lz4_decompress, lz4_compress
 from cdumm.archive.paz_repack import repack_entry_bytes, _save_timestamps
+from cdumm.archive.table_ext import (
+    alias_paths, header_path_for, is_body_path, BODY_EXTS, HEADER_EXTS,
+)
 from cdumm.engine.cdmods_paths import get_cdmods_root
 
 if TYPE_CHECKING:
@@ -70,7 +73,7 @@ def _prettify(name: str) -> str:
     return prettify_mod_name(name)
 
 
-_PABGB_DATA_TABLE_EXTS = (".pabgb", ".pabgh", ".pamt")
+_PABGB_DATA_TABLE_EXTS = BODY_EXTS + HEADER_EXTS + (".pamt",)
 
 
 def _should_reject_partial_pabgb(game_file: str, applied: int,
@@ -1783,7 +1786,7 @@ def convert_json_patch_to_paz(
         needs_pabgh = any(
             c.get("record_key") is not None or c.get("entry") for c in changes)
         if needs_pabgh:
-            pabgh_file = game_file.rsplit(".", 1)[0] + ".pabgh"
+            pabgh_file = header_path_for(game_file)
             pabgh_entry = entry_cache.get(pabgh_file.lower())
             if pabgh_entry is None:
                 pabgh_entry = _find_pamt_entry(pabgh_file, vanilla_dir)
@@ -2031,6 +2034,34 @@ def _update_pamt_record(pamt_path: Path, entry: PazEntry,
 _pamt_index_cache: dict[str, dict[str, PazEntry]] = {}
 
 
+_PAMT_INDEX_CACHE_VERSION = "v4"
+
+
+def _retire_superseded_index_caches(cdmods: Path) -> None:
+    """Delete PAMT index caches left behind by older cache versions.
+
+    Only files matching CDUMM's own ``.pamt_index*.cache`` naming are
+    touched, and only those NOT carrying the current version tag. One
+    CDMods root legitimately holds several current-version caches at
+    once (``_vanilla`` plus one ``_game_<hash>`` per install), so the
+    sweep must key on the version, not on the single filename the
+    caller happens to be about to write.
+    """
+    keep_prefix = f".pamt_index_{_PAMT_INDEX_CACHE_VERSION}_"
+    try:
+        for old in cdmods.glob(".pamt_index*.cache"):
+            if old.name.startswith(keep_prefix):
+                continue
+            try:
+                old.unlink()
+                logger.info("Removed superseded PAMT index cache: %s",
+                            old.name)
+            except OSError as e:
+                logger.debug("Could not remove %s: %s", old.name, e)
+    except OSError as e:
+        logger.debug("PAMT cache sweep failed in %s: %s", cdmods, e)
+
+
 def _get_pamt_index(game_dir: Path) -> dict[str, PazEntry]:
     """Build or retrieve a cached index of all PAMT entries for a game directory.
 
@@ -2070,6 +2101,10 @@ def _get_pamt_index(game_dir: Path) -> dict[str, PazEntry]:
     _key = "vanilla" if game_dir.name == "vanilla" else (
         "game_" + _hashlib.sha1(str(game_dir).encode("utf-8")).hexdigest()[:12]
     )
+    # Cache version bumped to v4 on 2026-09-04 for the .pabgb ->
+    # .staticinfobody alias keys (see cdumm.archive.table_ext). A v3
+    # cache carries only the post-update names, so every mod-declared
+    # ".pabgb" lookup missed and Apply ended in APPLY_SILENT_FAILURE.
     # Cache version bumped to v3 on 2026-05-26 when the twin-entry
     # tracking landed (AeGhBrA/jikulopo #167). Older caches only have
     # the single-entry path map; the twin retry path needs the new
@@ -2077,7 +2112,15 @@ def _get_pamt_index(game_dir: Path) -> dict[str, PazEntry]:
     # v2 was the first-seen-wins basename fix (paloroycevincent-sketch
     # GitHub #99). Bumping the filename forces a one-time rebuild on
     # the next run.
-    cache_path = cdmods / f".pamt_index_v3_{_key}.cache"
+    cache_path = cdmods / (
+        f".pamt_index_{_PAMT_INDEX_CACHE_VERSION}_{_key}.cache")
+    # Superseded index caches are never read again and are NOT small:
+    # a full live-game index pickles to ~600 MB, the vanilla snapshot
+    # to ~340 MB. Earlier bumps left them behind as "harmless
+    # leftovers"; at this size that is nearly a gigabyte of dead disk
+    # per CDMods root, so retire them when the new version is written
+    # (best-effort — a locked or missing file is not an error).
+    _retire_superseded_index_caches(cdmods)
     if cache_path.exists():
         try:
             cache_mtime = cache_path.stat().st_mtime
@@ -2116,55 +2159,66 @@ def _get_pamt_index(game_dir: Path) -> dict[str, PazEntry]:
         try:
             entries = parse_pamt(str(pamt), paz_dir=str(d))
             for e in entries:
-                ep = e.path.lower().replace("\\", "/")
-                # #167 (AeGhBrA, jikulopo): some PAMTs hold the same
-                # full path twice with different binary content. Skip
-                # More Animations (Nexus 774) patches paseq files that
-                # live in 0014 at "sequencer/gimmick_craft_stone_repair_01.paseq"
-                # for both copies; the mod JSON declares the longer
-                # "sequencer/binary__/baseseq/.../foo.paseq" form. The
-                # old index overwrote one entry with the other, so the
-                # apply path could only ever see whichever copy was
-                # parsed last. Track every copy under a sidecar
-                # "__twins:" key so the apply loop can retry on the
-                # other twin when the first one's bytes don't match.
-                if ep in index:
-                    twins_key = "__twins:" + ep
-                    twins = index.get(twins_key)
-                    if not isinstance(twins, list):
-                        twins = [index[ep]]
-                        index[twins_key] = twins
-                    twins.append(e)
-                index[ep] = e
-                bname = ep.rsplit("/", 1)[-1]
-                # First-seen-wins for bare-basename collisions. Crimson
-                # Desert ships two iteminfo.pabgb (one in gamedata/ in
-                # 0008/0.paz, one in ui/ in 0072/0.paz). The old code
-                # used a naive index[bname] = e, so 0072 overwrote
-                # 0008, and Format 3 mods targeting "iteminfo.pabgb"
-                # without a path prefix ended up reading the wrong
-                # file and erroring out with "vanilla bytes unavailable"
-                # because the writer's schema does not match the UI
-                # variant. paloroycevincent-sketch GitHub #99 reproduced
-                # this exactly. Because sorted(game_dir.iterdir())
-                # walks the numbered directories in ascending order,
-                # setdefault makes the lowest-numbered PAZ directory
-                # win, which for iteminfo.pabgb is 0008 = gamedata.
-                # Mod authors who want a specific path-distinguished
-                # variant should still use the full path (e.g.
-                # "ui/iteminfo.pabgb"); the exact-match branch in
-                # _find_pamt_entry handles those without ambiguity.
-                index.setdefault(bname, e)
-                # #167: also track EVERY entry with this basename, so
-                # _find_pamt_entries can hand all candidates back to
-                # the apply loop when the first-seen pick mismatches
-                # the patch's expected bytes.
-                bn_key = "__basename_all:" + bname
-                bn_list = index.get(bn_key)
-                if not isinstance(bn_list, list):
-                    bn_list = []
-                    index[bn_key] = bn_list
-                bn_list.append(e)
+                real_ep = e.path.lower().replace("\\", "/")
+                # The 2026-09-04 client update renamed every data
+                # table from <table>.pabgh / <table>.pabgb to
+                # <table>.staticinfoheader / <table>.staticinfobody
+                # without changing a byte of either container. Mods
+                # (and every already-imported CDMods entry) still
+                # declare the .pabgb names, so register each table
+                # entry under BOTH names and a lookup in either
+                # naming resolves. alias_paths puts the real name
+                # first, so the first-seen-wins rules below behave
+                # exactly as they did pre-update.
+                for ep in alias_paths(real_ep):
+                    # #167 (AeGhBrA, jikulopo): some PAMTs hold the same
+                    # full path twice with different binary content. Skip
+                    # More Animations (Nexus 774) patches paseq files that
+                    # live in 0014 at "sequencer/gimmick_craft_stone_repair_01.paseq"
+                    # for both copies; the mod JSON declares the longer
+                    # "sequencer/binary__/baseseq/.../foo.paseq" form. The
+                    # old index overwrote one entry with the other, so the
+                    # apply path could only ever see whichever copy was
+                    # parsed last. Track every copy under a sidecar
+                    # "__twins:" key so the apply loop can retry on the
+                    # other twin when the first one's bytes don't match.
+                    if ep in index:
+                        twins_key = "__twins:" + ep
+                        twins = index.get(twins_key)
+                        if not isinstance(twins, list):
+                            twins = [index[ep]]
+                            index[twins_key] = twins
+                        twins.append(e)
+                    index[ep] = e
+                    bname = ep.rsplit("/", 1)[-1]
+                    # First-seen-wins for bare-basename collisions. Crimson
+                    # Desert ships two iteminfo.pabgb (one in gamedata/ in
+                    # 0008/0.paz, one in ui/ in 0072/0.paz). The old code
+                    # used a naive index[bname] = e, so 0072 overwrote
+                    # 0008, and Format 3 mods targeting "iteminfo.pabgb"
+                    # without a path prefix ended up reading the wrong
+                    # file and erroring out with "vanilla bytes unavailable"
+                    # because the writer's schema does not match the UI
+                    # variant. paloroycevincent-sketch GitHub #99 reproduced
+                    # this exactly. Because sorted(game_dir.iterdir())
+                    # walks the numbered directories in ascending order,
+                    # setdefault makes the lowest-numbered PAZ directory
+                    # win, which for iteminfo.pabgb is 0008 = gamedata.
+                    # Mod authors who want a specific path-distinguished
+                    # variant should still use the full path (e.g.
+                    # "ui/iteminfo.pabgb"); the exact-match branch in
+                    # _find_pamt_entry handles those without ambiguity.
+                    index.setdefault(bname, e)
+                    # #167: also track EVERY entry with this basename, so
+                    # _find_pamt_entries can hand all candidates back to
+                    # the apply loop when the first-seen pick mismatches
+                    # the patch's expected bytes.
+                    bn_key = "__basename_all:" + bname
+                    bn_list = index.get(bn_key)
+                    if not isinstance(bn_list, list):
+                        bn_list = []
+                        index[bn_key] = bn_list
+                    bn_list.append(e)
         except Exception:
             continue
 
@@ -2456,7 +2510,7 @@ def import_json_as_entr(patch_data: dict, game_dir: Path, db, deltas_dir: Path,
         # v2 entry-anchored: resolve name→offset map for characterinfo.pabgb etc.
         name_offsets = None
         if any(c.get("entry") for c in changes):
-            pabgh_file = game_file.rsplit(".", 1)[0] + ".pabgh"
+            pabgh_file = header_path_for(game_file)
             pabgh_entry = entry_cache.get(pabgh_file.lower())
             if pabgh_entry is None:
                 pabgh_entry = _find_pamt_entry(pabgh_file, game_dir)
@@ -3021,7 +3075,7 @@ def process_json_patches_for_overlay(
         name_offsets = None
         any_entry_anchored = any(c.get("entry") for c in changes)
         if any_entry_anchored:
-            pabgh_file = game_file.rsplit(".", 1)[0] + ".pabgh"
+            pabgh_file = header_path_for(game_file)
             pabgh_entry = None
             if vanilla_source_resolver is not None:
                 try:
@@ -3343,8 +3397,8 @@ def process_json_patches_for_overlay(
         # the companion .pabgh must have its entry pointers shifted so the
         # game can still find each blob. Emit the fixed .pabgh as an extra
         # overlay entry so it overrides vanilla at load time.
-        if inserts_out and game_file.lower().endswith(".pabgb"):
-            pabgh_file = game_file.rsplit(".", 1)[0] + ".pabgh"
+        if inserts_out and is_body_path(game_file):
+            pabgh_file = header_path_for(game_file)
             pabgh_entry_for_fixup = None
             if vanilla_source_resolver is not None:
                 try:

--- a/src/cdumm/engine/mod_diagnostics.py
+++ b/src/cdumm/engine/mod_diagnostics.py
@@ -14,6 +14,8 @@ import struct
 import zipfile
 from pathlib import Path
 
+from cdumm.archive.table_ext import BODY_EXTS, header_path_for
+
 logger = logging.getLogger(__name__)
 
 
@@ -192,7 +194,7 @@ def _diagnose_archive(mod_path: Path, game_dir: Path, db_path: Path,
 
     # Check for loose game files (xml, css, etc. without numbered dirs)
     loose_game = [n for n in names if n.lower().endswith(
-        (".xml", ".css", ".pabgb", ".paac", ".dds"))
+        (".xml", ".css", ".paac", ".dds") + BODY_EXTS)
         and not n.startswith("__MACOSX")]
     if loose_game and "paz_dirs" not in detected:
         detected.append("loose_files")
@@ -487,7 +489,7 @@ def _verify_json_patch_bytes(data: dict, game_dir: Path,
                     from cdumm.engine.json_patch_handler import (
                         _build_name_offsets_for_v2,
                     )
-                    pabgh_file = game_file.rsplit(".", 1)[0] + ".pabgh"
+                    pabgh_file = header_path_for(game_file)
                     pabgh_entry = _find_pamt_entry(pabgh_file, game_dir)
                     if pabgh_entry is not None:
                         pabgh_raw = open(pabgh_entry.paz_file, 'rb').read()

--- a/src/cdumm/gui/pages/game_data_page.py
+++ b/src/cdumm/gui/pages/game_data_page.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (QDialog, QFileDialog, QHBoxLayout, QHeaderView,
                                QTableWidgetItem, QVBoxLayout, QWidget)
 from qfluentwidgets import TableItemDelegate, isDarkTheme
 
+from cdumm.archive.table_ext import header_path_for, is_body_path
 from cdumm.engine import game_index
 from cdumm.gui.pages.tool_page import ToolPageBase
 from cdumm.platform import IS_MACOS, IS_WINDOWS
@@ -210,6 +211,7 @@ _CAT_COLOUR = {
 }
 _EXT_CAT = {
     ".pabgb": "table", ".pabgh": "table",
+    ".staticinfobody": "table", ".staticinfoheader": "table",
     ".wem": "audio", ".bnk": "audio", ".pasound": "audio",
     ".mp4": "video",
     ".dds": "visual", ".png": "visual", ".padxil": "visual", ".material": "visual",
@@ -471,7 +473,7 @@ class _PreviewWorker(QObject):
         gd = self._game_dir
 
         # 1) keyed game-data table → parsed grid (CDUMM's semantic schemas)
-        if gd and self._path.endswith(".pabgb"):
+        if gd and is_body_path(self._path):
             try:
                 from cdumm.semantic import parser as sem
                 table = sem.identify_table_from_path(self._path)
@@ -484,7 +486,7 @@ class _PreviewWorker(QObject):
                 try:
                     body = game_index.extract_asset(con, self._path, gd)
                     header = game_index.extract_asset(
-                        con, self._path[:-6] + ".pabgh", gd)
+                        con, header_path_for(self._path), gd)
                     # Display-only decoder: honors override flags + walks
                     # variable-length fields so richly-schema'd tables
                     # (iteminfo, regioninfo, ...) show their real columns.

--- a/src/cdumm/semantic/parser.py
+++ b/src/cdumm/semantic/parser.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from cdumm.archive.table_ext import is_body_path, strip_table_ext
+
 logger = logging.getLogger(__name__)
 
 # Tables that use u32 count instead of u16 in pabgh header.
@@ -823,6 +825,7 @@ def identify_table_from_path(entry_path: str) -> str | None:
     """Extract table name from a PAMT entry path.
 
     e.g., 'gamedata/inventory.pabgb' → 'inventory'
+         'gamedata/inventory.staticinfobody' → 'inventory'
          'gamedata/binary__/client/bin/iteminfo.pabgb' → 'iteminfo'
     """
     if not entry_path:
@@ -832,8 +835,11 @@ def identify_table_from_path(entry_path: str) -> str | None:
     parts = entry_path.rsplit("/", 1)
     filename = parts[-1] if len(parts) > 1 else parts[0]
 
-    if not filename.endswith(".pabgb"):
+    # Post-2026-09-04 installs store the same container as
+    # <table>.staticinfobody; both names identify the same table
+    # (cdumm.archive.table_ext).
+    if not is_body_path(filename):
         return None
 
-    table_name = filename[:-6]  # strip .pabgb
+    table_name = strip_table_ext(filename)
     return table_name if has_schema(table_name) else None

--- a/tests/test_staticinfo_table_ext_aliases.py
+++ b/tests/test_staticinfo_table_ext_aliases.py
@@ -1,0 +1,249 @@
+"""The 2026-09-04 client update renamed every game-data table.
+
+``<table>.pabgh`` / ``<table>.pabgb`` became
+``<table>.staticinfoheader`` / ``<table>.staticinfobody``. The
+containers are byte-identical; only the extensions changed. Mods (and
+every already-imported CDMods entry) still declare the ``.pabgb``
+names, so every ``_find_pamt_entry`` lookup missed, every Format 3
+vanilla extraction returned None, and Apply finished with
+``APPLY_SILENT_FAILURE: N JSON mod(s) were enabled but produced no
+game changes`` while telling users their mods were outdated.
+
+These tests pin the alias layer that resolves both namings.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cdumm.archive.paz_parse import PazEntry
+from cdumm.archive.table_ext import (
+    BODY_EXTS,
+    HEADER_EXTS,
+    alias_paths,
+    body_path_for,
+    header_path_for,
+    is_body_path,
+    is_header_path,
+    is_table_path,
+    split_table_ext,
+    strip_table_ext,
+)
+
+# --------------------------------------------------------------- helpers
+
+def _FakeEntry(path: str, paz_file: str) -> PazEntry:
+    """A real PazEntry — _find_pamt_entry isinstance-checks its hits, so
+    a stand-in dataclass would pass the lookup and fail the type gate."""
+    return PazEntry(path=path, paz_file=paz_file, offset=0, comp_size=4,
+                    orig_size=4, flags=0, paz_index=0)
+
+
+# ------------------------------------------------------------- table_ext
+
+@pytest.mark.parametrize("path,expected", [
+    ("gamedata/iteminfo.pabgb",
+     ["gamedata/iteminfo.pabgb", "gamedata/iteminfo.staticinfobody"]),
+    ("gamedata/iteminfo.staticinfobody",
+     ["gamedata/iteminfo.staticinfobody", "gamedata/iteminfo.pabgb"]),
+    ("iteminfo.pabgh",
+     ["iteminfo.pabgh", "iteminfo.staticinfoheader"]),
+    # Non-table paths must stay single-element: alias_paths runs once
+    # per PAMT entry across millions of entries on an index build.
+    ("ui/texture/foo.dds", ["ui/texture/foo.dds"]),
+    ("noextension", ["noextension"]),
+])
+def test_alias_paths(path, expected):
+    assert alias_paths(path) == expected
+
+
+def test_alias_paths_puts_the_real_name_first():
+    """_get_pamt_index relies on this: the first alias keeps the
+    pre-update 'real name wins' / 'first seen wins' index semantics."""
+    for p in ("a/b.staticinfobody", "a/b.pabgb", "a/b.dds"):
+        assert alias_paths(p)[0] == p
+
+
+def test_header_and_body_derivation_stays_in_one_naming_family():
+    assert header_path_for("gamedata/iteminfo.pabgb") == \
+        "gamedata/iteminfo.pabgh"
+    assert header_path_for("gamedata/iteminfo.staticinfobody") == \
+        "gamedata/iteminfo.staticinfoheader"
+    assert body_path_for("gamedata/iteminfo.staticinfoheader") == \
+        "gamedata/iteminfo.staticinfobody"
+    # Not a table: handed back untouched so callers need no pre-check.
+    assert header_path_for("ui/foo.dds") == "ui/foo.dds"
+
+
+def test_predicates_and_stripping():
+    assert is_body_path("x.pabgb") and is_body_path("x.STATICINFOBODY")
+    assert is_header_path("x.pabgh") and is_header_path("x.staticinfoheader")
+    assert not is_body_path("x.pabgh")
+    assert not is_header_path("x.staticinfobody")
+    assert is_table_path("x.pabgh") and not is_table_path("x.dds")
+    assert split_table_ext("a/b.dds") == ("a/b.dds", None)
+    for name in ("gamedata/ItemInfo.PABGB", "iteminfo.staticinfobody",
+                 "iteminfo"):
+        assert strip_table_ext(name) == "iteminfo"
+
+
+def test_ext_tuples_cover_both_namings():
+    assert ".pabgb" in BODY_EXTS and ".staticinfobody" in BODY_EXTS
+    assert ".pabgh" in HEADER_EXTS and ".staticinfoheader" in HEADER_EXTS
+
+
+# ------------------------------------------------- PAMT index resolution
+
+def _index_over(tmp_path, monkeypatch, entry_names):
+    """Build a _get_pamt_index over a fake 0008 holding ``entry_names``."""
+    from cdumm.engine import json_patch_handler as jph
+
+    cdmods_root = tmp_path / "CDMods"
+    game_dir = tmp_path / "game"
+    (game_dir / "0008").mkdir(parents=True)
+    (game_dir / "0008" / "0.pamt").write_bytes(b"\x00")
+    (game_dir / "0008" / "0.paz").write_bytes(b"\x00")
+    cdmods_root.mkdir(parents=True)
+
+    monkeypatch.setattr(jph, "parse_pamt", lambda pamt_path, paz_dir: [
+        _FakeEntry(path=n, paz_file=str(Path(paz_dir) / "0.paz"))
+        for n in entry_names])
+    monkeypatch.setattr(jph, "get_cdmods_root",
+                        lambda config, gdir: cdmods_root)
+    jph._pamt_index_cache.clear()
+    return jph, game_dir
+
+
+POST_UPDATE = [
+    "gamedata/iteminfo.staticinfobody",
+    "gamedata/iteminfo.staticinfoheader",
+    "gamedata/dropsetinfo.staticinfobody",
+]
+
+
+@pytest.mark.parametrize("lookup,expected", [
+    # What every mod on Nexus declares.
+    ("gamedata/iteminfo.pabgb", "gamedata/iteminfo.staticinfobody"),
+    ("gamedata/iteminfo.pabgh", "gamedata/iteminfo.staticinfoheader"),
+    ("gamedata/dropsetinfo.pabgb", "gamedata/dropsetinfo.staticinfobody"),
+    # Format 3 mods target by bare basename.
+    ("iteminfo.pabgb", "gamedata/iteminfo.staticinfobody"),
+    # The real post-update name still resolves to itself.
+    ("gamedata/iteminfo.staticinfobody", "gamedata/iteminfo.staticinfobody"),
+])
+def test_find_pamt_entry_resolves_legacy_names_after_the_rename(
+        tmp_path, monkeypatch, lookup, expected):
+    jph, game_dir = _index_over(tmp_path, monkeypatch, POST_UPDATE)
+    entry = jph._find_pamt_entry(lookup, game_dir)
+    assert entry is not None, (
+        f"{lookup!r} did not resolve - this is the 2026-09-04 "
+        f"APPLY_SILENT_FAILURE regression")
+    assert entry.path == expected
+
+
+def test_find_pamt_entries_lists_the_aliased_entry(tmp_path, monkeypatch):
+    """The twin-retry pool (#167) must see the entry under either name."""
+    jph, game_dir = _index_over(tmp_path, monkeypatch, POST_UPDATE)
+    got = jph._find_pamt_entries("gamedata/iteminfo.pabgb", game_dir)
+    assert [e.path for e in got][:1] == ["gamedata/iteminfo.staticinfobody"]
+
+
+def test_basename_collision_still_prefers_the_lowest_numbered_dir(
+        tmp_path, monkeypatch):
+    """GitHub #99 guard: the game ships iteminfo twice (gamedata/ in
+    0008, ui/ in 0072). Aliasing must not disturb first-seen-wins."""
+    from cdumm.engine import json_patch_handler as jph
+
+    cdmods_root = tmp_path / "CDMods"
+    game_dir = tmp_path / "game"
+    for d in ("0008", "0072"):
+        (game_dir / d).mkdir(parents=True)
+        (game_dir / d / "0.pamt").write_bytes(b"\x00")
+        (game_dir / d / "0.paz").write_bytes(b"\x00")
+    cdmods_root.mkdir(parents=True)
+
+    def fake_parse(pamt_path, paz_dir):
+        name = ("gamedata/iteminfo.staticinfobody"
+                if Path(paz_dir).name == "0008"
+                else "ui/iteminfo.staticinfobody")
+        return [_FakeEntry(path=name,
+                           paz_file=str(Path(paz_dir) / "0.paz"))]
+
+    monkeypatch.setattr(jph, "parse_pamt", fake_parse)
+    monkeypatch.setattr(jph, "get_cdmods_root",
+                        lambda config, gdir: cdmods_root)
+    jph._pamt_index_cache.clear()
+
+    e = jph._find_pamt_entry("iteminfo.pabgb", game_dir)
+    assert e is not None
+    assert e.path == "gamedata/iteminfo.staticinfobody"
+    assert Path(e.paz_file).parent.name == "0008"
+
+
+def test_superseded_index_caches_are_removed(tmp_path, monkeypatch):
+    """The v4 bump strands ~1 GB of v3 pickles per CDMods root."""
+    jph, game_dir = _index_over(tmp_path, monkeypatch, POST_UPDATE)
+    cdmods = tmp_path / "CDMods"
+    stale = cdmods / ".pamt_index_v3_vanilla.cache"
+    stale.write_bytes(b"junk")
+    (cdmods / ".pamt_index.cache").write_bytes(b"junk")
+    unrelated = cdmods / "cdumm.db"
+    unrelated.write_bytes(b"keep me")
+
+    jph._get_pamt_index(game_dir)
+
+    assert not stale.exists()
+    assert not (cdmods / ".pamt_index.cache").exists()
+    assert unrelated.read_bytes() == b"keep me"
+    assert list(cdmods.glob(".pamt_index*.cache"))
+
+
+def test_sweep_keeps_the_sibling_current_version_caches(
+        tmp_path, monkeypatch):
+    """One CDMods root holds a vanilla cache AND one per game install.
+
+    Sweeping everything but the file being written would evict the
+    other dir's still-valid cache on every call, so vanilla and game
+    would take turns rebuilding a multi-million-key index (~9s each)
+    on every Apply.
+    """
+    jph, game_dir = _index_over(tmp_path, monkeypatch, POST_UPDATE)
+    cdmods = tmp_path / "CDMods"
+    ver = jph._PAMT_INDEX_CACHE_VERSION
+    sibling = cdmods / f".pamt_index_{ver}_vanilla.cache"
+    sibling.write_bytes(b"a valid current-version cache")
+
+    jph._get_pamt_index(game_dir)
+
+    assert sibling.exists(), (
+        "the sweep evicted a current-version cache for another directory")
+    assert sibling.read_bytes() == b"a valid current-version cache"
+
+
+# ------------------------------------------------- downstream name users
+
+def test_identify_table_from_path_accepts_the_new_name():
+    from cdumm.semantic.parser import identify_table_from_path
+    assert identify_table_from_path("gamedata/iteminfo.staticinfobody") == \
+        identify_table_from_path("gamedata/iteminfo.pabgb")
+    # A header is not a body and must not be mistaken for the table.
+    assert identify_table_from_path(
+        "gamedata/iteminfo.staticinfoheader") is None
+
+
+def test_byte_merge_is_still_allowed_on_renamed_tables():
+    """Two mods editing one table must byte-merge, not fall to last-wins."""
+    from cdumm.engine.apply_engine import _entry_supports_byte_merge
+    assert _entry_supports_byte_merge("gamedata/iteminfo.staticinfobody")
+    assert _entry_supports_byte_merge("gamedata/iteminfo.staticinfoheader")
+    assert _entry_supports_byte_merge("gamedata/iteminfo.pabgb")
+    assert not _entry_supports_byte_merge("ui/texture/foo.dds")
+
+
+def test_conflict_detector_matches_a_declared_target_to_a_renamed_entry():
+    from cdumm.engine.conflict_detector import ConflictDetector as CD
+    assert CD._entry_matches("iteminfo.pabgb",
+                             "gamedata/iteminfo.staticinfobody")
+    assert not CD._entry_matches("storeinfo.pabgb",
+                                 "gamedata/iteminfo.staticinfobody")


### PR DESCRIPTION
Fixes #400. The 2026-09-04 client update renamed every game-data table container: `gamedata/<table>.pabgh` and `.pabgb` are now `gamedata/<table>.staticinfoheader` and `.staticinfobody`. There is not a single `.pabgb` entry left in any of the install's 34 PAMTs. The containers themselves did not change — feeding the new `.staticinfoheader` blobs to `parse_pabgh_index` returns the same key size, record count and offsets, every one of them resolving inside its companion body — so this is a rename and nothing more.

Every mod on Nexus, every Format 3 document and every row already sitting in a user's CDMods library still names its target `<table>.pabgb`, so `_find_pamt_entry` missed on all of them. Mount-time patching logged "no PAMT entry for 'gamedata/dropsetinfo.pabgb' in vanilla or live", the Format 3 pipeline logged "vanilla extraction failed for iteminfo.pabgb; skipping", import rejected mods with "the target files couldn't be located in your game's PAZ archives", and Apply finished with APPLY_SILENT_FAILURE telling users their mods were outdated. #401 fixes the stuck state that failure leaves behind; this fixes the failure itself.

The two namings are now aliases of each other. `cdumm.archive.table_ext` owns the mapping and `_get_pamt_index` registers every table entry under both names, so a lookup in either naming resolves; the sibling-header lookups, the overlay builder's companion include, byte-merge eligibility, Format 3 target dispatch, conflict detection and table identification follow from there. CDUMM keeps `.pabgb` and `.pabgh` as its internal names because that is what mods speak, while overlay entries are still written under whatever name the live PAMT actually carries, so a patched table lands where the game looks for it. The reporter's `binarystaticinfo__/bin/` layout, where the tables also changed directory, is already covered by basename resolution.

The index cache is bumped to v4 so it rebuilds once. Superseded cache files are now deleted rather than left behind as harmless leftovers: a live-game index pickles to around 600 MB and the vanilla snapshot to around 340 MB, so the old policy was stranding nearly a gigabyte per CDMods root. The sweep keys on the cache version rather than on the single file it is about to write, so the vanilla and per-install caches never evict each other.

Verified against a 2.0 install: iteminfo, storeinfo, dropsetinfo, inventory, characterinfo and skill all resolve and extract again, and Max Inventory Storage matches 11 of 11 patches against vanilla where it previously found no target at all. One mod in that test set stays skipped for an unrelated reason — Trust Me 10x's dropsetinfo record grew by eight bytes in the update and it carries no signature to re-anchor from, so it genuinely needs a new release from its author.
