### PR TITLE
Format 3: stop dropping per-intent refusals on whole-table paths

### DIFF
--- a/src/cdumm/engine/format3_apply.py
+++ b/src/cdumm/engine/format3_apply.py
@@ -1204,7 +1204,8 @@ def expand_format3_into_aggregated(
                 pt_changes = 0
                 if passthrough:
                     extra = _intents_to_v2_changes(
-                        target, vanilla_body, vanilla_header, passthrough)
+                        target, vanilla_body, vanilla_header, passthrough,
+                        warnings_out=warnings_out)
                     if extra:
                         pt_changes = len(extra)
                         contrib_ids_pt = list(
@@ -1636,7 +1637,8 @@ def expand_format3_into_aggregated(
                 passthrough = [i for i in batched if not _writer_supported(i)]
                 if passthrough:
                     extra = _intents_to_v2_changes(
-                        target, vanilla_body, vanilla_header, passthrough)
+                        target, vanilla_body, vanilla_header, passthrough,
+                        warnings_out=warnings_out)
                     if extra:
                         contrib_ids_pt = list(
                             whole_table_mod_ids.get(target, []))
@@ -1743,7 +1745,8 @@ def expand_format3_into_aggregated(
                 continue
 
             changes = _intents_to_v2_changes(
-                target, vanilla_body, vanilla_header, batched)
+                target, vanilla_body, vanilla_header, batched,
+                warnings_out=warnings_out)
             if not changes:
                 logger.debug(
                     "Format 3 whole-table writer for %s: %d intent(s) "

--- a/tests/test_format3_warnings_are_threaded.py
+++ b/tests/test_format3_warnings_are_threaded.py
@@ -1,0 +1,61 @@
+"""Every ``_intents_to_v2_changes`` call has to pass ``warnings_out``.
+
+The per-intent writers raise refusals through ``warnings_out``, which
+``expand_format3_into_aggregated`` collects into ``f3_warnings`` and
+``apply_engine`` emits to the GUI as a "Format 3 warning(s)" InfoBar.
+A call site that omits the argument drops every refusal on that path:
+the intents are skipped, nothing is written, and the user is told
+nothing.
+
+Found while working #414. Three of the four call sites omitted it, all
+of them on whole-table branches where intents the whole-table writer
+does not claim fall through to the generic path. The refusals raised
+there could never reach a user.
+
+This is checked on the source rather than by driving an apply, because
+reaching those branches needs a whole-table target, a real vanilla body
+and header, and a mod whose intents split across the writer and the
+passthrough. The property that matters is simple and local: no call
+site forgets the argument.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = (Path(__file__).resolve().parents[1]
+        / "src" / "cdumm" / "engine" / "format3_apply.py")
+
+#: The call plus whatever follows on the next few lines, so a
+#: multi-line call is captured whole.
+_CALL = re.compile(
+    r"_intents_to_v2_changes\((?P<args>[^)]*)\)", re.DOTALL)
+
+
+def _call_sites() -> list[str]:
+    src = _SRC.read_text(encoding="utf-8")
+    # Drop the definition itself; only invocations matter.
+    src = src.replace("def _intents_to_v2_changes(", "def _DEFINITION(")
+    return [m.group("args") for m in _CALL.finditer(src)]
+
+
+def test_there_are_call_sites_to_check():
+    """Guard against the regex silently matching nothing."""
+    assert len(_call_sites()) >= 4
+
+
+def test_every_call_site_passes_warnings_out():
+    missing = [a.strip()[:70] for a in _call_sites()
+               if "warnings_out" not in a]
+    assert not missing, (
+        "these _intents_to_v2_changes call sites drop warnings_out, so "
+        f"refusals raised on those paths never reach the user: {missing}")
+
+
+def test_the_helper_still_accepts_the_argument():
+    """If the parameter is ever renamed, the test above goes green for
+    the wrong reason."""
+    src = _SRC.read_text(encoding="utf-8")
+    i = src.index("def _intents_to_v2_changes(")
+    sig = src[i:src.index(")", i)]
+    assert "warnings_out" in sig

--- a/tests/test_format3_whole_table_carries_target_file.py
+++ b/tests/test_format3_whole_table_carries_target_file.py
@@ -72,7 +72,11 @@ def test_whole_table_change_carries_target_file(tmp_path, monkeypatch):
         "label": "whole_table_merged",
     }
 
-    def fake_intents_to_v2_changes(target, body, header, intents):
+    def fake_intents_to_v2_changes(target, body, header, intents,
+                                   *, warnings_out=None):
+        # Signature has to track the real helper: every call site passes
+        # warnings_out so per-intent refusals reach the user, and a double
+        # that rejects it turns a threading change into a fake failure.
         return [dict(fake_change)]  # always succeed with one merged change
 
     monkeypatch.setattr(fa, "_intents_to_v2_changes",

--- a/tests/test_whole_table_skip_attribution.py
+++ b/tests/test_whole_table_skip_attribution.py
@@ -131,7 +131,10 @@ def test_whole_table_writer_tags_merged_change_with_contributor_ids(tmp_path):
 
     # Whole-table writer collects intents, calls _intents_to_v2_changes
     # ONCE post-loop with the union, returns one merged change.
-    def _stub_intents_to(target, body, header, intents):
+    def _stub_intents_to(target, body, header, intents,
+                         *, warnings_out=None):
+        # Signature tracks the real helper: every call site passes
+        # warnings_out so per-intent refusals reach the user.
         # Confirm we received the batched intents (2 mods worth).
         return [{"label": "iteminfo merged",
                  "offset": 0, "original": "00", "patched": "01"}]


### PR DESCRIPTION
Found while working #414, and worth closing on its own.

The per-intent writers raise refusals through `warnings_out`. `expand_format3_into_aggregated` collects those into `f3_warnings`, and `apply_engine` emits them to the GUI as a "Format 3 warning(s)" InfoBar. That chain only works if every call site passes the argument.

**Three of the four `_intents_to_v2_changes` call sites did not.** Checked against `HEAD`:

```
HEAD call sites: 4   missing warnings_out: 3
    target, vanilla_body, vanilla_header, passthrough
    target, vanilla_body, vanilla_header, passthrough
    target, vanilla_body, vanilla_header, batched
```

All three are whole-table branches, where intents the whole-table writer does not claim fall through to the generic path. A refusal raised there was discarded: the intent was skipped, nothing was written, and the user was told nothing. That is the exact shape of the silent-skip class this project keeps paying for (#285, #302, #329).

**This is not #414's path.** That reporter's mod targets `characterinfo`, which routes through the one call site that did thread it. I am not claiming this fixes his report.

**The test double needed updating, not the assertion.** `test_format3_whole_table_carries_target_file` monkeypatches `_intents_to_v2_changes` with a stub whose signature did not accept the keyword, so threading it turned a green test red for a reason that had nothing to do with the behaviour under test. The stub now tracks the real signature.

Three new tests, all in CI: that call sites exist to check at all (so the regex cannot silently match nothing), that none of them drop the argument, and that the helper still declares the parameter (so a rename cannot turn the first two green for the wrong reason).

Ran `-k "format3 or apply"`: 591 passed after the double was fixed. The nine lint findings in the touched test file are pre-existing and identical at `HEAD`.

No user-visible behaviour changes on paths that were already warning, so no release on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
