### PR TITLE
Retire #420's xfail: the evidence was read off a neighbouring function

### DIFF
--- a/tests/test_derive_register_hoisted_width.py
+++ b/tests/test_derive_register_hoisted_width.py
@@ -64,20 +64,32 @@ def deriver():
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    strict=True,
-    reason="Shipped in #420 on a measurement I cannot reproduce. The "
-           "disassembly above is not in doubt: the loop reads one byte "
-           "per element. But on a clean checkout list_element returns "
-           "None here, cold or warm, so the register width is still not "
-           "reaching this verdict by some path the commit did not "
-           "capture. Kept strict and visible rather than deleted or "
-           "softened to `is None`, which would bless behaviour I have "
-           "not shown to be right. CI never caught it: this test is "
-           "slow-marked and CI has no game install. GitHub #409.")
-def test_a_hoisted_width_resolves_to_the_element_size(deriver):
+def test_that_reader_abstains_because_the_loop_is_not_its_own(deriver):
+    """The #420 claim was read off a neighbouring function. It is wrong.
+
+    ``0x141494DB0`` is not the start of its own function. ``.pdata`` puts
+    it inside the range ``0x141494CF0`` to ``0x141494DF9``, and the loop
+    quoted in #420, at ``0x141494E10`` onward, is past that end. Those
+    instructions belong to a different fragment, so the `mov ebp, 1` /
+    `mov r8d, ebp` pair says nothing about this reader.
+
+    That is precisely the failure ``.pdata`` anchoring exists to prevent,
+    and this module's own docstring warns about: a fixed window runs off
+    a short function into whatever follows and attributes the
+    neighbour's loops to it. My #420 measurement came from a window that
+    did exactly that.
+
+    So the honest assertion is the abstention. ``body`` stops at the real
+    end, sees no sized stream read, and ``list_element`` returns None
+    rather than inventing a width. GitHub #409.
+    """
+    lo, hi = deriver.function_extent(0x141494DB0)
+    assert (lo, hi) == (0x141494CF0, 0x141494DF9)
+    assert not (lo <= 0x141494E1E < hi), (
+        "the loop #420 quoted must lie OUTSIDE this function, or this "
+        "test is arguing against something that is no longer true")
     deriver._memo.clear()
-    assert deriver.list_element(0x141494DB0) == ("fixed", 1)
+    assert deriver.list_element(0x141494DB0) is None
 
 
 @pytest.mark.slow

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -874,12 +874,21 @@ class Deriver:
                     # through _const_reg; the loop-body scan did not, and
                     # dropped the reader to "no verdict" instead.
                     #
+                    # NOTE: the worked example first given for this,
                     # stageinfo's _logoutMercenaryGroupInfoList
-                    # (sub_141494DB0) is the worked example, GitHub #409:
-                    # `mov ebp, 1` before the loop, `mov r8d, ebp` inside
-                    # it, one byte per element. _const_reg keeps the
+                    # (sub_141494DB0), was WRONG. That address is not a
+                    # function start: .pdata puts it inside
+                    # 0x141494CF0..0x141494DF9, and the `mov ebp, 1` /
+                    # `mov r8d, ebp` pair quoted for it lives past that
+                    # end, in a neighbouring fragment. It was read off a
+                    # raw window that overran the function, the exact
+                    # mistake .pdata anchoring exists to prevent.
+                    #
+                    # The mechanism is still real: field_reads resolves
+                    # register widths the same way and its own comment
+                    # records 86 fields that need it. _const_reg keeps the
                     # unique-or-nothing rule, so a register written on more
-                    # than one path still yields nothing.
+                    # than one path still yields nothing. GitHub #409.
                     pend = self._const_reg(ins, n, self.md.reg_name(o[1].reg))
                 else:
                     pend = None
@@ -948,8 +957,9 @@ class Deriver:
                 # (`mov ebp, 1` outside, `mov r8d, ebp` inside), and
                 # _const_reg returns it only when the register has exactly
                 # one definition in the function. Without this the reader
-                # got no verdict at all, which is how stageinfo's
-                # _logoutMercenaryGroupInfoList sat unresolved (#409).
+                # got no verdict at all. (The stageinfo example first
+                # cited here was misread from a neighbouring function; see
+                # the note on the count-scan branch above.)
                 if o[1].type == CS_OP_IMM:
                     pend = o[1].imm
                 elif i.mnemonic == "mov" and o[1].type == CS_OP_REG:


### PR DESCRIPTION
Resolves the strict xfail #422 left behind, and the answer is that my #420 evidence was wrong.

`0x141494DB0` is **not the start of its own function**. `.pdata` puts it inside `0x141494CF0` to `0x141494DF9`:

```
function_extent(0x141494DB0) -> (0x141494CF0, 0x141494DF9)
loop read at 0x141494E1E     -> outside that range
body(0x141494DB0)            -> 20 instructions, ends at the real ret
reads_stream(0x141494DB0)    -> False
```

The loop I quoted in #420, `mov ebp, 1` then `mov r8d, ebp` then the read, lives past that end and belongs to a different fragment. It says nothing about this reader. I read it from a raw window that overran the function, which is the exact mistake `.pdata` anchoring exists to prevent and which this module's own docstring warns about in as many words: a fixed window "runs off the end of a short function into whatever follows it, and then attributes the neighbour's loops and calls to this reader".

So the honest assertion is the abstention. `body` stops at the real end, sees no sized stream read, and `list_element` returns `None` rather than inventing a width. The test now asserts that, together with the extent and the fact that the quoted loop lies outside it, so the argument cannot quietly stop applying without the test noticing.

**The register-width code stays.** The mechanism is real: `field_reads` resolves register widths the same way and its own comment records 86 fields that need it, and `_const_reg` is unique-or-nothing so it cannot manufacture a value. Only my worked example was wrong. Both source comments citing it are corrected rather than left to mislead whoever reads them next.

Nothing else changes. Still 0 tables proven, stageinfo still stops at field 22 of 91, `tools/` is analysis-only so there is no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
