### PR TITLE
derive_table_layout: pin variable-element lists from the loop body

### DIFF
--- a/tests/test_derive_variable_list_element.py
+++ b/tests/test_derive_variable_list_element.py
@@ -1,0 +1,69 @@
+"""Variable-element lists are pinned from the loop body, not searched.
+
+``list_element`` already works out that a reader's element is "16 + n",
+meaning 12 bytes then a CString. Stage 1b used to report that and stop,
+so every such reader stayed unresolved and any table using one could
+never tile. It now pins ``('slist', n)`` with that base.
+
+The base comes from the loop body, exactly like the fixed-element base
+pinned one line above it in the same function. It is NOT searched against
+table data: searching is what produced the wrong constants shipped for
+HouseInfo (``CArray<[u8;46]>``) and FailMessageInfo (``CArray<[u8;33]>``),
+where every element string in the measured build happened to be one
+length.
+
+Measured on stageinfo (GitHub #409) when this landed: readers pinned from
+the loop body went from 3 to 9, and the record walk reached field 23 of 91
+instead of field 13. That is the same result three passes of proving those
+readers by hand produced one at a time.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+pytest.importorskip("capstone", reason="analysis-only dependency")
+
+from derive_table_layout import Deriver
+
+
+def _apply(blob: bytes, spec):
+    """``_apply`` touches no instance state, so drive it unbound."""
+    return Deriver._apply(None, blob, 0, len(blob), spec)
+
+
+def _slist(base: int, strings: list[bytes]) -> bytes:
+    out = struct.pack("<I", len(strings))
+    for s in strings:
+        out += b"\xAB" * base + struct.pack("<I", len(s)) + s
+    return out
+
+
+def test_slist_zero_base_is_a_carray_of_cstrings():
+    blob = _slist(0, [b"abc", b"", b"defgh"])
+    assert _apply(blob, ("slist", 0)) == len(blob)
+
+
+def test_slist_honours_the_element_prefix():
+    """The whole point: n > 0 must consume n bytes per element."""
+    blob = _slist(12, [b"abc", b"defgh"])
+    assert _apply(blob, ("slist", 12)) == len(blob)
+
+
+def test_the_wrong_base_does_not_land_on_the_end():
+    """A base that is off must fail rather than quietly tile."""
+    blob = _slist(12, [b"abc", b"defgh"])
+    assert _apply(blob, ("slist", 0)) != len(blob)
+
+
+def test_an_empty_list_consumes_only_its_count():
+    assert _apply(struct.pack("<I", 0) + b"junk", ("slist", 12)) == 4
+
+
+def test_a_truncated_element_is_refused_not_guessed():
+    blob = struct.pack("<I", 1) + b"\xAB" * 12 + struct.pack("<I", 99)
+    assert _apply(blob, ("slist", 12)) is None

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -81,6 +81,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import re
 import struct
 import sys
 from bisect import bisect_left, bisect_right
@@ -1251,8 +1252,9 @@ class Deriver:
                                                        LocalizableString
                                                        (which is 13 + n)
           ('list',  n)   u32 count + count * n       -- CArray<fixed>
-          ('slist', 0)   u32 count + count*(u32 len + len)
+          ('slist', n)   u32 count + count*(n + u32 len + len)
                                                      -- CArray<CString>
+                                                        when n == 0
           ('opt',   n)   u8 flag + (n bytes if set)  -- COptional<fixed>
         """
         kind, n = spec
@@ -1283,6 +1285,10 @@ class Deriver:
             if cnt > 100_000:
                 return None
             for _ in range(cnt):
+                # ``n`` is the element's fixed prefix, the bytes before
+                # its string. n == 0 is CArray<CString>; n > 0 is the
+                # "strplus" element stage 1b reports as "16 + n".
+                p += n
                 if p + 4 > end:
                     return None
                 ln = struct.unpack_from("<I", body, p)[0]
@@ -1622,6 +1628,23 @@ def main(argv: list[str] | None = None) -> int:
             d.elem[c] = ("list", el[1])
             static_lists += 1
         else:
+            # A variable element still has a SHAPE, and list_element has
+            # already computed it: "the element is 16 + n" means 12 bytes
+            # then a CString. Pin it as ('slist', base) with that base,
+            # taken from the loop body, NOT searched against table data.
+            # Searching is what produced the HouseInfo and FailMessageInfo
+            # constants; reading the base off the same loop body that
+            # pins a fixed element is the same provenance stage 1b
+            # already trusts one line above.
+            #
+            # Measured on stageinfo (GitHub #409): pinning all six of its
+            # variable lists this way walks the record from field 13 to
+            # field 23, which is exactly what three passes of proving
+            # those readers by hand produced, one at a time.
+            m_el = re.search(r"element is (\d+) \+ n", el[1] or "")
+            if m_el:
+                d.elem[c] = ("slist", int(m_el.group(1)) - 4)
+                static_lists += 1
             variable[c] = el[1]
     print(f"sub-readers: {auto} solved statically, {hand} hand-verified, "
           f"{static_lists} count-prefixed lists pinned from the loop body "
@@ -1644,8 +1667,8 @@ def main(argv: list[str] | None = None) -> int:
         # missing three fields the exe reads (GitHub #409). Offering the
         # shape is necessary but not sufficient; do not ship it alone.
         print(f"list elements that are VARIABLE-length ({len(variable)}) -- "
-              f"no constant width may be fitted for these, and `candidates` "
-              f"offers no variable-element shape, so these stay unresolved:")
+              f"no CONSTANT width may be fitted for these; each is pinned "
+              f"as ('slist', n) from its own loop body instead:")
         for c, s in sorted(variable.items()):
             print(f"   sub_{c:X}  {s}")
 


### PR DESCRIPTION
From #409. Stops me hand-proving one reader per pass and lets the tool do it.

`list_element` already works out that a reader's element is "16 + n", meaning 12 bytes then a CString. Stage 1b printed that and stopped, so every such reader stayed unresolved and any table using one could never tile. It now pins `('slist', n)` with that base, and `_apply` honours `n` instead of ignoring it.

**The base comes from the loop body**, exactly like the fixed-element base pinned one line above it in the same function. It is not searched against table data. Searching is what put `CArray<[u8;46]>` on HouseInfo and `CArray<[u8;33]>` on FailMessageInfo, where every element string in the measured build happened to be one length, and that distinction is the whole reason this is safe to do and that was not.

**Measured on stageinfo:**

| | before | after |
|---|---|---|
| readers pinned from the loop body | 3 | 9 |
| record walk reaches | field 13 of 91 | field 23 of 91 |

Across a ten table batch, pinned readers go from 8 to 29.

That field 13 to 23 jump is the same result three passes of proving those readers by hand produced, one at a time. Doing the remaining 68 fields that way was not a sensible use of anyone's time, which is the argument for putting it in the tool.

**Said plainly: this still proves 0 tables.** stageinfo stays blocked on two readers with no element verdict at all (`sub_141494DB0`, `sub_14149A200`) and on `_sequencerDesc`'s optional-object variant. This is a prerequisite, not the fix, and I am not claiming otherwise.

I withdrew an earlier version of this in #413 because it searched a base and changed nothing measurable. This one reads the base off the loop body and moves the walk ten fields, which is why it ships and that did not.

Five tests, all in CI, no game install needed. One fails with the change reverted: the one asserting a non-zero prefix is actually consumed.

No shipped code path changes, `tools/` is analysis-only, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
