### PR TITLE
Stop classifying u32 string-table references as inline CStrings

### DIFF
--- a/tests/test_derive_hash_ref_is_not_a_cstring.py
+++ b/tests/test_derive_hash_ref_is_not_a_cstring.py
@@ -1,0 +1,141 @@
+"""A u32 string-table reference must not be classified as a CString.
+
+``solve_reader`` decides a reader is an inline length-prefixed string when
+it sees a leading 4-byte read plus an unsized one. It used to accept the
+PERMISSIVE unsized flag (``var_seen``: any non-immediate write to r8),
+on the argument that requiring the leading read to be exactly 4 made
+that safe, because 4 is the length prefix.
+
+It is not safe, and the counterexample is a whole class of reader rather
+than one stray function. A u32 STRING-TABLE REFERENCE reads exactly four
+bytes and then treats them as a hash::
+
+    14148F57C  mov   r8d, 4              ; the only stream read
+    14148F587  call  [rax+8]
+    14148F5B9  div   ecx                 ; hash % bucket count
+    14148F5C4  add   r11, [r10+0x78]     ; bucket table
+    14148F5E3  mov   r8, [rax+rcx*8]     ; <- sets var_seen
+    14148F5F8  mov   eax, 0xffff         ; miss sentinel
+
+The bucket-pointer load writes r8 from memory, so ``var_seen`` was set,
+the leading read was 4, and the rule fired. On disk such a field is four
+bytes and nothing more, so calling it ``('str', 0)`` made every walk past
+it eat the following field's bytes as string payload.
+
+The discriminator is a SECOND STREAM READ. A CString reads its length and
+then reads that many bytes, so it makes two calls into the stream vtable.
+The hash reference makes exactly one and does the rest in memory. That is
+what ``var_read`` tests, and it is what the rule now requires.
+
+``sub_1411A33C0``, the function the permissive flag was kept for, does not
+need it: its reads go through immediate calls rather than an r8 width, so
+``var_seen`` is False there and it never reached this rule. The flag
+bought nothing and cost every hash-referenced string field.
+
+Measured over every table with a verified order, switching to the strict
+flag regressed nothing and took sixteen tables further, including these
+going from no fully walked record to all of them:
+
+    CharacterAppearanceIndexInfo  0 -> 8350
+    UIMapTextureInfo              0 -> 2025
+    KnowledgeGroupInfo            0 ->  615
+    QuestGaugeInfo                0 ->  511
+    GameAdviceInfo                0 ->  478
+    ContentsPhaseInfo             0 ->    4
+    FactionOperationGroupInfo     0 ->    9
+
+GitHub #409. Checked against the installed game because the input is the
+shipped executable; there is no fixture for a function body.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+pytest.importorskip("capstone", reason="analysis-only dependency")
+pytest.importorskip("pefile", reason="analysis-only dependency")
+
+#: Reads 4 bytes, then resolves them through the string hash table.
+HASH_REF = 0x14148F570
+#: Same shape, a second instance so the fix is not pinned to one address.
+HASH_REF_2 = 0x14148FA00
+#: A genuine CString: reads a u32 length, then reads that many bytes.
+CSTRING = 0x1413910A0
+
+
+def _game_dir() -> Path | None:
+    env = os.environ.get("CDUMM_GAME_DIR")
+    if env and (Path(env) / "bin64").is_dir():
+        return Path(env)
+    for root in ("C:", "D:", "E:", "F:"):
+        for lib in ("SteamLibrary", "Steam"):
+            p = Path(f"{root}/{lib}/steamapps/common/Crimson Desert")
+            if (p / "bin64").is_dir():
+                return p
+    return None
+
+
+@pytest.fixture(scope="module")
+def deriver():
+    game = _game_dir()
+    if game is None:
+        pytest.skip("no Crimson Desert install found (set CDUMM_GAME_DIR)")
+    from derive_table_layout import Deriver
+    return Deriver(game)
+
+
+def _stream_calls(deriver, va: int) -> int:
+    """Calls through the stream vtable, i.e. `call qword ptr [reg + disp]`."""
+    from capstone import CS_OP_MEM
+    n = 0
+    for ins in deriver.body(va):
+        if ins.mnemonic == "call" and ins.operands[0].type == CS_OP_MEM:
+            n += 1
+    return n
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("va", [HASH_REF, HASH_REF_2])
+def test_a_hash_reference_consumes_four_bytes_and_no_payload(deriver, va):
+    deriver._memo.clear()
+    assert deriver.solve_reader(va) == ("fixed", 4)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("va", [HASH_REF, HASH_REF_2])
+def test_the_hash_reference_makes_exactly_one_stream_read(deriver, va):
+    """The property the classification rests on, asserted directly.
+
+    If this ever becomes 2, the reader genuinely reads a payload and the
+    expectation above should be revisited rather than forced.
+    """
+    assert _stream_calls(deriver, va) == 1
+
+
+@pytest.mark.slow
+def test_a_real_cstring_is_still_a_cstring(deriver):
+    """The fix must not buy its correctness by refusing real strings."""
+    deriver._memo.clear()
+    assert deriver.solve_reader(CSTRING) == ("str", 0)
+    assert _stream_calls(deriver, CSTRING) >= 2
+
+
+@pytest.mark.slow
+def test_characterinfo_string_fields_are_four_bytes_each(deriver):
+    """The table that surfaced this, checked end to end.
+
+    ``_uiIconPath`` and ``_category`` are hash references. Before the fix
+    the walk died on ``_uiIconPath`` for all 7250 records because the
+    preceding field had been read as a string.
+    """
+    reads = {name: (kind, val) for name, kind, val
+             in deriver.field_reads("CharacterInfo")}
+    for field in ("_uiIconPath", "_category"):
+        kind, val = reads[field]
+        assert kind == "call"
+        deriver._memo.clear()
+        assert deriver.solve_reader(val) == ("fixed", 4), field

--- a/tools/derive_table_layout.py
+++ b/tools/derive_table_layout.py
@@ -751,16 +751,35 @@ class Deriver:
             got = ("fixed", total)
             self._memo[va] = got
             return got
-        # CString detection deliberately uses the PERMISSIVE flag. The
-        # strict call-site rule misses sub_1411A33C0, which reads its u32
-        # length and then reads the bytes through `call qword ptr [rax+0x20]`
-        # and `call r8` rather than the usual `call [rax+8]` -- so no
-        # unsized read is visible at a recognised call site. The permissive
-        # flag is safe HERE because the rule also requires the reader's
-        # first read to be exactly 4 bytes, which is the length prefix; it
-        # is not safe for the loop veto above, where it counted a
-        # hash-bucket pointer load as a read.
-        if (var_read or var_seen) and reads[:1] == [4]:
+        # CString detection uses the STRICT flag: an unsized read seen at an
+        # actual call site. It once used the permissive `var_seen` too, on
+        # the argument that requiring a leading 4-byte read made it safe
+        # because that read is the length prefix. It is not safe, and the
+        # counterexample is a whole class of reader rather than a stray
+        # function.
+        #
+        # A u32 STRING-TABLE REFERENCE has the identical signature under
+        # the permissive flag. sub_14148F570 reads exactly 4 bytes and then
+        # treats them as a hash: `div ecx` into buckets, walk the table at
+        # [r10+0x78], compare the key, store 0xFFFF on a miss. The bucket
+        # pointer load is `mov r8, qword ptr [rax + rcx*8]`, which sets
+        # var_seen, and the leading read is 4, so the rule fired and called
+        # it ('str', 0) -- an inline length-prefixed string. On disk it is
+        # four bytes, not four plus a payload, so every walk past such a
+        # field consumed the next field's bytes as string data.
+        #
+        # The discriminator is a SECOND stream read. A CString reads its
+        # length and then reads that many bytes, so it has two calls into
+        # the stream vtable; the hash reference has exactly one and does
+        # all its remaining work in memory. That is what var_read tests and
+        # var_seen does not.
+        #
+        # The sub_1411A33C0 case the permissive flag was kept for does not
+        # need it: that function has var_seen False (its reads go through
+        # immediate calls, not an r8 width), so it never reached this rule
+        # and still resolves as ('fixed', 0). The flag bought nothing and
+        # cost every hash-referenced string field. GitHub #409.
+        if var_read and reads[:1] == [4]:
             self._memo[va] = ("str", 0)
             return self._memo[va]
         extra, kind = 0, "fixed"


### PR DESCRIPTION
A reader-classification bug in `derive_table_layout`, found while chasing the CharacterInfo divergence on #409. It is the largest single correction this tool has had.

### The bug

`solve_reader` calls a reader an inline length-prefixed string when it sees a leading 4-byte read plus an unsized one, and it accepted the permissive unsized flag (`var_seen`, any non-immediate write to r8). The comment defending that argued the leading-4 requirement made it safe, since 4 is the length prefix.

A u32 string-table reference has the identical signature:

```
14148F57C  mov   r8d, 4              ; the only stream read
14148F587  call  [rax+8]
14148F5B9  div   ecx                 ; hash % bucket count
14148F5C4  add   r11, [r10+0x78]     ; bucket table
14148F5E3  mov   r8, [rax+rcx*8]     ; <- sets var_seen
14148F5F8  mov   eax, 0xffff         ; miss sentinel
```

Four bytes on disk and nothing more, but it was resolving to `('str', 0)`, so every walk past such a field ate the next field's bytes as string payload.

### The discriminator

A CString reads its length and then reads that many bytes, so it makes two calls through the stream vtable. The hash reference makes exactly one and does the rest in memory. `var_read` tests that; `var_seen` does not.

```
sub_14148F570 hash-ref     var_read=False var_seen=True  reads=[4]
sub_14148FA00 hash-ref     var_read=False var_seen=True  reads=[4]
sub_1413910A0 real CString var_read=True  var_seen=True  reads=[4]
sub_1411A33C0 call-r8      var_read=False var_seen=False reads=[]
```

`sub_1411A33C0` is the function the permissive flag was kept for. Its `var_seen` is False, so it never reached this rule and still resolves as `('fixed', 0)`. The flag bought nothing and cost every hash-referenced string field.

### Measured over every table with a verified order

Nothing regressed. Sixteen tables went further, these from no fully walked record to all of them:

```
CharacterAppearanceIndexInfo  0 -> 8350
UIMapTextureInfo              0 -> 2025
KnowledgeGroupInfo            0 ->  615
QuestGaugeInfo                0 ->  511
GameAdviceInfo                0 ->  478
QuestGroupInfo                0 ->   42
MercenaryInfo                 0 ->   21
MaterialBloodDecalInfo        0 ->   13
FailMessageInfo               0 ->   11
FactionOperationGroupInfo     0 ->    9
FieldInfo                     0 ->    8
GameAdviceGroupInfo           0 ->    8
ContentsPhaseInfo             0 ->    4
SocketInfo                    0 ->    2
```

plus EquipTypeInfo 63 to 117 and HouseInfo 18 to 22. CharacterInfo mean walk depth goes from 5.0 to 38.0 of 194 fields.

Two of the tables named in #409's title, ContentsPhaseInfo and FactionOperationGroupInfo, now walk every record.

Analysis tooling only, so no runtime behaviour changes and no release. Full suite: 2703 passed, only the known local `test_script_import_consent_gate` failure.