### PR TITLE
derive_table_layout: resolve a loop width held in a register

### DIFF
--- a/tests/test_derive_register_hoisted_width.py
+++ b/tests/test_derive_register_hoisted_width.py
@@ -1,0 +1,76 @@
+"""A loop whose element width sits in a register still gets a verdict.
+
+MSVC hoists a literal width out of a loop when every iteration reads the
+same size: `mov ebp, 1` before the loop, `mov r8d, ebp` inside it.
+``field_reads`` already resolved that through ``_const_reg``. The
+loop-body scan in ``list_element`` did not, so those readers came back
+with no verdict at all, and a table using one could never be described.
+
+stageinfo's ``_logoutMercenaryGroupInfoList`` (``sub_141494DB0``) is the
+worked example, GitHub #409. Its body:
+
+    141494DC6  mov  r8d, 4          ; u32 count
+    141494DD3  call [rax+8]
+    141494DFC  cmp  [rsp+0x68], esi ; count == 0 -> done
+    141494E02  mov  ebp, 1          ; the width, hoisted
+    141494E18  mov  r8d, ebp        ; one byte per element
+    141494E1E  call [rax+8]
+    141494E25  movzx edx, byte [rsp+0x50]
+
+so the element is a single byte and the reader is ``CArray<u8>``. The
+``movzx`` afterwards is the decoded value being widened for storage, not
+a second stream read.
+
+``_const_reg`` keeps its unique-or-nothing rule, so this does not become
+a guess: a register written on more than one path still yields nothing.
+``sub_14149A200`` takes its width from ``r15d``, which has no unique
+definition, and correctly stays unresolved.
+
+Checked against the installed game because the input is the shipped
+executable; there is no fixture for a function body.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+pytest.importorskip("capstone", reason="analysis-only dependency")
+pytest.importorskip("pefile", reason="analysis-only dependency")
+
+
+def _game_dir() -> Path | None:
+    env = os.environ.get("CDUMM_GAME_DIR")
+    if env and (Path(env) / "bin64").is_dir():
+        return Path(env)
+    for root in ("C:", "D:", "E:", "F:"):
+        for lib in ("SteamLibrary", "Steam"):
+            p = Path(f"{root}/{lib}/steamapps/common/Crimson Desert")
+            if (p / "bin64").is_dir():
+                return p
+    return None
+
+
+@pytest.fixture(scope="module")
+def deriver():
+    game = _game_dir()
+    if game is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_DIR)")
+    from derive_table_layout import Deriver
+    return Deriver(game)
+
+
+@pytest.mark.slow
+def test_a_hoisted_width_resolves_to_the_element_size(deriver):
+    deriver._memo.clear()
+    assert deriver.list_element(0x141494DB0) == ("fixed", 1)
+
+
+@pytest.mark.slow
+def test_a_width_with_no_unique_definition_still_abstains(deriver):
+    """Unique-or-nothing survives the change; this one must stay unknown."""
+    deriver._memo.clear()
+    assert deriver.list_element(0x14149A200) is None

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -851,6 +851,21 @@ class Deriver:
                          if o[1].mem.base else None)
                     pend = (o[1].mem.disp if b and Frame.q(b) in
                             {Frame.q(z) for z in zeros[n]} else None)
+                elif i.mnemonic == "mov" and o[1].type == CS_OP_REG:
+                    # `mov r8d, ebp` -- MSVC hoists a literal width into a
+                    # callee-saved register when a loop reads the same size
+                    # every iteration, so the constant is defined once
+                    # outside the loop. field_reads already resolves this
+                    # through _const_reg; the loop-body scan did not, and
+                    # dropped the reader to "no verdict" instead.
+                    #
+                    # stageinfo's _logoutMercenaryGroupInfoList
+                    # (sub_141494DB0) is the worked example, GitHub #409:
+                    # `mov ebp, 1` before the loop, `mov r8d, ebp` inside
+                    # it, one byte per element. _const_reg keeps the
+                    # unique-or-nothing rule, so a register written on more
+                    # than one path still yields nothing.
+                    pend = self._const_reg(ins, n, self.md.reg_name(o[1].reg))
                 else:
                     pend = None
             elif (i.mnemonic == "lea" and len(o) == 2 and dst == "rdx"
@@ -912,7 +927,21 @@ class Deriver:
                 # work (`mov r8, qword ptr [rcx + rdx*8]` in sub_14129A5F0
                 # is a hash-bucket pointer). A missing width only matters
                 # where a stream call actually happens, below.
-                pend = o[1].imm if o[1].type == CS_OP_IMM else None
+                #
+                # A register source is resolved the same way field_reads
+                # does it: MSVC hoists a constant width out of the loop
+                # (`mov ebp, 1` outside, `mov r8d, ebp` inside), and
+                # _const_reg returns it only when the register has exactly
+                # one definition in the function. Without this the reader
+                # got no verdict at all, which is how stageinfo's
+                # _logoutMercenaryGroupInfoList sat unresolved (#409).
+                if o[1].type == CS_OP_IMM:
+                    pend = o[1].imm
+                elif i.mnemonic == "mov" and o[1].type == CS_OP_REG:
+                    pend = self._const_reg(
+                        ins, ins.index(i), self.md.reg_name(o[1].reg))
+                else:
+                    pend = None
             elif i.mnemonic == "call" and len(o) == 1:
                 if o[0].type == CS_OP_MEM:
                     if pend is None:


### PR DESCRIPTION
From #409. One of the two readers that had no element verdict at all now has one, read off its own loop body.

MSVC hoists a literal width out of a loop when every iteration reads the same size: `mov ebp, 1` before the loop, `mov r8d, ebp` inside it. `field_reads` already resolved that through `_const_reg`, with a comment explaining that after the `.pdata` sweep it accounted for every remaining unknown. The loop-body scan in `list_element` never got the same treatment, so those readers came back unresolved and nothing downstream could describe them.

**`sub_141494DB0`, stageinfo's `_logoutMercenaryGroupInfoList`:**

```
141494DC6  mov   r8d, 4          ; u32 count
141494E02  mov   ebp, 1          ; the width, hoisted out of the loop
141494E18  mov   r8d, ebp        ; one byte per element
141494E1E  call  [rax+8]
141494E25  movzx edx, byte [rsp+0x50]
```

One byte per element, so `CArray<u8>`. It reports `('fixed', 1)` now. The `movzx` afterwards widens the decoded value for storage and is not a second stream read.

**It stays unique-or-nothing.** `_const_reg` returns a value only when the register has exactly one definition in the function, so a width set on two paths still yields nothing. `sub_14149A200`, the other unresolved reader, takes its width from `r15d`, which has no unique definition, and correctly stays unknown. One of the two tests pins that, so a later change cannot quietly turn abstention into a guess.

**Said plainly: stageinfo still does not tile.** 222 of 260 probe records now stop **at** `_logoutMercenaryGroupInfoList` rather than before reaching any verdict for it. The reader is described and the walk still fails there, which is the next thing to read. I am not calling this more than it is.

Two tests, marked slow because the input is the shipped executable and there is no fixture for a function body.

No shipped code path changes, `tools/` is analysis-only, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
