### PR TITLE
schemas: correct two field orders derived before the block-leader fix

### DIFF
--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -2152,7 +2152,7 @@
     }
   },
   "AIEventTableInfo": {
-    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class AIEventTableInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 988 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'aieventtableinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class AIEventTableInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 988 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'aieventtableinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked. CORRECTED 2026-09-08: _eventDelayType and _isSequencerInterruptEvent were in the wrong order here. The derivation ordered fields by the hot-path branch reaching each error block, and that rule was missing a basic-block leader at the fall-through of a conditional branch, so an inline error block was attributed to the preceding block and keyed on an inbound edge belonging to something else (see GitHub #407). The byte-consumption proof quoted above cannot catch this: both orders consume the same total, so the walk still ends on the record's last byte either way. Three independent checks agree on the corrected order: the deserializer reads 8 bytes into +0x38 guarded at 0x1414651F3 with _eventDelayType's message and 1 byte into +0x41 with _isSequencerInterruptEvent's, matching the declared u64 and u8; corrected, _isSequencerInterruptEvent reads 0 or 1 on all 1003 records and _eventDelayType reads 0, 1 or 2, while the old order gave the boolean a value of 2 and the enum 72057594037927936, which is 1 shifted into the top byte.",
     "_no_null_skip": true,
     "_ordered_fields": [
       "_isBlocked",
@@ -2161,8 +2161,8 @@
       "_reactionLevel",
       "_allowTypeFlag",
       "_eventType",
-      "_isSequencerInterruptEvent",
       "_eventDelayType",
+      "_isSequencerInterruptEvent",
       "_isTargetMustExist",
       "_isMustHandled"
     ],
@@ -2457,7 +2457,7 @@
     }
   },
   "QuestGaugeInfo": {
-    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class QuestGaugeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 509 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'questgaugeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked.",
+    "_meta_note": "Derived 2026-08-13 from game buildid 24613230 by tools/derive_table_layout.py, reflection class QuestGaugeInfo. Field ORDER comes from the exe's reflection error strings ordered by the hot-path branch that reaches each error block. Field WIDTHS come from the sized reads in the deserializer; count-prefixed list ELEMENT widths come from the loop body via Deriver.list_element (validated against the 8 readers stage 2 had independently pinned from table data: 5 reproduced exactly, 2 correctly reported variable-length, 1 abstained, 0 contradictions). PROOF: the walk consumes every one of this table's 509 records to its exact last byte, and no other shape in the format's grammar does. KEYED BY FILE STEM 'questgaugeinfo' because that is what identify_table_from_path returns and what get_schema is asked for; the class name would resolve to a key the app never looks up on this table. _stringKey/_key are omitted because the entry header consumes them. _verified_fields is EMPTY on purpose: tiling proves the structure and each field's offset, NOT what any field means, so nothing here may be presented as fact or written to until its values are cross-checked. CORRECTED 2026-09-08: _percent and _gaugeTime were in the wrong order here. The derivation ordered fields by the hot-path branch reaching each error block, and that rule was missing a basic-block leader at the fall-through of a conditional branch, so an inline error block was attributed to the preceding block and keyed on an inbound edge belonging to something else (see GitHub #407). The byte-consumption proof quoted above cannot catch this: both orders consume the same total, so the walk still ends on the record's last byte either way. Three independent checks agree on the corrected order: the deserializer reads 8 bytes into +0x78 guarded at 0x14148320D with _percent's message and 4 bytes into +0x80 with _gaugeTime's, matching the declared u64 and u32; _percent then reads 0 to 1000000 over 10 values with 1000000 as the ceiling, the shape of a fixed-point percent, and _gaugeTime reads 259200, exactly 72 hours; under the old order _percent held 1113255523123200.",
     "_no_null_skip": true,
     "_ordered_fields": [
       "_isBlocked",
@@ -2469,8 +2469,8 @@
       "_excludeStageInfoList",
       "_factionInfoList",
       "_factionNodeInfoList",
-      "_gaugeTime",
       "_percent",
+      "_gaugeTime",
       "_gaugeType",
       "_progressDataList"
     ],

--- a/tests/test_ordered_fields_inline_error_block_swap.py
+++ b/tests/test_ordered_fields_inline_error_block_swap.py
@@ -1,0 +1,151 @@
+"""Two verified orders had a pair of fields the wrong way round.
+
+``QuestGaugeInfo`` and ``AIEventTableInfo`` were derived on 2026-08-13 by
+``tools/derive_table_layout.py``, which ordered fields by the hot-path
+branch that reaches each field's error block. That rule was missing a
+basic-block leader at the fall-through of a conditional branch, so an
+inline (not outlined) error block folded into the block before the
+field's own ``jne ok`` and got keyed on an inbound edge belonging to
+something else. GitHub #407 fixed the rule; these two orders are the
+fallout of having been derived before it.
+
+WHY THE ORIGINAL PROOF DID NOT CATCH IT
+---------------------------------------
+Both entries quote a byte-consumption proof: the walk consumes every
+record to its exact last byte. That is true of the wrong order too. The
+swapped fields are fixed-width primitives, so the pair consumes the same
+total either way (12 bytes on QuestGaugeInfo, 9 on AIEventTableInfo) and
+the walk still lands on the final byte. Byte consumption cannot see a
+same-total swap, which is why this needs a value-domain test rather than
+another decode check.
+
+WHAT PINS THE CORRECTED ORDER
+-----------------------------
+Three independent things, all on buildid 25116796.
+
+1. The deserializer itself. QuestGaugeInfo reads 8 bytes into ``+0x78``
+   guarded at 0x14148320D with ``_percent``'s message, then 4 bytes into
+   ``+0x80`` with ``_gaugeTime``'s. AIEventTableInfo reads 8 bytes into
+   ``+0x38`` guarded at 0x1414651F3 with ``_eventDelayType``'s message,
+   then 1 byte into ``+0x41`` with ``_isSequencerInterruptEvent``'s.
+2. The declared widths agree with those reads: u64 then u32, u64 then u8.
+3. The values, which is what this file tests. They are checked on the
+   installed game rather than a fixture because neither table has one.
+"""
+from __future__ import annotations
+
+import json
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+from cdumm.engine.schema_verify import verified_order
+
+_SCHEMAS = Path(__file__).resolve().parents[1] / "schemas"
+
+
+def _order(cls: str) -> list[str]:
+    over = json.loads((_SCHEMAS / "pabgb_type_overrides.json")
+                      .read_text(encoding="utf-8-sig"))
+    return over[cls]["_ordered_fields"]
+
+
+def test_questgaugeinfo_reads_percent_before_gauge_time():
+    o = _order("QuestGaugeInfo")
+    assert o.index("_percent") < o.index("_gaugeTime")
+
+
+def test_aieventtableinfo_reads_delay_type_before_the_interrupt_flag():
+    o = _order("AIEventTableInfo")
+    assert o.index("_eventDelayType") < o.index("_isSequencerInterruptEvent")
+
+
+def test_the_loaded_schema_agrees_with_the_override_file():
+    """The override is only worth anything if the walker actually uses it."""
+    assert (verified_order("questgaugeinfo").index("_percent")
+            < verified_order("questgaugeinfo").index("_gaugeTime"))
+    assert (verified_order("aieventtableinfo").index("_eventDelayType")
+            < verified_order("aieventtableinfo")
+            .index("_isSequencerInterruptEvent"))
+
+
+# ── against the installed game (skips without one) ───────────────────────
+
+def _game_dir() -> Path | None:
+    env = os.environ.get("CDUMM_GAME_DIR")
+    if env and (Path(env) / "bin64").is_dir():
+        return Path(env)
+    for root in ("C:", "D:", "E:", "F:"):
+        for lib in ("SteamLibrary", "Steam"):
+            p = Path(f"{root}/{lib}/steamapps/common/Crimson Desert")
+            if (p / "bin64").is_dir():
+                return p
+    return None
+
+
+def _values(game: Path, table: str, wanted: set[str]) -> dict[str, list[int]]:
+    from cdumm.engine.schema_verify import _consume_field_bytes, _payload_offset, _schema_in_order
+    from cdumm.engine.v2_to_format3 import _load_vanilla_table
+    from cdumm.semantic.parser import parse_pabgh_index
+
+    body = _load_vanilla_table(game, table + ".pabgb")
+    header = _load_vanilla_table(game, table + ".pabgh")
+    schema = _schema_in_order(table, verified_order(table))
+    key_size, offs = parse_pabgh_index(header, table)
+    entries = sorted(offs.items(), key=lambda kv: kv[1])
+    out: dict[str, list[int]] = {name: [] for name in wanted}
+    for i, (_key, off0) in enumerate(entries):
+        end = entries[i + 1][1] if i + 1 < len(entries) else len(body)
+        po = _payload_offset(body, off0, key_size,
+                             no_null_skip=schema.no_null_skip,
+                             no_entry_header=schema.no_entry_header)
+        if po is None:
+            continue
+        off = po
+        for f in schema.fields:
+            c = _consume_field_bytes(body, off, f, end)
+            if c is None:
+                break
+            if f.name in wanted:
+                out[f.name].append(
+                    struct.unpack_from("<" + f.struct_fmt, body, off)[0])
+            off += c
+    return out
+
+
+@pytest.mark.slow
+def test_questgauge_values_are_coherent_on_the_installed_game():
+    """``_percent`` tops out at 1000000 and ``_gaugeTime`` reads 259200.
+
+    A fixed-point percent whose ceiling is 1,000,000, and a duration of
+    exactly 72 hours. Under the old order ``_percent`` held
+    1113255523123200, which is what a u64 read across the wrong boundary
+    looks like.
+    """
+    game = _game_dir()
+    if game is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_DIR)")
+    v = _values(game, "questgaugeinfo", {"_percent", "_gaugeTime"})
+    assert v["_percent"], "no records decoded"
+    assert max(v["_percent"]) == 1_000_000
+    assert 259_200 in v["_gaugeTime"]
+    assert max(v["_gaugeTime"]) <= 259_200
+
+
+@pytest.mark.slow
+def test_aievent_values_are_coherent_on_the_installed_game():
+    """The boolean reads as a boolean and the enum stays small.
+
+    Under the old order the boolean took a value of 2 and the enum took
+    72057594037927936, which is 1 shifted into the top byte of a u64.
+    """
+    game = _game_dir()
+    if game is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_DIR)")
+    v = _values(game, "aieventtableinfo",
+                {"_isSequencerInterruptEvent", "_eventDelayType"})
+    assert v["_isSequencerInterruptEvent"], "no records decoded"
+    assert set(v["_isSequencerInterruptEvent"]) <= {0, 1}
+    assert max(v["_eventDelayType"]) <= 2

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -1090,7 +1090,16 @@ class Deriver:
                     and o[0].type == CS_OP_IMM):
                 targets.add(o[0].imm)
                 inbound[o[0].imm].append(i.address)
-            if i.mnemonic in _UNCOND_END:
+            # A conditional branch ends a block too, so the instruction
+            # after it leads one. Without this leader an inline (not
+            # outlined) error block folds into the block before the
+            # field's own "jne ok" and gets keyed on that block's inbound
+            # edges, which belong to something else entirely. That is what
+            # put _percent after _gaugeTime on QuestGaugeInfo and
+            # _isSequencerInterruptEvent before _eventDelayType on
+            # AIEventTableInfo in the 2026-08-13 derivation. Same fix as
+            # extract_field_order_win.sweep_bytes (GitHub #407).
+            if i.mnemonic in _UNCOND_END or i.mnemonic.startswith("j"):
                 targets.add(i.address + i.size)
         blocks = sorted(targets | {addrs[0]})
         set_addrs = set(addrs)


### PR DESCRIPTION
Follow-on from #408. Two of the six tables tracked in #409 turn out to be schema bugs, not extraction bugs, and this fixes them.

`QuestGaugeInfo` had `_gaugeTime` before `_percent`; `AIEventTableInfo` had `_isSequencerInterruptEvent` before `_eventDelayType`. Both orders were derived on 2026-08-13 by `tools/derive_table_layout.py`, whose ordering rule carried the same missing basic-block leader that #408 fixed in `extract_field_order_win`. So the two tables that appeared to regress in #408 were not regressions: the extractor started telling the truth and the schema did not.

**Why the original proof missed it.** Both entries quote a byte-consumption proof, that the walk consumes every record to its exact last byte. That holds for the wrong order too. The swapped fields are fixed-width primitives, so the pair consumes the same total either way (12 bytes on QuestGaugeInfo, 9 on AIEventTableInfo) and the walk still lands on the final byte. `decode_score` gives both orders 100% of records complete. Byte consumption is blind to a same-total swap.

**Three independent checks on the corrected order**, all on buildid 25116796:

1. The deserializer. QuestGaugeInfo reads 8 bytes into `+0x78` guarded at `0x14148320D` with `_percent`'s message, then 4 bytes into `+0x80` with `_gaugeTime`'s. AIEventTableInfo reads 8 bytes into `+0x38` guarded at `0x1414651F3` with `_eventDelayType`'s message, then 1 byte into `+0x41` with `_isSequencerInterruptEvent`'s.
2. The declared widths match those reads: u64 then u32, u64 then u8.
3. The values, over the live tables:

| field | old order | corrected |
|---|---|---|
| `_percent` (u64) | max 1113255523123200, 2 distinct | 0 to 1000000, 10 distinct |
| `_gaugeTime` (u32) | 0 to 1000000 | 0 or 259200, exactly 72 hours |
| `_isSequencerInterruptEvent` (u8) | 0, 1 **or 2** | 0 or 1 on all 1003 records |
| `_eventDelayType` (u64) | 0 or 72057594037927936 | 0, 1 or 2 |

`1000000` as the ceiling of a fixed-point percent, `259200` as a 72 hour duration, a boolean that is actually boolean, and an enum that is actually small. `72057594037927936` is `1` shifted into the top byte of a u64, which is what the misaligned read produces.

Also fixes the deriver's own copy of the block-leader rule so a future derivation does not reintroduce this.

Tables whose extracted order disagrees with the verified order drop from **6 to 4**. The remaining four stay in #409.

Five tests. Three run in CI: the two override orders, and that the loaded schema actually reflects them. Two are marked slow and check the value domains above against an installed game.

Full suite: 3,223 passed. The one failure is `test_script_import_consent_gate`, a long-standing local-only failure unrelated to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr
