### PR TITLE
derive_table_layout: keep a multi-string LIST ELEMENT as a sequence

### DIFF
--- a/tests/test_derive_multi_string_reader.py
+++ b/tests/test_derive_multi_string_reader.py
@@ -84,3 +84,36 @@ def test_parts_nest():
     parts = (("fixed", 1), inner, ("str", 0))
     blob = b"\x00" + _s(b"xy") + b"\xAA\xBB" + _s(b"z")
     assert _apply(blob, ("parts", parts)) == len(blob)
+
+
+def test_a_list_of_multi_string_elements_walks_every_element():
+    """``plist``: u32 count, then N elements each an ordered sequence.
+
+    stageinfo's ``_executeTargetStageList`` (``sub_141493A00``) is the
+    worked example, GitHub #409. Its element reader ``sub_14145B100``
+    reads TWO strings plus 12 fixed bytes, and ``solve_reader`` collapses
+    that to ``strplus(12)``. Pinning the sequence instead carried the
+    record walk from field 23 to field 24.
+    """
+    import struct as _s
+    element = (("str", 0), ("str", 0), ("fixed", 4))
+    blob = _s.pack("<I", 2)
+    for a, b in ((b"one", b"two"), (b"", b"xyz")):
+        blob += (_s.pack("<I", len(a)) + a
+                                       + _s.pack("<I", len(b)) + b
+                                       + b"\xAA\xBB\xCC\xDD")
+    assert _apply(blob, ("plist", element)) == len(blob)
+
+
+def test_an_empty_plist_consumes_only_its_count():
+    import struct as _s
+    assert _apply(_s.pack("<I", 0) + b"junk",
+                  ("plist", (("str", 0),))) == 4
+
+
+def test_collapsing_that_element_to_one_string_falls_short():
+    """Why plist exists: slist drops the second string of each element."""
+    import struct as _s
+    blob = _s.pack("<I", 1) + _s.pack("<I", 3) + b"one" + \
+        _s.pack("<I", 3) + b"two" + b"\xAA\xBB\xCC\xDD"
+    assert _apply(blob, ("slist", 12)) != len(blob)

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -780,6 +780,21 @@ class Deriver:
         self._memo[va] = got
         return got
 
+    def element_reader(self, va: int):
+        """The per-element callee of a count-prefixed list reader, or None.
+
+        The first stream-reading immediate call in the body. ``list_element``
+        already locates the loop; this exposes the callee so a caller can ask
+        what ONE element is made of rather than only how wide it is.
+        """
+        from capstone import CS_OP_IMM
+        for i in self.body(va, window=260):
+            if (i.mnemonic == "call" and len(i.operands) == 1
+                    and i.operands[0].type == CS_OP_IMM
+                    and self.reads_stream(i.operands[0].imm)):
+                return i.operands[0].imm
+        return None
+
     def list_element(self, va: int, seen: frozenset | None = None):
         """What ONE element of a count-prefixed list reader consumes.
 
@@ -1287,6 +1302,25 @@ class Deriver:
           ('opt',   n)   u8 flag + (n bytes if set)  -- COptional<fixed>
         """
         kind, n = spec
+        if kind == "plist":
+            # u32 count, then `count` elements each described by an
+            # ordered part sequence. Needed when the element reader holds
+            # MORE THAN ONE string: ('slist', n) expresses exactly one, so
+            # collapsing such an element keeps its fixed total and drops
+            # every string after the first, the same mistake #418 fixed
+            # one level up in the field readers.
+            import struct as _s
+            if p + 4 > end:
+                return None
+            cnt = _s.unpack_from("<I", body, p)[0]
+            p += 4
+            if cnt > 100_000:
+                return None
+            for _ in range(cnt):
+                p = self._apply(body, p, end, ("parts", n))
+                if p is None or p > end:
+                    return None
+            return p
         if kind == "parts":
             # An ordered sequence of members, used when a reader holds
             # MORE THAN ONE string. ('str', n) expresses exactly one, so
@@ -1361,7 +1395,9 @@ class Deriver:
                     return None, name
                 t, base = m
                 # stage-1 models use 'strplus' for "base then a string"
-                if t == "parts":
+                if t == "plist":
+                    spec = ("plist", base)
+                elif t == "parts":
                     spec = ("parts", base)
                 elif t in ("str", "strplus"):
                     spec = ("str", base)
@@ -1701,6 +1737,22 @@ def main(argv: list[str] | None = None) -> int:
             # variable lists this way walks the record from field 13 to
             # field 23, which is exactly what three passes of proving
             # those readers by hand produced, one at a time.
+            # An element whose reader holds MORE THAN ONE string cannot be
+            # described by ('slist', n), which expresses exactly one. Same
+            # mistake as #418 one level down: the collapsed form keeps the
+            # element's fixed total and drops every string after the first.
+            # stageinfo's _executeTargetStageList (sub_141493A00) is the
+            # worked example: its element reader sub_14145B100 reads TWO
+            # strings plus 12 fixed bytes, and solve_reader calls it
+            # strplus(12). Pinning the part sequence instead carried the
+            # record walk from field 23 to field 24 (GitHub #409).
+            er = d.element_reader(c)
+            ep = d.reader_parts(er) if er is not None else None
+            if ep and sum(1 for _k, _v in ep if _k == "str") > 1:
+                d.elem[c] = ("plist", tuple(ep))
+                static_lists += 1
+                variable[c] = el[1]
+                continue
             m_el = re.search(r"element is (\d+) \+ n", el[1] or "")
             if m_el:
                 d.elem[c] = ("slist", int(m_el.group(1)) - 4)


### PR DESCRIPTION
From #409. #418 fixed this for field readers; the same collapse was still happening one level down, for the element of a count-prefixed list.

**`sub_141493A00`, stageinfo's `_executeTargetStageList`.** Its element reader `sub_14145B100` reads:

```
str, str, fixed 4, fixed 4, fixed 1, fixed 1, fixed 1, fixed 1
```

So the element is `20 + a + b`: two length-prefixed strings plus 12 fixed bytes. `solve_reader` summarises it as `strplus(12)`, which is `16 + n`. The fixed total is right and the second string is gone, which is exactly the shape of mistake #418 named.

**How the culprit was identified, rather than guessed.** At the field after it the cursor was one byte short. The `u32` there read **2816** (`0x0B00`) with the following bytes `00 0b 00 00 | 00 40 41 42 43 4b 44 48 45 49 4a 47`. Shifted one byte later it reads **11**, followed by exactly **11 single-byte elements**, which is what `CArray<u8>` should look like. A misread count that becomes coherent under a one-byte shift points at the field before it, not at itself.

Stage 1b now asks the element reader for its part sequence and pins `('plist', parts)` when that sequence holds more than one string. `_apply` gains the shape: `u32 count`, then `count` elements each walked as an ordered sequence.

**Measured on the 260 record probe:** the walk moves from stopping at field 23 to stopping at **field 24**. Readers pinned from the loop body on stageinfo go from 9 to 10.

**Still 0 tables proven.** Field 24 is `_hideMercenaryGroupInfoList`, which uses the same `CArray<u8>` reader as field 23. So one passes and the very next does not, and that is the next thing to read rather than something to assume.

Three new tests, all in CI: a list of two-string elements walks every element, an empty one consumes only its count, and collapsing that element to a single string demonstrably falls short.

No shipped code path changes, `tools/` is analysis-only, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
