### PR TITLE
Inspect Mod: recognise plural-targets Format 3 instead of calling it unsupported

### DIFF
--- a/src/cdumm/engine/mod_diagnostics.py
+++ b/src/cdumm/engine/mod_diagnostics.py
@@ -16,6 +16,29 @@ from pathlib import Path
 
 from cdumm.archive.table_ext import BODY_EXTS, header_path_for
 
+
+def _parse_format3_pairs(member: str, mod_path: Path):
+    """``[(target, intents), ...]`` for a Format 3 member of ``mod_path``,
+    or None when the importer would not accept it either.
+
+    The parser takes a path, so the member is spilled to a temp file.
+    Worth it: shape-testing the dict here is what let this report and
+    the importer disagree in the first place.
+    """
+    import tempfile
+
+    from cdumm.engine.format3_handler import parse_format3_mod_targets
+    try:
+        with zipfile.ZipFile(mod_path) as zf:
+            raw = zf.read(member)
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / Path(member).name
+            p.write_bytes(raw)
+            return parse_format3_mod_targets(p) or None
+    except Exception as e:  # noqa: BLE001 - a report must never crash
+        logger.debug("format3 diagnose parse failed for %s: %s", member, e)
+        return None
+
 logger = logging.getLogger(__name__)
 
 
