### PR TITLE
extract_field_order_win: treat the instruction after a conditional branch as a block leader

### DIFF
--- a/tests/test_extract_field_order_win.py
+++ b/tests/test_extract_field_order_win.py
@@ -170,6 +170,75 @@ def test_hot_key_is_a_total_order_within_one_cold_block():
     assert func.hot_key(a) < func.hot_key(b)
 
 
+def _build_inline_function():
+    """Two consecutive fields whose error blocks are NOT outlined.
+
+    This is the shape that swapped ``_itemDesc`` and ``_itemDesc2`` on
+    the live exe. Both errors sit inline, so field 0's block is a
+    fall-through after its own ``jne`` while field 1's block is the
+    ``jne`` target and therefore has an inbound edge. Add one backward
+    branch into the entry block and field 0 keys on that branch, which
+    sits after field 1's key, and the two come out reversed::
+
+        1000  test al, al
+        1002  jne  1010            <- field 1's block gets this inbound
+        1004  lea  rax, [rip+..]   <- field 0's error message
+        100B  jmp  1030
+        1010  test al, al          <- field 1 starts here
+        1012  jne  1020
+        1014  lea  rax, [rip+..]   <- field 1's error message
+        101B  jmp  1030
+        1020  jmp  1000            <- the stale inbound edge on 0x1000
+        1030  ret
+
+    Returns ``(blob, base_va, [lea0, lea1])``.
+    """
+    base = _BASE
+    b = bytearray()
+    b += b"\x84\xc0"                                    # 1000 test al, al
+    b += b"u\x0c"                                        # 1002 jne 1010
+    b += b"H\x8d\x05" + struct.pack("<i", 0x900)        # 1004 lea rax
+    b += b"\xe9" + struct.pack("<i", 0x20)               # 100B jmp 1030
+    b += b"\x84\xc0"                                    # 1010 test al, al
+    b += b"u\x0c"                                        # 1012 jne 1020
+    b += b"H\x8d\x05" + struct.pack("<i", 0x900)        # 1014 lea rax
+    b += b"\xe9" + struct.pack("<i", 0x10)               # 101B jmp 1030
+    b += b"\xe9" + struct.pack("<i", -0x25)              # 1020 jmp 1000
+    b += b"\x90" * 11                                    # 1025 padding
+    b += b"\xc3"                                         # 1030 ret
+    return bytes(b), base, [base + 0x04, base + 0x14]
+
+
+def test_an_inline_error_block_starts_its_own_block():
+    """The leader that was missing: the instruction after a conditional.
+
+    Without it field 0's lea is folded into the entry block, picks up
+    whatever branches into that block, and sorts by an address that has
+    nothing to do with the field.
+    """
+    blob, base, leas = _build_inline_function()
+    func = sweep_bytes(blob, base)
+
+    # The bug is present in the input: something does branch back into
+    # the entry block, and that edge is later than field 1's key.
+    assert base in func.inbound, (
+        "the synthetic function no longer models the stale inbound edge "
+        "that made this misorder possible")
+    assert min(func.inbound[base]) > min(func.inbound[base + 0x10])
+
+    # Each lea now leads its own block, so neither inherits that edge.
+    assert func.block_start_of(leas[0]) == leas[0]
+    assert func.block_start_of(leas[1]) == leas[1]
+    assert leas[0] not in func.inbound and leas[1] not in func.inbound
+
+
+def test_hot_path_order_survives_two_inline_error_blocks():
+    """The user-visible half of the same fact: the order comes out right."""
+    blob, base, leas = _build_inline_function()
+    func = sweep_bytes(blob, base)
+    assert sorted(range(2), key=lambda i: func.hot_key(leas[i])) == [0, 1]
+
+
 # ── against the real binary (skips without a game install) ────────────────
 
 def _game_exe() -> Path | None:

--- a/tools/extract_field_order_win.py
+++ b/tools/extract_field_order_win.py
@@ -296,7 +296,17 @@ def sweep_bytes(blob: bytes, lo: int) -> Func:
                 if lo <= t < hi:
                     targets.add(t)
                     f.inbound.setdefault(t, []).append(ins.address)
-        if m in _UNCOND_END:
+        # A conditional branch ends a block too, so the instruction after
+        # it starts one. Without this leader an inline (non-outlined)
+        # error block is folded into whatever block precedes the field's
+        # own "jne ok", and hot_key then orders it by a branch that has
+        # nothing to do with the field. That is what swapped _itemDesc
+        # and _itemDesc2 on ItemInfo: _itemDesc's lea sits in the
+        # fall-through at 0x14147CE47, which was attributed to the block
+        # at 0x14147CE2D and keyed on an inbound edge at 0x14147CE5D,
+        # while _itemDesc2's outlined block keyed on 0x14147CE45 and
+        # sorted ahead of it.
+        if m in _UNCOND_END or m.startswith("j"):
             nxt = ins.address + ins.size
             if lo <= nxt < hi:
                 targets.add(nxt)


### PR DESCRIPTION
Closes #407.

`sweep_bytes` marked a new basic block at every branch target and after every unconditional terminator, but not at the fall-through of a conditional branch. An error block that was **not** outlined lives exactly there, so it got folded into whatever block preceded the field's own `jne ok`, and `hot_key` then ordered that field by an inbound edge belonging to a different block.

That is the `_itemDesc` / `_itemDesc2` swap from #407. On buildid 25116796:

```
_itemDesc   lea=0x14147CE47 block=0x14147CE2D inbound=[0x14147CE5D]  -> key CE5D
_itemDesc2  lea=0x14147CE72 block=0x14147CE5F inbound=[0x14147CE45]  -> key CE45
```

`_itemDesc`'s lea is a fall-through, attributed to the block at CE2D and keyed on a later branch into it. `_itemDesc2`'s block is the target of `_itemDesc`'s own `jne` at CE45, so it keyed on CE45 and sorted ahead. With the leader added, each lea starts its own block, neither inherits a stale edge, and both fall back to their own address, which is already in sequence.

**Measured on the same exe:** tables whose extracted order disagrees with the verified order drop from 10 to 6.

| | before | after |
|---|---|---|
| ItemInfo (101 shared, the oracle) | diverges at 15 | **matches** |
| CraftToolInfo, GameAdviceInfo, JobInfo, MaterialBloodDecalInfo, RegionInfo | diverge | **match** |
| CharacterInfo, ContentsPhaseInfo, FactionOperationGroupInfo, StageInfo | diverge | diverge, unchanged |
| AIEventTableInfo, QuestGaugeInfo | match | diverge |

The last row is a real trade and I am not hiding it. Both are small tables (10 and 13 shared fields) whose verified order is not pinned by byte-exact round-trip the way ItemInfo's is, so which side is wrong there is not established. It is written up in #407 rather than resolved by picking whichever answer makes the count look better.

Two new tests, both synthetic and both running in CI without a game install: one pins the missing leader directly (each inline lea starts its own block and inherits no stale inbound edge), one pins the resulting order. Reverting the one-line change fails both, plus the real-exe test that started this.

No shipped code path changes: `tools/` is analysis-only and nothing under `src/cdumm` imports it, so there is no release to cut for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr
