### PR TITLE
derive_table_layout: the variable-element shape is expressible, say so

### DIFF
--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -1631,9 +1631,21 @@ def main(argv: list[str] | None = None) -> int:
         # exactly the HouseInfo / FailMessageInfo bug: it can tile 100% of
         # records and still be wrong, because the strings in one build happen
         # to share a length.
+        # The shape IS expressible, and saying otherwise sends the next
+        # reader off to build support that already exists. `_apply` carries
+        # it as ('slist', n), and semantic/pabgb_types.consume_bytes walks
+        # CArray<T>, [T;N] and named sub-structs, so a per-element fixed
+        # prefix followed by a string has a descriptor. What is missing is
+        # that `candidates` never OFFERS an slist, so stage 2 cannot fit
+        # one. Measured 2026-09-08: adding slist to the candidate space
+        # changes nothing on its own (0 tables proven either way over
+        # stageinfo plus 11 other undecoded tables), because the tables
+        # that need it are blocked earlier -- stageinfo, for one, is
+        # missing three fields the exe reads (GitHub #409). Offering the
+        # shape is necessary but not sufficient; do not ship it alone.
         print(f"list elements that are VARIABLE-length ({len(variable)}) -- "
-              f"no constant width may be fitted for these; the shape is not "
-              f"in the walker's grammar, so the honest result is unresolved:")
+              f"no constant width may be fitted for these, and `candidates` "
+              f"offers no variable-element shape, so these stay unresolved:")
         for c, s in sorted(variable.items()):
             print(f"   sub_{c:X}  {s}")
 


### PR DESCRIPTION
Comment-only, from working the variable-length list elements left in #409.

The refusal message claimed the shape is not in the walker's grammar. It is:

* `_apply` in this same file already carries it as `('slist', n)`.
* `semantic/pabgb_types.consume_bytes` walks `CArray<T>`, `[T;N]` and named sub-structs, so a per-element fixed prefix followed by a string has a descriptor: `CArray<S>` where `S` is `[u8;n]` then `CString`.

What is actually missing is narrower: `candidates` never offers an slist, so stage 2 has no way to fit one. The message as written would send whoever picks this up next to build support that already exists, which is why it is worth correcting even though nothing else changes.

**I wrote the candidate-space change, measured it, and reverted it.** Offering `('slist', n)` for statically-variable elements, with `_apply` honouring `n` as the element's fixed prefix, proved **0 tables with it and 0 without**, over `stageinfo` plus 11 other undecoded tables (`collectioninfo`, `actionpointinfo`, `boardinfo`, `buffinfo`, `aidialogstringinfo`, `aidialogtextdata`, `actioncamerashakedesc`, `playeractionlimitdesc`, `actionrestrictionorderinfo`, `houseinfo`, `failmessageinfo`, `gimmickinfo`; 7 of them loaded from the install). Identical output either way.

The reason is that the tables needing the shape are blocked earlier. StageInfo is missing three fields the exe reads (`_spawnFactionSpawnDataInfo` at `+0x168`, `_spawnFactionNodeInfo` at `+0x16A`, `_disableFactionSpawnPartyNameHashList` at `+0x170`, all established in #412), so no element model can make it tile no matter how correct.

Offering the shape is necessary but not sufficient, and shipping it alone would have been a change that looks right and does nothing. The note in the code now says so, with the measurement, so the next attempt starts from the real blocker instead of repeating this.

No behavior change, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171WFoHWQThdDZkKhrbnCGr
