### PR TITLE
derive_table_layout: route slist in _consume, and correct two of my own claims

### DIFF
--- a/tests/test_derive_consume_covers_every_shape.py
+++ b/tests/test_derive_consume_covers_every_shape.py
@@ -1,0 +1,71 @@
+"""Every shape ``_apply`` walks must have a branch in ``_consume``.
+
+``_consume`` translates a pinned model into the ``(kind, n)`` spec
+``_apply`` takes. Its final ``else`` produces ``("fixed", base)``, so a
+shape added to ``_apply`` without a matching branch here does not fail
+loudly: it is silently read as a bare ``base`` bytes.
+
+That happened. #417 taught stage 1b to pin ``('slist', n)`` and ``_apply``
+to walk it, and this mapping never got the branch, so a pinned
+variable-element list was consumed as ``n`` bytes with no count, no
+elements and no strings. It made stage 2 disagree with a hand walk that
+mapped the same model correctly, and it flattered the stageinfo probe:
+the walk appeared to reach field 24 while skipping straight past the
+fields it could not really read. With the branch in place it stops at
+field 22, which is the honest position.
+
+This is checked structurally rather than by driving a table, because the
+property is exactly "the two lists agree" and a behavioural test would
+only cover the shapes someone remembered to exercise.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = (Path(__file__).resolve().parents[1]
+        / "tools" / "derive_table_layout.py")
+
+
+def _section(name: str) -> str:
+    src = _SRC.read_text(encoding="utf-8")
+    start = src.index(f"    def {name}(self")
+    nxt = src.index("\n    def ", start + 1)
+    return src[start:nxt]
+
+
+def _apply_kinds() -> set[str]:
+    """Shapes ``_apply`` handles, from its `if kind == "..."` tests."""
+    return set(re.findall(r'kind == "(\w+)"', _section("_apply")))
+
+
+def _consume_kinds() -> set[str]:
+    """Shapes ``_consume`` maps, from its `t == "..."` / `t in (...)` tests."""
+    body = _section("_consume")
+    kinds = set(re.findall(r't == "(\w+)"', body))
+    for group in re.findall(r't in \(([^)]*)\)', body):
+        kinds |= set(re.findall(r'"(\w+)"', group))
+    return kinds
+
+
+def test_both_sides_were_found():
+    """Guard against the regexes quietly matching nothing."""
+    assert len(_apply_kinds()) >= 4
+    assert len(_consume_kinds()) >= 4
+
+
+def test_consume_maps_every_shape_apply_can_walk():
+    # 'fixed' is the documented default of the final else, so it needs no
+    # branch of its own; everything else does.
+    missing = sorted(_apply_kinds() - _consume_kinds() - {"fixed"})
+    assert not missing, (
+        "these shapes are walkable by _apply but have no branch in "
+        f"_consume, so they degrade to ('fixed', base) in silence: "
+        f"{missing}")
+
+
+def test_slist_specifically_is_mapped():
+    """The one that actually got lost. Pinned by name so a refactor that
+    drops it again fails here rather than in a probe months later."""
+    assert "slist" in _apply_kinds()
+    assert "slist" in _consume_kinds()

--- a/tests/test_derive_register_hoisted_width.py
+++ b/tests/test_derive_register_hoisted_width.py
@@ -64,6 +64,17 @@ def deriver():
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    strict=True,
+    reason="Shipped in #420 on a measurement I cannot reproduce. The "
+           "disassembly above is not in doubt: the loop reads one byte "
+           "per element. But on a clean checkout list_element returns "
+           "None here, cold or warm, so the register width is still not "
+           "reaching this verdict by some path the commit did not "
+           "capture. Kept strict and visible rather than deleted or "
+           "softened to `is None`, which would bless behaviour I have "
+           "not shown to be right. CI never caught it: this test is "
+           "slow-marked and CI has no game install. GitHub #409.")
 def test_a_hoisted_width_resolves_to_the_element_size(deriver):
     deriver._memo.clear()
     assert deriver.list_element(0x141494DB0) == ("fixed", 1)

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -1403,6 +1403,20 @@ class Deriver:
                     spec = ("str", base)
                 elif t == "list":
                     spec = ("list", base)
+                elif t == "opt":
+                    # COptional<fixed>. _apply walks it and nothing pins
+                    # it today, but leaving it out is how slist got lost:
+                    # the else below turns an unmapped shape into a bare
+                    # width rather than an error.
+                    spec = ("opt", base)
+                elif t == "slist":
+                    # #417 taught stage 1b to pin ('slist', n) and _apply
+                    # to walk it, but this mapping was never given the
+                    # branch, so a pinned variable-element list was read
+                    # as a BARE n bytes: no count, no elements, no
+                    # strings. Silent and badly wrong, and it made stage
+                    # 2 disagree with a hand walk that mapped it right.
+                    spec = ("slist", base)
                 else:
                     spec = ("fixed", base)
                 p = self._apply(body, p, end, spec)


### PR DESCRIPTION
Two things, both found by chasing #409 into field 24 and both corrections to my own recent work.

**1. `_consume` never routed `slist`, so a pinned list was read as a bare width.**

`_consume` translates a pinned model into the `(kind, n)` spec `_apply` takes. Its final `else` produces `("fixed", base)`, so a shape added to `_apply` without a branch here does not fail loudly. #417 taught stage 1b to pin `('slist', n)` and `_apply` to walk it, and this mapping never got the branch. A pinned variable-element list was therefore consumed as `n` bytes: no count, no elements, no strings.

**That inflated the numbers I reported in the last two passes.** With `slist` routed, the stageinfo probe stops **earlier**, not later:

```
230  stopped at _executeTargetStageList   (field 22)
 14  stopped at _ownerMissionInfo
  4  stopped at _spawnFactionSpawnDataInfo
  4  stopped at _parentStage
  4  stopped at _logoutMercenaryGroupInfoList
  2  stopped at _sequencerDesc
  1  stopped at _childStageList
  1  stopped at _executorMissionList
```

The walk was not reaching field 24. It was stepping over the fields it could not read. Field 22 is the honest position, and I have said so on the issue.

`opt` had the same gap and is mapped now too. Nothing pins it today, but leaving it out is exactly how `slist` was lost.

The new test compares the shapes `_apply` walks against the shapes `_consume` maps, so the next one cannot go missing the same way. `fixed` is excluded as the documented default of the final `else`.

**2. #420 shipped a test I cannot reproduce, now marked `xfail(strict=True)`.**

It asserts `list_element(sub_141494DB0) == ('fixed', 1)`. On a clean checkout it returns `None`, and a bisect over #420, #421 and this branch returns `None` at every one. The measurement I reported when opening #420 was taken against a working tree I cannot reconstruct. CI never caught it because the test is slow-marked and CI has no game install, so it only ever ran locally.

The disassembly in its docstring is not in doubt, `mov ebp, 1` then `mov r8d, ebp` then the read. What is in doubt is that the code reaches that verdict. Marked strict rather than deleted or softened to `is None`, which would bless behaviour I have not shown to be right. Strict means it fails the moment it starts passing, which is what should happen when the real cause turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
