### PR TITLE
Launch: name the RUNASADMIN flag instead of blaming Steam

### DIFF
--- a/src/cdumm/gui/fluent_window.py
+++ b/src/cdumm/gui/fluent_window.py
@@ -6933,7 +6933,24 @@ class CdummWindow(FluentWindow):
                 title=tr("main.game_launched"), content=tr("main.game_launched_msg"),
                 duration=3000, position=InfoBarPosition.TOP, parent=self)
             self._hide_for_game_launch()
-        except Exception:
+        except Exception as launch_exc:
+            # WinError 740 is "the requested operation requires
+            # elevation", raised by Popen when the exe carries the
+            # RUNASADMIN compatibility flag. It has nothing to do with
+            # Steam, so the Steam message below sends the user to check
+            # a client that is running fine (ombre03, GitHub #415, who
+            # tried every launch method in turn). The bug report already
+            # detects this flag; the launch path now names it too.
+            if getattr(launch_exc, "winerror", None) == 740:
+                logger.info(
+                    "Launch failed with WinError 740 (needs elevation); "
+                    "exe likely has the RUNASADMIN compatibility flag: %s",
+                    exe)
+                InfoBar.error(
+                    title=tr("infobar.launch_failed"),
+                    content=tr("main.launch_failed_needs_elevation"),
+                    duration=10000, position=InfoBarPosition.TOP, parent=self)
+                return
             if steam:
                 # Could not reach Steam. Spawning the bare exe here
                 # would silently fail under Themida + Denuvo and the

--- a/src/cdumm/translations/de.json
+++ b/src/cdumm/translations/de.json
@@ -943,6 +943,7 @@
   "tray.quit": "CDUMM beenden",
   "tray.hidden_msg": "Während des Spielens ausgeblendet. Klicke auf das Tray-Symbol, um CDUMM zurückzuholen.",
   "main.launch_failed_steam_not_running": "Steam ist nicht erreichbar. Stelle sicher, dass der Steam-Client läuft, und versuche dann erneut, das Spiel zu starten. Crimson Desert braucht die Steam-Laufzeitumgebung, ein direkter Start der Exe funktioniert daher nicht.",
+  "main.launch_failed_needs_elevation": "Windows hat den Start verweigert, weil CrimsonDesert.exe als Administrator ausgefuehrt werden soll. Rechtsklick auf CrimsonDesert.exe, Eigenschaften, Reiter Kompatibilitaet, dort \"Programm als Administrator ausfuehren\" abwaehlen und dann erneut Spiel starten. Das ist kein Steam-Problem.",
   "main.launch_failed_xbox_not_running": "Die Xbox-App ist nicht erreichbar. Stelle sicher, dass sie installiert und angemeldet ist, und versuche dann erneut, das Spiel zu starten.",
   "main.no_mods_in_file": "Keine Mods in der Datei gefunden.",
   "main.snapshot_failed": "Snapshot fehlgeschlagen",

--- a/src/cdumm/translations/en.json
+++ b/src/cdumm/translations/en.json
@@ -943,6 +943,7 @@
   "tray.quit": "Quit CDUMM",
   "tray.hidden_msg": "Hidden during gameplay. Click the tray icon to bring CDUMM back.",
   "main.launch_failed_steam_not_running": "Could not reach Steam. Make sure the Steam client is running, then try Launch Game again. Crimson Desert needs the Steam runtime, so launching the bare exe will not work.",
+  "main.launch_failed_needs_elevation": "Windows refused to start the game because CrimsonDesert.exe is set to run as administrator. Right-click CrimsonDesert.exe, open Properties, go to the Compatibility tab and uncheck \"Run this program as an administrator\", then try Launch Game again. This is not a Steam problem.",
   "main.launch_failed_xbox_not_running": "Could not reach the Xbox app. Make sure it is installed and signed in, then try Launch Game again.",
   "main.no_mods_in_file": "No mods found in the file.",
   "main.snapshot_failed": "Snapshot Failed",

--- a/src/cdumm/translations/fr.json
+++ b/src/cdumm/translations/fr.json
@@ -983,5 +983,6 @@
   "mod_list.click_to_update": "Cliquer pour mettre à jour",
   "tooltip.update_available_with_version": "Mise à jour disponible. Installé : {version}. Cliquer pour mettre à jour.",
   "settings.nexus_none_linked": "Aucun de vos {count} mods n'est lié à une page NexusMods, donc aucun ne peut être vérifié. Les mods importés depuis une archive téléchargée manuellement n'ont pas de lien Nexus ; réimportez-les via le téléchargement Nexus ou ajoutez le lien sur la carte du mod.",
-  "settings.nexus_up_to_date_partial": "{checked} mod(s) lié(s) sont à jour. {unlinked} mod(s) sans lien NexusMods n'ont pas pu être vérifiés."
+  "settings.nexus_up_to_date_partial": "{checked} mod(s) lié(s) sont à jour. {unlinked} mod(s) sans lien NexusMods n'ont pas pu être vérifiés.",
+  "main.launch_failed_needs_elevation": "Windows a refuse de lancer le jeu parce que CrimsonDesert.exe est configure pour s'executer en tant qu'administrateur. Clic droit sur CrimsonDesert.exe, Proprietes, onglet Compatibilite, decochez \"Executer ce programme en tant qu'administrateur\", puis relancez le jeu. Ce n'est pas un probleme Steam."
 }

--- a/tests/test_launch_elevation_error_is_named.py
+++ b/tests/test_launch_elevation_error_is_named.py
@@ -1,0 +1,72 @@
+"""GitHub #415 (ombre03): a launch blocked by RUNASADMIN blamed Steam.
+
+``_on_launch_game`` spawns the exe directly for a non-storefront
+install, and for a Steam install when ``steam_launch_method`` is
+``exe``. When ``CrimsonDesert.exe`` carries the RUNASADMIN
+compatibility flag, Windows refuses that spawn with **WinError 740,
+"the requested operation requires elevation"**. The old handler caught
+it in the blanket ``except`` and, for a Steam install, showed
+``main.launch_failed_steam_not_running`` -- telling the user to check a
+Steam client that was running perfectly well.
+
+ombre03 reported exactly that loop: every launch method tried, same
+outcome, no mention of the real cause. The flag was sitting in his own
+bug report the whole time, because ``gui/bug_report.py`` already detects
+it. The launch path now names it too.
+
+The check is on the source rather than a live Qt launch because
+``_on_launch_game`` needs a constructed main window, a database and a
+game directory. What matters is the branch order: the WinError 740 test
+must come BEFORE the Steam branch, or the Steam message wins again.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_KEY = "main.launch_failed_needs_elevation"
+
+
+def _launch_body() -> str:
+    src = (_ROOT / "src" / "cdumm" / "gui"
+           / "fluent_window.py").read_text(encoding="utf-8")
+    start = src.index("def _on_launch_game")
+    nxt = src.index("\n    def ", start + 1)
+    return src[start:nxt]
+
+
+def test_winerror_740_is_handled_at_all():
+    body = _launch_body()
+    assert "740" in body, (
+        "the launch handler no longer special-cases WinError 740, so an exe "
+        "with RUNASADMIN set will be reported as some other failure")
+    assert _KEY in body
+
+
+def test_the_elevation_check_runs_before_the_steam_message():
+    """Order is the whole fix. Steam-first would mask it again."""
+    body = _launch_body()
+    assert body.index("740") < body.index(
+        "main.launch_failed_steam_not_running"), (
+        "the WinError 740 branch must be tested before the Steam branch, "
+        "otherwise a Steam install still reports 'could not reach Steam'")
+
+
+def test_the_message_names_the_compatibility_flag_not_steam():
+    """The text has to send the user somewhere that helps."""
+    en = json.loads((_ROOT / "src" / "cdumm" / "translations" / "en.json")
+                    .read_text(encoding="utf-8"))
+    msg = en[_KEY].lower()
+    assert "administrator" in msg
+    assert "compatibility" in msg
+    assert "crimsondesert.exe" in msg
+    assert "not a steam problem" in msg
+
+
+def test_every_parity_locale_carries_the_key():
+    """en and de are the pair tests/test_i18n_key_parity.py enforces."""
+    for lang in ("en", "de"):
+        d = json.loads((_ROOT / "src" / "cdumm" / "translations"
+                        / f"{lang}.json").read_text(encoding="utf-8"))
+        assert _KEY in d, f"{lang}.json is missing {_KEY}"


### PR DESCRIPTION
Fixes the misleading half of #415.

`_on_launch_game` spawns the exe directly for a non-storefront install, and for a Steam install when `steam_launch_method` is `exe`. When `CrimsonDesert.exe` carries the RUNASADMIN compatibility flag, Windows refuses that spawn with **WinError 740, "the requested operation requires elevation"**. The blanket `except` caught it and, for a Steam install, showed `main.launch_failed_steam_not_running`, which sends the user to check a Steam client that is running perfectly well.

ombre03 hit exactly that loop in #415: Steam URI, then `-applaunch`, then Game exe (skip Steam), same outcome each time, nothing naming the real cause. His own bug report had it at the top the whole time, since `gui/bug_report.py` already detects the flag:

```
1. Game exe has RUNASADMIN set in Windows compatibility flags — this causes
   WINerror 740 and blocks drag-drop.
...
Game Exe Compat Flags: RUNASADMIN
```

Only the launch path stayed quiet about it.

**The change.** Test `winerror == 740` before the Steam and Xbox branches, and show a message naming the flag and where to clear it. Branch order is the whole fix: Steam-first masks it again, and one of the tests pins the ordering rather than just the presence of the check.

Translations for `en`, `de` (the pair `tests/test_i18n_key_parity.py` enforces) and `fr`, since ombre03 runs CDUMM in French.

Four tests, all in CI, all four failing with the change reverted.

Full suite: 3,232 passed. The one failure is `test_script_import_consent_gate`, a long-standing local-only failure unrelated to this.

**What this does not do.** It does not explain why ombre03's game stopped launching, and I have said so on the issue rather than implying otherwise. His verify state reads 224 of 224 files matching the snapshot, so his install is already back to vanilla and CDUMM is not holding modified files. What his Steam client reports after that is outside what this repo can answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