@@ -138,18 +161,34 @@ def _diagnose_archive(mod_path: Path, game_dir: Path, db_path: Path,
                 detected.append("json_patch")
                 _s(f"Detected: JSON Patch mod ({jf})")
                 _diagnose_json_patch(data, jf, game_dir, sections)
-            elif (isinstance(data, dict)
-                    and data.get("format") == 3
-                    and isinstance(data.get("intents"), list)
-                    and isinstance(data.get("target"), str)):
-                detected.append("natt_format_3")
-                n_intents = len(data.get("intents", []))
-                target = data.get("target", "?")
-                _s(f"Detected: Format 3 mod ({jf}), "
-                   f"target {target}, {n_intents} intent(s)")
-                _s("  Note: Format 3 needs a field_schema/<table>.json "
-                   "mapping to apply. See field_schema/README.md "
-                   "next to CDUMM3.exe.")
+            elif isinstance(data, dict) and data.get("format") == 3:
+                # Ask the real parser instead of shape-testing here.
+                # This branch used to require a top-level ``target``
+                # string plus ``intents`` list, which is only the
+                # SINGULAR dialect. Every multi-target export (the
+                # plural ``targets`` shape almost all current mods
+                # ship) fell through to "No recognized mod format
+                # detected", so Inspect Mod called a perfectly
+                # importable mod unsupported: woowoots hit it on Dye
+                # Hard CD2.00.02 while the same file imported fine.
+                # Routing through parse_format3_mod_targets is what
+                # keeps this report and the importer from drifting
+                # apart again.
+                pairs = _parse_format3_pairs(jf, mod_path)
+                if pairs is not None:
+                    detected.append("natt_format_3")
+                    total = sum(len(i) for _t, i in pairs)
+                    _s(f"Detected: Format 3 mod ({jf}), "
+                       f"{len(pairs)} target(s), {total} intent(s)")
+                    for tname, tintents in pairs:
+                        _s(f"  {tname}: {len(tintents)} intent(s)")
+                    # Conditional now, not absolute: many tables have a
+                    # native writer and need no schema at all. Saying
+                    # otherwise sent authors chasing a file they did not
+                    # need (see #259, where that advice was unactionable).
+                    _s("  Note: a target CDUMM has no writer for needs a "
+                       "field_schema/<table>.json mapping. See "
+                       "field_schema/README.md next to CDUMM3.exe.")
             elif isinstance(data, dict) and "files_dir" in data:
                 detected.append("crimson_browser")
                 _s(f"Detected: Crimson Browser mod ({jf})")

--- a/tests/test_diagnose_format3_plural_targets.py
+++ b/tests/test_diagnose_format3_plural_targets.py
@@ -1,0 +1,74 @@
+"""GitHub #400 follow-up (woowoots): Inspect Mod reported "No recognized
+mod format detected" for Dye Hard CD2.00.02, a Format 3 mod that imports
+and applies fine.
+
+The detector required a top-level ``target`` string plus ``intents``
+list, which is only the SINGULAR dialect. Every multi-target export (the
+plural ``targets`` shape current mods ship) fell through to the
+unsupported branch, so the report called a working mod broken.
+
+It now asks parse_format3_mod_targets, the same parser the importer
+uses, so the two cannot drift apart again.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from cdumm.engine.mod_diagnostics import _parse_format3_pairs
+
+PLURAL = {
+    "modinfo": {"version": "CD2.00.02"},
+    "format": 3, "format_minor": 1,
+    "targets": [
+        {"file": "npcinfo.pabgb", "intents": [
+            {"entry": "n", "key": 1, "field": "dye_color_group_data_list",
+             "op": "set", "new": []},
+            {"entry": "n", "key": 1, "field": "dye_texture_set_data_list",
+             "op": "set", "new": []},
+        ]},
+        {"file": "storeinfo.pabgb", "intents": [
+            {"entry": "s", "key": 2, "field": "reset_day", "op": "set", "new": 1},
+        ]},
+    ],
+}
+
+SINGULAR = {
+    "format": 3, "target": "iteminfo.pabgb",
+    "intents": [{"entry": "i", "key": 3, "field": "price", "op": "set", "new": 1}],
+}
+
+
+def _zip(tmp_path: Path, name: str, payload) -> Path:
+    z = tmp_path / "mod.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr(name, json.dumps(payload))
+    return z
+
+
+def test_plural_targets_are_recognised(tmp_path):
+    z = _zip(tmp_path, "DyeHard_CD2.00.02.json", PLURAL)
+    pairs = _parse_format3_pairs("DyeHard_CD2.00.02.json", z)
+    assert pairs is not None, "plural Format 3 must not read as unsupported"
+    assert {t for t, _i in pairs} == {"npcinfo.pabgb", "storeinfo.pabgb"}
+    assert sum(len(i) for _t, i in pairs) == 3
+
+
+def test_singular_dialect_still_recognised(tmp_path):
+    z = _zip(tmp_path, "m.json", SINGULAR)
+    pairs = _parse_format3_pairs("m.json", z)
+    assert pairs is not None
+    assert [t for t, _i in pairs] == ["iteminfo.pabgb"]
+
+
+def test_non_format3_json_returns_none(tmp_path):
+    z = _zip(tmp_path, "m.json", {"patches": [{"offset": 0}]})
+    assert _parse_format3_pairs("m.json", z) is None
+
+
+def test_malformed_json_never_raises(tmp_path):
+    z = tmp_path / "mod.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("m.json", "{not json")
+    assert _parse_format3_pairs("m.json", z) is None

--- a/tests/test_multifile_mod_partial_skip.py
+++ b/tests/test_multifile_mod_partial_skip.py
@@ -63,6 +63,7 @@ def test_multi_file_mod_skips_one_failed_file_keeps_others():
     from cdumm.engine.snapshot_manager import SnapshotManager
     from cdumm.storage.database import Database
     from cdumm.archive.paz_parse import parse_pamt
+    from cdumm.archive.table_ext import to_legacy_name
     from cdumm.engine.json_patch_handler import _extract_from_paz
 
     game_dir = Path(r'E:\SteamLibrary\steamapps\common\Crimson Desert')
@@ -72,7 +73,7 @@ def test_multi_file_mod_skips_one_failed_file_keeps_others():
     pamt = game_dir / '0008' / '0.pamt'
     entries = parse_pamt(str(pamt), paz_dir=str(pamt.parent))
     iteminfo = next(e for e in entries
-                    if e.path == 'gamedata/iteminfo.pabgb')
+                    if to_legacy_name(e.path) == 'gamedata/iteminfo.pabgb')
     iteminfo_bytes = bytes(_extract_from_paz(iteminfo))
     # Pick any 4-byte window we can match exactly.
     file_a_offset = 100
@@ -84,7 +85,7 @@ def test_multi_file_mod_skips_one_failed_file_keeps_others():
     # multi-patch-group iteration.
     # Actually use a different game_file: vehicleinfo.pabgb in 0008.
     vehicleinfo = next((e for e in entries
-                        if e.path == 'gamedata/vehicleinfo.pabgb'), None)
+                        if to_legacy_name(e.path) == 'gamedata/vehicleinfo.pabgb'), None)
     if vehicleinfo is None:
         pytest.skip("vehicleinfo.pabgb not in 0008/")
 

--- a/tests/test_multifile_skip_surfaces_to_user.py
+++ b/tests/test_multifile_skip_surfaces_to_user.py
@@ -29,6 +29,7 @@ def test_partial_skip_populates_info_field_on_result():
     from cdumm.engine.snapshot_manager import SnapshotManager
     from cdumm.storage.database import Database
     from cdumm.archive.paz_parse import parse_pamt
+    from cdumm.archive.table_ext import to_legacy_name
     from cdumm.engine.json_patch_handler import _extract_from_paz
     import zipfile, json
 
@@ -39,7 +40,7 @@ def test_partial_skip_populates_info_field_on_result():
     pamt = game_dir / '0008' / '0.pamt'
     entries = parse_pamt(str(pamt), paz_dir=str(pamt.parent))
     iteminfo = next(e for e in entries
-                    if e.path == 'gamedata/iteminfo.pabgb')
+                    if to_legacy_name(e.path) == 'gamedata/iteminfo.pabgb')
     iteminfo_bytes = bytes(_extract_from_paz(iteminfo))
     file_a_offset = 100
     file_a_orig = iteminfo_bytes[file_a_offset:file_a_offset+4].hex()
@@ -103,6 +104,7 @@ def test_clean_import_no_skipped_files_keeps_info_none():
     from cdumm.engine.snapshot_manager import SnapshotManager
     from cdumm.storage.database import Database
     from cdumm.archive.paz_parse import parse_pamt
+    from cdumm.archive.table_ext import to_legacy_name
     from cdumm.engine.json_patch_handler import _extract_from_paz
     import zipfile, json
 
@@ -113,7 +115,7 @@ def test_clean_import_no_skipped_files_keeps_info_none():
     pamt = game_dir / '0008' / '0.pamt'
     entries = parse_pamt(str(pamt), paz_dir=str(pamt.parent))
     iteminfo = next(e for e in entries
-                    if e.path == 'gamedata/iteminfo.pabgb')
+                    if to_legacy_name(e.path) == 'gamedata/iteminfo.pabgb')
     iteminfo_bytes = bytes(_extract_from_paz(iteminfo))
     off = 100
     orig = iteminfo_bytes[off:off+4].hex()


### PR DESCRIPTION
Follow-up to #400. Inspect Mod reported "No recognized mod format detected" for Dye Hard CD2.00.02, a mod the importer accepts and applies without complaint.

The detector required a top-level `target` string plus `intents` list, which is only the singular dialect. The plural `targets` shape that nearly every current mod ships fell straight through to the unsupported branch.

It now calls `parse_format3_mod_targets`, the same parser the importer uses, so the report cannot disagree with the importer again, and it lists each target with its intent count. The `field_schema` pointer stays but is now conditional: many tables have a native writer and need no schema at all, and the absolute wording is what made that advice unactionable in #259.

Also repoints three live-game test lookups at `to_legacy_name`. #402 aliased production code for the 4 September table rename but left these tests matching `gamedata/iteminfo.pabgb` exactly, so on an updated install they raised `StopIteration`. CI never saw it because it has no live game dir.

Tests: 4 new (plural recognised, singular still recognised, non-Format-3 returns None, malformed JSON never raises). Full suite 3170 passed, 1 known machine-local failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr