### PR TITLE
schemas: gate StageInfo, whose layout is wrong past _sequencerDesc

### DIFF
--- a/schemas/pabgb_type_overrides.json
+++ b/schemas/pabgb_type_overrides.json
@@ -645,8 +645,15 @@
     }
   },
   "StageInfo": {
-    "_meta_note": "82 fields ported from NattKh stageinfo_parser.py. Field _sequencerDesc (#7) has an optional-object variant (flag=1) NattKh's parser can't decode; entries with that variant fail cleanly via the StageInfo_SequencerDescOptObj tagged variant.",
+    "_meta_note": "82 fields ported from NattKh stageinfo_parser.py. Field _sequencerDesc (#7) has an optional-object variant (flag=1) NattKh's parser can't decode; entries with that variant fail cleanly via the StageInfo_SequencerDescOptObj tagged variant. GATED 2026-09-08: _verified_fields added, covering only the five fields the exe read sequence confirms. The deserializer at 0x141488903 reads _isBlocked (1 byte, +0x10), then _name (+0x18), _stageDesc (+0x38) and _completeLog (+0x58) through reader 0x141231470, then _sequencerDesc (+0x78) through 0x14228E9D0 -- all matching this order. It then reads THREE fields this schema does not contain at all: _spawnFactionSpawnDataInfo (+0x168), _spawnFactionNodeInfo (+0x16A) and _disableFactionSpawnPartyNameHashList (+0x170). Only after those does it reach _stageCategory, and it reads EIGHT stream bytes for it where this schema declares u32. So every field from _stageCategory onward is misaligned, which is why the walk reaches 0% of 51,861 records complete and stalls on _closeCondition. Corroborating: the exe also puts _closeFilterByGroup (+0x188) before _stageDataType (+0x1A9, read as ONE byte, not the declared u32) before _fieldInfo (+0x21C, a sub-reader, not a scalar), against this order which has them at 20, 6 and 7. The gate stops the grid presenting those values as fact and stops a Format 3 mod writing to them at an offset that is not proven. Re-deriving the table needs the six variable-length list element readers that tools/derive_table_layout.py reports it cannot fit; see GitHub #409.",
     "_no_null_skip": true,
+    "_verified_fields": [
+      "_isBlocked",
+      "_name",
+      "_stageDesc",
+      "_completeLog",
+      "_sequencerDesc"
+    ],
     "_ordered_fields": [
       "_isBlocked",
       "_name",

--- a/tests/test_stageinfo_verified_gate.py
+++ b/tests/test_stageinfo_verified_gate.py
@@ -1,0 +1,75 @@
+"""StageInfo is misaligned past ``_sequencerDesc``, so it is gated.
+
+The schema was ported from an upstream parser rather than derived from
+the game, and the exe disagrees with it structurally, not by a swap.
+Reading the deserializer at 0x141488903 on buildid 25116796:
+
+* ``_isBlocked`` (1 byte, ``+0x10``), then ``_name`` (``+0x18``),
+  ``_stageDesc`` (``+0x38``) and ``_completeLog`` (``+0x58``) through
+  reader 0x141231470, then ``_sequencerDesc`` (``+0x78``) through
+  0x14228E9D0. Those five match this schema's order.
+* It then reads THREE fields the schema does not contain at all:
+  ``_spawnFactionSpawnDataInfo`` (``+0x168``), ``_spawnFactionNodeInfo``
+  (``+0x16A``) and ``_disableFactionSpawnPartyNameHashList``
+  (``+0x170``).
+* Only then does it reach ``_stageCategory``, and it reads EIGHT stream
+  bytes where the schema declares ``u32``.
+
+So everything from ``_stageCategory`` onward sits at an offset that is
+not proven, which is why the walk reaches 0% of 51,861 records complete.
+
+``_verified_fields`` is the existing mechanism for exactly this: the grid
+renders ungated fields as ``(unverified)`` rather than a possibly-wrong
+number, and ``format3_apply`` refuses to write to them, so a mod cannot
+land a value on the wrong byte. Gating is the honest state until the
+table is re-derived. That re-derivation is blocked on the six
+variable-length list element readers ``tools/derive_table_layout.py``
+reports it cannot fit (GitHub #409).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cdumm.semantic.parser import get_schema
+
+_SCHEMAS = Path(__file__).resolve().parents[1] / "schemas"
+_EXPECTED = ["_isBlocked", "_name", "_stageDesc", "_completeLog",
+             "_sequencerDesc"]
+
+
+def _override() -> dict:
+    return json.loads((_SCHEMAS / "pabgb_type_overrides.json")
+                      .read_text(encoding="utf-8-sig"))["StageInfo"]
+
+
+def test_stageinfo_vouches_only_for_the_five_confirmed_fields():
+    assert _override()["_verified_fields"] == _EXPECTED
+
+
+def test_the_gate_reaches_the_loaded_schema():
+    """An override nothing reads would be decoration."""
+    vf = get_schema("stageinfo").verified_fields
+    assert vf is not None, "StageInfo lost its verified-only gate"
+    assert set(vf) == set(_EXPECTED)
+
+
+def test_the_misaligned_fields_are_not_vouched_for():
+    """The named evidence, pinned so a future widening has to face it."""
+    vf = get_schema("stageinfo").verified_fields
+    for name in ("_stageCategory", "_stageDataType", "_fieldInfo",
+                 "_closeFilterByGroup", "_closeCondition"):
+        assert name not in vf, (
+            f"{name} was vouched for, but the exe reads it at an offset "
+            f"this schema does not produce")
+
+
+def test_gating_did_not_drop_any_field_from_the_order():
+    """The gate is a display and write guard, not a schema truncation.
+
+    Dropping a field from ``_ordered_fields`` would shift every later
+    field's offset, which is the failure CONSENSUS-1 guards against in
+    the loader. The order must stay whole.
+    """
+    assert len(_override()["_ordered_fields"]) == 81
+    assert len(get_schema("stageinfo").fields) == 81


### PR DESCRIPTION
Resolves the StageInfo half of #409, though not the way I expected going in.

I set out to re-derive StageInfo's field order. What the exe actually shows is that the disagreement was never an ordering question. StageInfo's order was ported from an upstream parser rather than derived from the game, and the two disagree structurally. Reading the deserializer at `0x141488903` on buildid 25116796:

| field | struct offset | how it is read |
|---|---|---|
| `_isBlocked` | `+0x10` | 1 byte |
| `_name` | `+0x18` | reader `0x141231470` |
| `_stageDesc` | `+0x38` | reader `0x141231470` |
| `_completeLog` | `+0x58` | reader `0x141231470` |
| `_sequencerDesc` | `+0x78` | reader `0x14228E9D0` |
| `_spawnFactionSpawnDataInfo` | `+0x168` | **not in this schema** |
| `_spawnFactionNodeInfo` | `+0x16A` | **not in this schema** |
| `_disableFactionSpawnPartyNameHashList` | `+0x170` | **not in this schema** |
| `_stageCategory` | stack temp | **8 stream bytes**, schema declares `u32` |

Five fields match, then the exe reads three fields the schema does not contain at all, then reads eight bytes for a field the schema calls four. Everything from `_stageCategory` onward sits at an offset that is not proven.

That explains two things that did not add up before. The walk reaches **0% of 51,861 records complete** and stalls on `_closeCondition`. And the reorder I tried last pass scored *worse* (median 17 against 24) rather than better, which it would not have done if a swap were the problem.

Corroborating, further down the same function: `_closeFilterByGroup` (`+0x188`) is read before `_stageDataType` (`+0x1A9`, **one** byte, not the declared `u32`) before `_fieldInfo` (`+0x21C`, a sub-reader, not a scalar), against a schema placing them at 20, 6 and 7.

**What this PR does.** It gates StageInfo with `_verified_fields`, listing the five the exe confirms. That is not cosmetic: the grid renders ungated fields as `(unverified)` instead of a possibly-wrong number, and `format3_apply` refuses to write to them, so a Format 3 mod can no longer land a value on a byte whose offset is not proven. Before this, 76 unproven columns were presented as fact and were writable.

Nothing is removed from `_ordered_fields`. Dropping a field would shift every later offset, which is exactly what the loader's CONSENSUS-1 guard exists to catch, so the order stays whole at 81 and one test pins that.

**What it does not do.** It does not fix StageInfo. A real re-derivation is blocked: running `tools/derive_table_layout.py --tables stageinfo` reports six list element readers it cannot fit because they are variable-length (`4 + n`, `16 + n`, `10 + n`, `8 + n` shapes), and it proves 0 tables as a result. That needs the walker's grammar extended before StageInfo can be derived. Left in #409 with the reader addresses.

Four tests, all running in CI without a game install: the gate contents, that the loaded schema actually reflects it, that the specific misaligned fields are not vouched for, and that the order was not truncated.

Full suite: 3,228 passed. The one failure is `test_script_import_consent_gate`, a long-standing local-only failure unrelated to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
